### PR TITLE
Corrected value for scrollTo behaviour parameter

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -470,7 +470,7 @@ export class Replayer {
           this.iframe.contentWindow!.scrollTo({
             top: d.y,
             left: d.x,
-            behavior: isSync ? 'instant' : 'smooth',
+            behavior: isSync ? 'auto' : 'smooth',
           });
         } else {
           try {


### PR DESCRIPTION
TypeScript was (rightfully so) complaining about the parameter passed to the `window.scrollTo` function. The value `instant` is not a recognized behaviour value, and a quick search did not turn up any browser that currently recognized this value. Per the CSS standard draft, `auto` is used to specify instant scrolling.

See also https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions/behavior and https://drafts.csswg.org/cssom-view/#enumdef-scrollbehavior.