### PR TITLE
fix remove node observer and check on the result of getNode

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -136,8 +136,7 @@ export type attributeMutation = {
 };
 
 export type removedNodeMutation = {
-  parentId?: number;
-  parentNode?: Node;
+  parentId: number;
   id: number;
 };
 

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -2194,10 +2194,6 @@ exports[`select2 1`] = `
         {
           \\"parentId\\": 25,
           \\"id\\": 36
-        },
-        {
-          \\"parentId\\": 45,
-          \\"id\\": 46
         }
       ],
       \\"adds\\": [


### PR DESCRIPTION
1. Fix a bug:
After we update the `mirror.getId` method which will return -1 for an unserialized node, we do not update the condition in remove node observer. After the fix, we will not get remove node record like this anymore: `{ id: -1, parentId: -1 }`.
2. Optimize
Check whether the removed node's parent is still in the mirror map. If not, it means its parent node was removed before, so we can ignore the removal child node.
3. Debug
Add more warning messages to check if the nodes exist or not.