### PR TITLE
added 'pointer-events: none' for Replayer iframe

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -178,6 +178,7 @@ export class Replayer {
     this.iframe = document.createElement('iframe');
     this.iframe.setAttribute('sandbox', 'allow-same-origin');
     this.iframe.setAttribute('scrolling', 'no');
+    this.iframe.setAttribute('style', 'pointer-events: none');
     this.wrapper.appendChild(this.iframe);
   }
 


### PR DESCRIPTION
'pointer-events: none' prevents the user from interacting with the DOM
inside of the iframe. This prevents accidental tampering by a user when
watching replays such as link clicks or DOM manipulation.

pointer-events supported by 97.15% usage: https://caniuse.com/#feat=pointer-events