### PR TITLE
Fix new timeOffset in waitForStylesheetLoad

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -104,6 +104,10 @@ export class Replayer {
     };
   }
 
+  public getCurrentTime(): number {
+    return this.timer.timeOffset + this.getTimeOffset();
+  }
+
   public getTimeOffset(): number {
     return this.baselineTime - this.events[0].timestamp;
   }
@@ -315,7 +319,7 @@ export class Replayer {
               this.pause();
               this.emitter.emit(ReplayerEvents.LoadStylesheetStart);
               timer = window.setTimeout(() => {
-                this.resume(this.timer.timeOffset);
+                this.resume(this.getCurrentTime());
                 // mark timer was called
                 timer = -1;
               }, this.config.loadTimeout);
@@ -324,7 +328,7 @@ export class Replayer {
             css.addEventListener('load', () => {
               unloadSheets.delete(css);
               if (unloadSheets.size === 0 && timer !== -1) {
-                this.resume(this.timer.timeOffset);
+                this.resume(this.getCurrentTime());
                 this.emitter.emit(ReplayerEvents.LoadStylesheetEnd);
                 if (timer) {
                   window.clearTimeout(timer);


### PR DESCRIPTION
In the case that the replayer triggers multiple FullSnapshot events, it will call waitForStylesheetLoad multiple times. When the replayer resumes, timeOffset could be set to something > 0 either manually from a play/resume call or from a previous waitForStylesheetLoad call which triggers a resume call. In this case our new timeOffset should be the value of our current time in the replay (timer.timeOffset + getTimeOffset()). To solve this, I created a public getCurrentTime function which correctly returns the time in the replay and used this new function as our new timeoffset when resuming from a stylesheet load.


See below image for example of incorrect timeOffset on waitForStylesheetLoad call. Notice how the new time after the resume is less than the previous time, which is incorrect. Although not seen in the logs, this is a resume call from a waitForStylesheetLoad call.

<img width="491" alt="Screen Shot 2019-08-09 at 11 42 32 AM" src="https://user-images.githubusercontent.com/14287381/62802687-529a8180-ba9d-11e9-998b-6e6237dce248.png">

