### PR TITLE
Add show function to replayer

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -135,6 +135,20 @@ export class Replayer {
     this.emitter.emit(ReplayerEvents.Start);
   }
 
+  public show(timeOffset: number) {
+    this.timer.clear();
+    this.timer.timeOffset = 0;
+    this.baselineTime = this.events[0].timestamp + timeOffset;
+    for (const event of this.events) {
+      if (event.timestamp < this.baselineTime) {
+        this.getCastFn(event, true)();
+      } else {
+        break;
+      }
+    }
+    this.emitter.emit(ReplayerEvents.Show);
+  }
+
   public pause() {
     this.timer.clear();
     this.emitter.emit(ReplayerEvents.Pause);

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,4 +297,5 @@ export enum ReplayerEvents {
   SkipStart = 'skip-start',
   SkipEnd = 'skip-end',
   MouseInteraction = 'mouse-interaction',
+  Show = 'show',
 }

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -235,6 +235,7 @@ export declare enum ReplayerEvents {
     LoadStylesheetEnd = "load-stylesheet-end",
     SkipStart = "skip-start",
     SkipEnd = "skip-end",
-    MouseInteraction = "mouse-interaction"
+    MouseInteraction = "mouse-interaction",
+    Show = "show"
 }
 export {};


### PR DESCRIPTION
The show function allows the replayer to jump to a specific point in time without actually starting the timer. This is useful for a drag functionality (though quite slow cause we rebuilding our snapshot), when you want to display a freeze frame in time, or when you simply do not want the replayer to call timer.start().