### PR TITLE
Changing Array.from to iterators.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@types/smoothscroll-polyfill": "^0.3.0",
     "mitt": "^1.1.3",
-    "rrweb-snapshot": "^0.7.18",
+    "rrweb-snapshot": "IMFIL/rrweb-snapshot#master",
     "smoothscroll-polyfill": "^0.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@types/smoothscroll-polyfill": "^0.3.0",
     "mitt": "^1.1.3",
-    "rrweb-snapshot": "IMFIL/rrweb-snapshot#master",
+    "rrweb-snapshot": "^0.7.19",
     "smoothscroll-polyfill": "^0.4.3"
   }
 }

--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -207,23 +207,11 @@ function initMutationObserver(
       });
     };
 
-    // for (var it = movedSet.values(), n = null; (n = it.next().value); ) {
-    //   pushAdd(n);
-    // }
+    for (var it = movedSet.values(), n = null; (n = it.next().value); ) {
+      pushAdd(n);
+    }
 
-    // for (var it = addedSet.values(), n = null; (n = it.next().value); ) {
-    //   if (!isAncestorInSet(droppedSet, n) && !isParentRemoved(removes, n)) {
-    //     pushAdd(n);
-    //   } else if (isAncestorInSet(movedSet, n)) {
-    //     pushAdd(n);
-    //   } else {
-    //     droppedSet.add(n);
-    //   }
-    // }
-
-    Array.from(movedSet).forEach(pushAdd);
-
-    Array.from(addedSet).forEach(n => {
+    for (var it = addedSet.values(), n = null; (n = it.next().value); ) {
       if (!isAncestorInSet(droppedSet, n) && !isParentRemoved(removes, n)) {
         pushAdd(n);
       } else if (isAncestorInSet(movedSet, n)) {
@@ -231,7 +219,7 @@ function initMutationObserver(
       } else {
         droppedSet.add(n);
       }
-    });
+    }
 
     while (addQueue.length) {
       if (

--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -207,9 +207,11 @@ function initMutationObserver(
       });
     };
 
-    Array.from(movedSet).forEach(pushAdd);
+    for (var it = movedSet.values(), n = null; (n = it.next().value); ) {
+      pushAdd(n);
+    }
 
-    Array.from(addedSet).forEach(n => {
+    for (var it = addedSet.values(), n = null; (n = it.next().value); ) {
       if (!isAncestorInSet(droppedSet, n) && !isParentRemoved(removes, n)) {
         pushAdd(n);
       } else if (isAncestorInSet(movedSet, n)) {
@@ -217,7 +219,7 @@ function initMutationObserver(
       } else {
         droppedSet.add(n);
       }
-    });
+    }
 
     while (addQueue.length) {
       if (


### PR DESCRIPTION
Array.from was leaving some set items out of the loop leading in missing nodes during replay. This PR replaces the Array.from(set) to iterators iterating through the set.