### PR TITLE
Fix for TouchEnd event on a text element 

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -681,7 +681,9 @@ export class Replayer {
       });
     let currentEl: Element | null = el;
     while (currentEl) {
-      currentEl.classList.add(':hover');
+      if (currentEl.classList) {
+        currentEl.classList.add(':hover');
+      }
       currentEl = currentEl.parentElement;
     }
   }


### PR DESCRIPTION
Was experiencing case when a TouchEnd event occurred on a text element i.e. nodeType: 3

text elements don't have class lists so an unrecoverable error was stopping playback.

This was a recording taken with rrweb 0.7.27 (3afff63970d19ac17eac3dc026c7b2699021f042) and rrweb-snapshot 0.7.21 (a0dc9481b21fbbbdc590d8998f055676f2279cab) so issue may have been fixed in the intervening commits

This change seems sensible to me even if the underlying issue has been addressed.