### PR TITLE
Fix for certain websites which don't scroll on their documentElement

### DIFF
--- a/src/record/index.ts
+++ b/src/record/index.ts
@@ -97,8 +97,20 @@ function record<T = eventWithTime>(
         data: {
           node,
           initialOffset: {
-            left: document.documentElement!.scrollLeft,
-            top: document.documentElement!.scrollTop,
+            left: (window.pageXOffset !== undefined) ?
+	      window.pageXOffset : (
+		document!.documentElement.scrollLeft ||
+		  document!.body!.parentNode.scrollLeft ||
+		  document!.body.scrollLeft ||
+		  0
+	      ),
+            top: (window.pageYOffset !== undefined) ?
+	      window.pageYOffset : (
+		document!.documentElement.scrollTop ||
+		  document!.body!.parentNode.scrollTop ||
+		  document!.body.scrollTop ||
+		  0
+	      ),
           },
         },
       }),


### PR DESCRIPTION
 - document.documentElement.scrollTop may be zero, but document.body.scrollTop may have the actual scrolling amount
 - main fallback idea taken from https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX
 - modified as `(document.documentElement || document.body).scrollTop` will incorrectly report zero.
 - version here supported by https://github.com/mochi/mochikit/blob/master/MochiKit/Position.js#L23