### PR TITLE
Introduce state machine to implement player

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-postcss": "^1.6.2",
-    "rollup-plugin-terser": "^3.0.0",
+    "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-typescript": "^1.0.0",
     "ts-node": "^7.0.1",
     "tslib": "^1.9.3",
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@types/smoothscroll-polyfill": "^0.3.0",
+    "@xstate/fsm": "^1.3.0",
     "mitt": "^1.1.3",
     "pako": "^1.0.11",
     "rrweb-snapshot": "^0.7.26",

--- a/src/declarations/@xstate/fsm/index.d.ts
+++ b/src/declarations/@xstate/fsm/index.d.ts
@@ -1,0 +1,22 @@
+import * as fsm from '@xstate/fsm';
+
+declare module '@xstate/fsm' {
+  export namespace StateMachine {
+    interface Service<
+      TContext extends object,
+      TEvent extends fsm.EventObject,
+      TState extends fsm.Typestate<TContext> = any
+    > {
+      send: (event: TEvent | TEvent['type']) => void;
+      subscribe: (
+        listener: StateListener<State<TContext, TEvent, TState>>,
+      ) => {
+        unsubscribe: () => void;
+      };
+      start: () => Service<TContext, TEvent, TState>;
+      stop: () => Service<TContext, TEvent, TState>;
+      readonly status: fsm.InterpreterStatus;
+      readonly state: State<TContext, TEvent, TState>;
+    }
+  }
+}

--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -1,0 +1,151 @@
+import {
+  createMachine,
+  EventObject,
+  Typestate,
+  InterpreterStatus,
+  StateMachine,
+} from '@xstate/fsm';
+import { playerConfig, eventWithTime } from '../types';
+
+type PlayerContext = {
+  events: eventWithTime[];
+  timeOffset: number;
+  speed: playerConfig['speed'];
+};
+type PlayerEvent =
+  | { type: 'PLAY' }
+  | { type: 'PAUSE' }
+  | { type: 'RESUME' }
+  | { type: 'END' }
+  | { type: 'REPLAY' }
+  | { type: 'FAST_FORWARD' }
+  | { type: 'BACK_TO_NORMAL' };
+type PlayerState =
+  | {
+      value: 'inited';
+      context: PlayerContext;
+    }
+  | {
+      value: 'playing';
+      context: PlayerContext;
+    }
+  | {
+      value: 'paused';
+      context: PlayerContext;
+    }
+  | {
+      value: 'ended';
+      context: PlayerContext;
+    }
+  | {
+      value: 'skipping';
+      context: PlayerContext;
+    };
+
+// TODO: import interpret when this relased
+// https://github.com/davidkpiano/xstate/issues/1080
+// tslint:disable no-any
+function toEventObject<TEvent extends EventObject>(
+  event: TEvent['type'] | TEvent,
+): TEvent {
+  return (typeof event === 'string' ? { type: event } : event) as TEvent;
+}
+const INIT_EVENT = { type: 'xstate.init' };
+const executeStateActions = <
+  TContext extends object,
+  TEvent extends EventObject = any,
+  TState extends Typestate<TContext> = any
+>(
+  state: StateMachine.State<TContext, TEvent, TState>,
+  event: TEvent | typeof INIT_EVENT,
+) =>
+  state.actions.forEach(
+    ({ exec }) => exec && exec(state.context, event as any),
+  );
+function interpret<
+  TContext extends object,
+  TEvent extends EventObject = EventObject,
+  TState extends Typestate<TContext> = any
+>(
+  machine: StateMachine.Machine<TContext, TEvent, TState>,
+): StateMachine.Service<TContext, TEvent, TState> {
+  let state = machine.initialState;
+  let status = InterpreterStatus.NotStarted;
+  const listeners = new Set<StateMachine.StateListener<typeof state>>();
+
+  const service = {
+    _machine: machine,
+    send: (event: TEvent | TEvent['type']): void => {
+      if (status !== InterpreterStatus.Running) {
+        return;
+      }
+      state = machine.transition(state, event);
+      executeStateActions(state, toEventObject(event));
+      listeners.forEach((listener) => listener(state));
+    },
+    subscribe: (listener: StateMachine.StateListener<typeof state>) => {
+      listeners.add(listener);
+      listener(state);
+
+      return {
+        unsubscribe: () => listeners.delete(listener),
+      };
+    },
+    start: () => {
+      status = InterpreterStatus.Running;
+      executeStateActions(state, INIT_EVENT);
+      return service;
+    },
+    stop: () => {
+      status = InterpreterStatus.Stopped;
+      listeners.clear();
+      return service;
+    },
+    get state() {
+      return state;
+    },
+    get status() {
+      return status;
+    },
+  };
+
+  return service;
+}
+
+export function createPlayerService(context: PlayerContext) {
+  const playerMachine = createMachine<PlayerContext, PlayerEvent, PlayerState>({
+    id: 'player',
+    context,
+    initial: 'inited',
+    states: {
+      inited: {
+        on: {
+          PLAY: 'playing',
+        },
+      },
+      playing: {
+        on: {
+          PAUSE: 'paused',
+          END: 'ended',
+          FAST_FORWARD: 'skipping',
+        },
+      },
+      paused: {
+        on: {
+          RESUME: 'playing',
+        },
+      },
+      skipping: {
+        on: {
+          BACK_TO_NORMAL: 'playing',
+        },
+      },
+      ended: {
+        on: {
+          REPLAY: 'playing',
+        },
+      },
+    },
+  });
+  return interpret(playerMachine);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "target": "ES5",
     "noImplicitAny": true,
     "strictNullChecks": true,
     "removeComments": true,


### PR DESCRIPTION
In this patch, we add `@xstate/fsm` which is a lightweight state machine library to refactor out player code.

The basic state machine of the player looks like this:
![image](https://user-images.githubusercontent.com/13651389/79062845-360bb480-7cd0-11ea-9bef-ea0bd52c7675.png)

Since this is the first patch of our state machine refactoring, we do not make too much change on the code. Instead of it, we only replace the `playing` flag with a machine match.