### PR TITLE
Bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "keywords": [
     "rrweb"
   ],
-  "main": "lib/rrweb.js",
-  "module": "es/rrweb/src/index.js",
+  "main": "lib/rrweb-boost.js",
+  "module": "es/rrweb/src/boost.js",
   "unpkg": "dist/rrweb.js",
   "sideEffects": false,
   "typings": "typings/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,16 @@ function toPackPath(path) {
     .replace('rrweb', 'rrweb-pack');
 }
 
+function toPackerPath(path) {
+  return path
+    .replace(/^([\w]+)\//, '$1/packer/')
+    .replace('rrweb', 'rrweb-packer');
+}
+
+function toBoostPath(path) {
+  return path.replace('rrweb', 'rrweb-boost');
+}
+
 function toMinPath(path) {
   return path.replace(/\.js$/, '.min.js');
 }
@@ -28,20 +38,35 @@ const namedExports = {
 };
 
 const baseConfigs = [
+  // record only
   {
     input: './src/record/index.ts',
     name: 'rrwebRecord',
     pathFn: toRecordPath,
   },
+  // pack only
   {
     input: './src/packer/pack.ts',
     name: 'rrwebPack',
     pathFn: toPackPath,
   },
+  // packer only
+  {
+    input: './src/packer/index.ts',
+    name: 'rrwebPacker',
+    pathFn: toPackerPath,
+  },
+  // record and replay
   {
     input: './src/index.ts',
     name: 'rrweb',
     pathFn: (p) => p,
+  },
+  // all in one
+  {
+    input: './src/boost.ts',
+    name: 'rrwebBoost',
+    pathFn: toBoostPath,
   },
 ];
 

--- a/src/boost.ts
+++ b/src/boost.ts
@@ -1,0 +1,2 @@
+export * from './index';
+export * from './packer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export {
   MouseInteractions,
   ReplayerEvents,
 } from './types';
-export { pack, unpack } from './packer';
 
 const { addCustomEvent } = record;
 


### PR DESCRIPTION
With some further discussions in https://github.com/rrweb-io/rrweb/issues/151, now I plan to provide the following bundle outputs.

```js
const baseConfigs = [
  // record only
  {
    input: './src/record/index.ts',
    name: 'rrwebRecord',
    pathFn: toRecordPath,
  },
  // pack only
  {
    input: './src/packer/pack.ts',
    name: 'rrwebPack',
    pathFn: toPackPath,
  },
  // packer only
  {
    input: './src/packer/index.ts',
    name: 'rrwebPacker',
    pathFn: toPackerPath,
  },
  // record and replay
  {
    input: './src/index.ts',
    name: 'rrweb',
    pathFn: (p) => p,
  },
  // all in one
  {
    input: './src/boost.ts',
    name: 'rrwebBoost',
    pathFn: toBoostPath,
  },
];
```

Under this config, the `dist` directory (iife output) looks like this:
```shell
dist
├── [996K]  packer
│   ├── [258K]  rrweb-packer.js
│   ├── [ 50K]  rrweb-packer.min.js
│   ├── [332K]  rrweb-packer.min.js.map
│   ├── [140K]  rrweb-pack.js
│   ├── [ 28K]  rrweb-pack.min.js
│   └── [185K]  rrweb-pack.min.js.map
├── [176K]  record
│   ├── [ 51K]  rrweb-record.js
│   ├── [ 19K]  rrweb-record.min.js
│   └── [103K]  rrweb-record.min.js.map
├── [381K]  rrweb-boost.js
├── [ 94K]  rrweb-boost.min.js
├── [512K]  rrweb-boost.min.js.map
├── [124K]  rrweb.js
├── [1.3K]  rrweb.min.css
├── [2.1K]  rrweb.min.css.map
├── [ 46K]  rrweb.min.js
└── [186K]  rrweb.min.js.map
```

And I change the CommonJS and es module entry point to the all in one file: boost.ts. So module users can still import from a single line:
```ts
import { record, pack } from 'rrweb'
```