### PR TITLE
add custom event thrown

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -302,6 +302,11 @@ export class Replayer {
           }
         };
         break;
+      case EventType.Custom:
+        castFn = () => {
+          this.emitter.emit(ReplayerEvents.Custom, event);
+        }
+        break;
       default:
     }
     const wrappedCastFn = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -366,5 +366,5 @@ export enum ReplayerEvents {
   SkipEnd = 'skip-end',
   MouseInteraction = 'mouse-interaction',
   EventCast = 'event-cast',
-  Custom = 'custom'
+  Custom = 'custom',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -366,4 +366,5 @@ export enum ReplayerEvents {
   SkipEnd = 'skip-end',
   MouseInteraction = 'mouse-interaction',
   EventCast = 'event-cast',
+  Custom = 'custom'
 }


### PR DESCRIPTION
之前是监听event-cast 来获取 custom event 进行处理，后面发现 event-cast 在chrome 设置 disable cache的情况下，监听到的event-cast有丢失（原因未知），故添加对 custom 事件专门监听 custom event 