### PR TITLE
This dimension is in px but is unitless 

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -226,8 +226,8 @@ export class Replayer {
   }
 
   private handleResize(dimension: viewportResizeDimention) {
-    this.iframe.width = `${dimension.width}px`;
-    this.iframe.height = `${dimension.height}px`;
+    this.iframe.setAttribute('width', dimension.width);
+    this.iframe.setAttribute('height', dimension.height);
   }
 
   // TODO: add speed to mouse move timestamp calculation


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe

didn't have to use `setAttribute`; can revert to direct attribute modification is that better suits project tastes.