### PR TITLE
Keep `npm run typings` happy

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -226,8 +226,8 @@ export class Replayer {
   }
 
   private handleResize(dimension: viewportResizeDimention) {
-    this.iframe.setAttribute('width', dimension.width);
-    this.iframe.setAttribute('height', dimension.height);
+    this.iframe.setAttribute('width', String(dimension.width));
+    this.iframe.setAttribute('height', String(dimension.height));
   }
 
   // TODO: add speed to mouse move timestamp calculation


### PR DESCRIPTION
Forgot to convert to string.

Incidentally, should `npm run typings` be part of the test suite?

There are a few unrelated errors when the typings command is run.