### PR TITLE
Live mode 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@types/smoothscroll-polyfill": "^0.3.0",
-    "@xstate/fsm": "^1.3.0",
+    "@xstate/fsm": "^1.4.0",
     "mitt": "^1.1.3",
     "pako": "^1.0.11",
     "rrweb-snapshot": "^0.7.26",

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -183,6 +183,16 @@ export class Replayer {
     );
   }
 
+  public enableInteract() {
+    this.iframe.setAttribute('scrolling', 'auto');
+    this.iframe.style.pointerEvents = 'auto';
+  }
+
+  public disableInteract() {
+    this.iframe.setAttribute('scrolling', 'no');
+    this.iframe.style.pointerEvents = 'none';
+  }
+
   private setupDom() {
     this.wrapper = document.createElement('div');
     this.wrapper.classList.add('replayer-wrapper');
@@ -194,8 +204,7 @@ export class Replayer {
 
     this.iframe = document.createElement('iframe');
     this.iframe.setAttribute('sandbox', 'allow-same-origin');
-    this.iframe.setAttribute('scrolling', 'no');
-    this.iframe.setAttribute('style', 'pointer-events: none');
+    this.disableInteract();
     this.wrapper.appendChild(this.iframe);
   }
 
@@ -214,7 +223,7 @@ export class Replayer {
       case EventType.Custom:
         castFn = () => {
           /**
-           * emit custom-event and pass the event object. 
+           * emit custom-event and pass the event object.
            *
            * This will add more value to the custom event and allows the client to react for custom-event.
            */

--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -1,11 +1,4 @@
-import {
-  createMachine,
-  EventObject,
-  Typestate,
-  InterpreterStatus,
-  StateMachine,
-  assign,
-} from '@xstate/fsm';
+import { createMachine, interpret, assign } from '@xstate/fsm';
 import {
   playerConfig,
   eventWithTime,
@@ -79,76 +72,6 @@ export type PlayerState =
       value: 'live';
       context: PlayerContext;
     };
-
-// TODO: import interpret when this relased
-// https://github.com/davidkpiano/xstate/issues/1080
-// tslint:disable no-any
-function toEventObject<TEvent extends EventObject>(
-  event: TEvent['type'] | TEvent,
-): TEvent {
-  return (typeof event === 'string' ? { type: event } : event) as TEvent;
-}
-const INIT_EVENT = { type: 'xstate.init' };
-const executeStateActions = <
-  TContext extends object,
-  TEvent extends EventObject = any,
-  TState extends Typestate<TContext> = any
->(
-  state: StateMachine.State<TContext, TEvent, TState>,
-  event: TEvent | typeof INIT_EVENT,
-) =>
-  state.actions.forEach(
-    ({ exec }) => exec && exec(state.context, event as any),
-  );
-function interpret<
-  TContext extends object,
-  TEvent extends EventObject = EventObject,
-  TState extends Typestate<TContext> = any
->(
-  machine: StateMachine.Machine<TContext, TEvent, TState>,
-): StateMachine.Service<TContext, TEvent, TState> {
-  let state = machine.initialState;
-  let status = InterpreterStatus.NotStarted;
-  const listeners = new Set<StateMachine.StateListener<typeof state>>();
-
-  const service = {
-    _machine: machine,
-    send: (event: TEvent | TEvent['type']): void => {
-      if (status !== InterpreterStatus.Running) {
-        return;
-      }
-      state = machine.transition(state, event);
-      executeStateActions(state, toEventObject(event));
-      listeners.forEach((listener) => listener(state));
-    },
-    subscribe: (listener: StateMachine.StateListener<typeof state>) => {
-      listeners.add(listener);
-      listener(state);
-
-      return {
-        unsubscribe: () => listeners.delete(listener),
-      };
-    },
-    start: () => {
-      status = InterpreterStatus.Running;
-      executeStateActions(state, INIT_EVENT);
-      return service;
-    },
-    stop: () => {
-      status = InterpreterStatus.Stopped;
-      listeners.clear();
-      return service;
-    },
-    get state() {
-      return state;
-    },
-    get status() {
-      return status;
-    },
-  };
-
-  return service;
-}
 
 type PlayerAssets = {
   emitter: Emitter;

--- a/src/replay/timer.ts
+++ b/src/replay/timer.ts
@@ -1,6 +1,12 @@
-import { playerConfig, actionWithDelay } from '../types';
+import {
+  playerConfig,
+  actionWithDelay,
+  eventWithTime,
+  EventType,
+  IncrementalSource,
+} from '../types';
 
-export default class Timer {
+export class Timer {
   public timeOffset: number = 0;
 
   private actions: actionWithDelay[];
@@ -74,4 +80,22 @@ export default class Timer {
     }
     return start;
   }
+}
+
+// TODO: add speed to mouse move timestamp calculation
+export function getDelay(event: eventWithTime, baselineTime: number): number {
+  // Mouse move events was recorded in a throttle function,
+  // so we need to find the real timestamp by traverse the time offsets.
+  if (
+    event.type === EventType.IncrementalSnapshot &&
+    event.data.source === IncrementalSource.MouseMove
+  ) {
+    const firstOffset = event.data.positions[0].timeOffset;
+    // timeOffset is a negative offset to event.timestamp
+    const firstTimestamp = event.timestamp + firstOffset;
+    event.delay = firstTimestamp - baselineTime;
+    return firstTimestamp - baselineTime;
+  }
+  event.delay = event.timestamp - baselineTime;
+  return event.timestamp - baselineTime;
 }


### PR DESCRIPTION
In this patch, we improved the live mode which made it easier to use and suitable for more real-world scenarios.

Previously, we use a `liveMode` flag to enable live mode in the player. And users can use the `addEvent` method to add events to the player dynamically and asynchronous.

But there are some shortages in this implementation:
1. The calculation of the timing may make the replay looks laggy.
2. Other issues described in https://github.com/rrweb-io/rrweb/pull/191.

Since we already add a state machine to our player, it becomes easier to implement a more solid live mode.

Now the public API of the player looks like this:
```js
// now you can create a live mode player with empty events
const replayer = new Replayer([], {
  root: playerDom,
  liveMode: true,
});

// You need to call `startLive` to start a live replay.
// The parameter of `startLive` is an optional baseline timestamp, which is useful to create a buffer time for the replay.
// For example, if you are receiving some events from a remote source, it may cause some time to load it.
// When set a buffer time, like 1000ms, the player will delay all the events with 1000ms, which means your replay will look fine when the delay of loading event is less than 1000ms.
replayer.startLive(FIRST_EVENT.timestamp - BUFFER);

replayer.addEvent(event)
```