### PR TITLE
Expose startTime and endTime in the `getMetaData()` call.

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -155,6 +155,8 @@ export class Replayer {
     const firstEvent = events[0];
     const lastEvent = events[events.length - 1];
     return {
+      startTime: firstEvent.timestamp,
+      endTime: lastEvent.timestamp,
       totalTime: lastEvent.timestamp - firstEvent.timestamp,
     };
   }


### PR DESCRIPTION
 I was using `player.events[0].timestamp` but `player.events` has gone away (since a78da77 I believe)

I was doing things like `e.offset = e.timestamp - rrweb_replayer.events[0].timestamp;` in client code for constructing timelines.