### PR TITLE
`.play()` backwards compatibility

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -178,7 +178,14 @@ export class Replayer {
    * @param timeOffset number
    */
   public play(timeOffset = 0) {
-    this.service.send({ type: 'PLAY', payload: { timeOffset } });
+    if (this.service.state.value == 'ended') {
+      this.service.send({ type: 'REPLAY'});
+    }
+    if (this.service.state.value == 'paused') {
+      this.service.send({ type: 'RESUME', payload: { timeOffset } });
+    } else {
+      this.service.send({ type: 'PLAY', payload: { timeOffset } });
+    }
     this.emitter.emit(ReplayerEvents.Start);
   }
 


### PR DESCRIPTION
Ensure api method `.play()` can be called by external code without worrying about the internal state of the finite state machine