### PR TITLE
fast-forward implementation v1

### DIFF
--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -8,6 +8,7 @@ import {
   Emitter,
 } from '../types';
 import { Timer, getDelay } from './timer';
+import { needCastInSyncMode } from '../utils';
 
 export type PlayerContext = {
   events: eventWithTime[];
@@ -194,6 +195,9 @@ export function createPlayerService(
               continue;
             }
             const isSync = event.timestamp < baselineTime;
+            if (isSync && !needCastInSyncMode(event)) {
+              continue;
+            }
             const castFn = getCastFn(event, isSync);
             if (isSync) {
               castFn();
@@ -207,6 +211,7 @@ export function createPlayerService(
               });
             }
           }
+          emitter.emit(ReplayerEvents.Flush);
           timer.addActions(actions);
           timer.start();
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,13 +168,13 @@ export type hooksParam = {
 
 // https://dom.spec.whatwg.org/#interface-mutationrecord
 export type mutationRecord = {
-  type: string,
-  target: Node,
-  oldValue: string | null,
-  addedNodes: NodeList,
-  removedNodes: NodeList,
-  attributeName: string | null,
-}
+  type: string;
+  target: Node;
+  oldValue: string | null;
+  addedNodes: NodeList;
+  removedNodes: NodeList;
+  attributeName: string | null;
+};
 
 export type textCursor = {
   node: Node;
@@ -377,4 +377,5 @@ export enum ReplayerEvents {
   MouseInteraction = 'mouse-interaction',
   EventCast = 'event-cast',
   CustomEvent = 'custom-event',
+  Flush = 'flush',
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,16 @@ import {
   listenerHandler,
   hookResetter,
   blockClass,
+  eventWithTime,
+  EventType,
+  IncrementalSource,
+  addedNodeMutation,
+  removedNodeMutation,
+  textMutation,
+  attributeMutation,
+  mutationData,
+  scrollData,
+  inputData,
 } from './types';
 import { INode } from 'rrweb-snapshot';
 
@@ -170,5 +180,224 @@ export function polyfill() {
   if ('NodeList' in window && !NodeList.prototype.forEach) {
     NodeList.prototype.forEach = (Array.prototype
       .forEach as unknown) as NodeList['forEach'];
+  }
+}
+
+export function needCastInSyncMode(event: eventWithTime): boolean {
+  switch (event.type) {
+    case EventType.DomContentLoaded:
+    case EventType.Load:
+    case EventType.Custom:
+      return false;
+    case EventType.FullSnapshot:
+    case EventType.Meta:
+      return true;
+    default:
+      break;
+  }
+
+  switch (event.data.source) {
+    case IncrementalSource.MouseMove:
+    case IncrementalSource.MouseInteraction:
+    case IncrementalSource.TouchMove:
+    case IncrementalSource.MediaInteraction:
+      return false;
+    case IncrementalSource.ViewportResize:
+    case IncrementalSource.StyleSheetRule:
+    case IncrementalSource.Scroll:
+    case IncrementalSource.Input:
+      return true;
+    default:
+      break;
+  }
+
+  return true;
+}
+
+export type TreeNode = {
+  id: number;
+  mutation: addedNodeMutation;
+  parent?: TreeNode;
+  children: Record<number, TreeNode>;
+  texts: textMutation[];
+  attributes: attributeMutation[];
+};
+export class TreeIndex {
+  public tree!: Record<number, TreeNode>;
+
+  private removeNodeMutations!: removedNodeMutation[];
+  private textMutations!: textMutation[];
+  private attributeMutations!: attributeMutation[];
+  private indexes!: Map<number, TreeNode>;
+  private removeIdSet!: Set<number>;
+  private scrollMap!: Map<number, scrollData>;
+  private inputMap!: Map<number, inputData>;
+
+  constructor() {
+    this.reset();
+  }
+
+  public add(mutation: addedNodeMutation) {
+    const parentTreeNode = this.indexes.get(mutation.parentId);
+    const treeNode: TreeNode = {
+      id: mutation.node.id,
+      mutation,
+      children: [],
+      texts: [],
+      attributes: [],
+    };
+    if (!parentTreeNode) {
+      this.tree[treeNode.id] = treeNode;
+    } else {
+      treeNode.parent = parentTreeNode;
+      parentTreeNode.children[treeNode.id] = treeNode;
+    }
+    this.indexes.set(treeNode.id, treeNode);
+  }
+
+  public remove(mutation: removedNodeMutation) {
+    const parentTreeNode = this.indexes.get(mutation.parentId);
+    const treeNode = this.indexes.get(mutation.id);
+
+    const deepRemoveFromMirror = (id: number) => {
+      this.removeIdSet.add(id);
+      const node = mirror.getNode(id);
+      node?.childNodes.forEach((childNode) =>
+        deepRemoveFromMirror(((childNode as unknown) as INode).__sn.id),
+      );
+    };
+    const deepRemoveFromTreeIndex = (node: TreeNode) => {
+      this.removeIdSet.add(node.id);
+      Object.values(node.children).forEach((n) => deepRemoveFromTreeIndex(n));
+      const _treeNode = this.indexes.get(node.id);
+      if (_treeNode) {
+        const _parentTreeNode = _treeNode.parent;
+        if (_parentTreeNode) {
+          delete _treeNode.parent;
+          delete _parentTreeNode.children[_treeNode.id];
+          this.indexes.delete(mutation.id);
+        }
+      }
+    };
+
+    if (!treeNode) {
+      this.removeNodeMutations.push(mutation);
+      deepRemoveFromMirror(mutation.id);
+    } else if (!parentTreeNode) {
+      delete this.tree[treeNode.id];
+      this.indexes.delete(treeNode.id);
+      deepRemoveFromTreeIndex(treeNode);
+    } else {
+      delete treeNode.parent;
+      delete parentTreeNode.children[treeNode.id];
+      this.indexes.delete(mutation.id);
+      deepRemoveFromTreeIndex(treeNode);
+    }
+  }
+
+  public text(mutation: textMutation) {
+    const treeNode = this.indexes.get(mutation.id);
+    if (treeNode) {
+      treeNode.texts.push(mutation);
+    } else {
+      this.textMutations.push(mutation);
+    }
+  }
+
+  public attribute(mutation: attributeMutation) {
+    const treeNode = this.indexes.get(mutation.id);
+    if (treeNode) {
+      treeNode.attributes.push(mutation);
+    } else {
+      this.attributeMutations.push(mutation);
+    }
+  }
+
+  public scroll(d: scrollData) {
+    this.scrollMap.set(d.id, d);
+  }
+
+  public input(d: inputData) {
+    this.inputMap.set(d.id, d);
+  }
+
+  public flush(): {
+    mutationData: mutationData;
+    scrollMap: TreeIndex['scrollMap'];
+    inputMap: TreeIndex['inputMap'];
+  } {
+    const {
+      tree,
+      removeNodeMutations,
+      textMutations,
+      attributeMutations,
+    } = this;
+
+    const batchMutationData: mutationData = {
+      source: IncrementalSource.Mutation,
+      removes: removeNodeMutations,
+      texts: textMutations,
+      attributes: attributeMutations,
+      adds: [],
+    };
+
+    const walk = (treeNode: TreeNode, removed: boolean) => {
+      if (removed) {
+        this.removeIdSet.add(treeNode.id);
+      }
+      batchMutationData.texts = batchMutationData.texts
+        .concat(removed ? [] : treeNode.texts)
+        .filter((m) => !this.removeIdSet.has(m.id));
+      batchMutationData.attributes = batchMutationData.attributes
+        .concat(removed ? [] : treeNode.attributes)
+        .filter((m) => !this.removeIdSet.has(m.id));
+      if (
+        !this.removeIdSet.has(treeNode.id) &&
+        !this.removeIdSet.has(treeNode.mutation.parentId) &&
+        !removed
+      ) {
+        batchMutationData.adds.push(treeNode.mutation);
+        if (treeNode.children) {
+          Object.values(treeNode.children).forEach((n) => walk(n, false));
+        }
+      } else {
+        Object.values(treeNode.children).forEach((n) => walk(n, true));
+      }
+    };
+
+    Object.values(tree).forEach((n) => walk(n, false));
+
+    for (const id of this.scrollMap.keys()) {
+      if (this.removeIdSet.has(id)) {
+        this.scrollMap.delete(id);
+      }
+    }
+    for (const id of this.inputMap.keys()) {
+      if (this.removeIdSet.has(id)) {
+        this.inputMap.delete(id);
+      }
+    }
+
+    const scrollMap = new Map(this.scrollMap);
+    const inputMap = new Map(this.inputMap);
+
+    this.reset();
+
+    return {
+      mutationData: batchMutationData,
+      scrollMap,
+      inputMap,
+    };
+  }
+
+  private reset() {
+    this.tree = [];
+    this.indexes = new Map();
+    this.removeNodeMutations = [];
+    this.textMutations = [];
+    this.attributeMutations = [];
+    this.removeIdSet = new Set();
+    this.scrollMap = new Map();
+    this.inputMap = new Map();
   }
 }

--- a/test/machine.test.ts
+++ b/test/machine.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { getLastSession } from '../src/replay/machine';
+import { sampleEvents } from './utils';
+import { EventType } from '../src/types';
+
+const events = sampleEvents.filter(
+  (e) => ![EventType.DomContentLoaded, EventType.Load].includes(e.type),
+);
+
+describe('get last session', () => {
+  it('will return all the events when there is only one session', () => {
+    expect(getLastSession(events)).to.deep.equal(events);
+  });
+
+  it('will return last session when there is more than one in the events', () => {
+    const multiple = events.concat(events).concat(events);
+    expect(getLastSession(multiple)).to.deep.equal(events);
+  });
+});

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -5,115 +5,7 @@ import * as path from 'path';
 import * as puppeteer from 'puppeteer';
 import { expect } from 'chai';
 import { Suite } from 'mocha';
-import {
-  EventType,
-  eventWithTime,
-  IncrementalSource,
-  MouseInteractions,
-} from '../src/types';
-import { Replayer } from '../src';
-import { launchPuppeteer } from './utils';
-
-const now = Date.now();
-
-const events: eventWithTime[] = [
-  {
-    type: EventType.DomContentLoaded,
-    data: {},
-    timestamp: now,
-  },
-  {
-    type: EventType.Load,
-    data: {},
-    timestamp: now + 1000,
-  },
-  {
-    type: EventType.Meta,
-    data: {
-      href: 'http://localhost',
-      width: 1000,
-      height: 800,
-    },
-    timestamp: now + 1000,
-  },
-  {
-    type: EventType.FullSnapshot,
-    data: {
-      node: {
-        type: 0,
-        childNodes: [
-          {
-            type: 2,
-            tagName: 'html',
-            attributes: {},
-            childNodes: [
-              {
-                type: 2,
-                tagName: 'head',
-                attributes: {},
-                childNodes: [],
-                id: 3,
-              },
-              {
-                type: 2,
-                tagName: 'body',
-                attributes: {},
-                childNodes: [],
-                id: 4,
-              },
-            ],
-            id: 2,
-          },
-        ],
-        id: 1,
-      },
-      initialOffset: {
-        top: 0,
-        left: 0,
-      },
-    },
-    timestamp: now + 1000,
-  },
-  {
-    type: EventType.IncrementalSnapshot,
-    data: {
-      source: IncrementalSource.MouseInteraction,
-      type: MouseInteractions.Click,
-      id: 1,
-      x: 0,
-      y: 0,
-    },
-    timestamp: now + 2000,
-  },
-  {
-    type: EventType.IncrementalSnapshot,
-    data: {
-      source: IncrementalSource.MouseInteraction,
-      type: MouseInteractions.Click,
-      id: 1,
-      x: 0,
-      y: 0,
-    },
-    timestamp: now + 3000,
-  },
-  {
-    type: EventType.IncrementalSnapshot,
-    data: {
-      source: IncrementalSource.MouseInteraction,
-      type: MouseInteractions.Click,
-      id: 1,
-      x: 0,
-      y: 0,
-    },
-    timestamp: now + 4000,
-  },
-];
-
-interface IWindow extends Window {
-  rrweb: {
-    Replayer: typeof Replayer;
-  };
-}
+import { launchPuppeteer, sampleEvents as events } from './utils';
 
 interface ISuite extends Suite {
   code: string;
@@ -121,7 +13,7 @@ interface ISuite extends Suite {
   page: puppeteer.Page;
 }
 
-describe('replayer', function(this: ISuite) {
+describe('replayer', function (this: ISuite) {
   before(async () => {
     this.browser = await launchPuppeteer();
 
@@ -136,7 +28,7 @@ describe('replayer', function(this: ISuite) {
     await page.evaluate(`const events = ${JSON.stringify(events)}`);
     this.page = page;
 
-    page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
   });
 
   afterEach(async () => {
@@ -148,60 +40,62 @@ describe('replayer', function(this: ISuite) {
   });
 
   it('can get meta data', async () => {
-    const meta = await this.page.evaluate(() => {
-      const { Replayer } = ((window as unknown) as IWindow).rrweb;
+    const meta = await this.page.evaluate(`
+      const { Replayer } = rrweb;
       const replayer = new Replayer(events);
-      return replayer.getMetaData();
-    });
+      replayer.getMetaData();
+    `);
     expect(meta).to.deep.equal({
+      startTime: events[0].timestamp,
+      endTime: events[events.length - 1].timestamp,
       totalTime: events[events.length - 1].timestamp - events[0].timestamp,
     });
   });
 
   it('will start actions when play', async () => {
-    const actionLength = await this.page.evaluate(() => {
-      const { Replayer } = ((window as unknown) as IWindow).rrweb;
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
       const replayer = new Replayer(events);
       replayer.play();
-      return replayer['timer']['actions'].length;
-    });
+      replayer['timer']['actions'].length;
+    `);
     expect(actionLength).to.equal(events.length);
   });
 
   it('will clean actions when pause', async () => {
-    const actionLength = await this.page.evaluate(() => {
-      const { Replayer } = ((window as unknown) as IWindow).rrweb;
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
       const replayer = new Replayer(events);
       replayer.play();
       replayer.pause();
-      return replayer['timer']['actions'].length;
-    });
+      replayer['timer']['actions'].length;
+    `);
     expect(actionLength).to.equal(0);
   });
 
   it('can play at any time offset', async () => {
-    const actionLength = await this.page.evaluate(() => {
-      const { Replayer } = ((window as unknown) as IWindow).rrweb;
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
       const replayer = new Replayer(events);
       replayer.play(1500);
-      return replayer['timer']['actions'].length;
-    });
+      replayer['timer']['actions'].length;
+    `);
     expect(actionLength).to.equal(
-      events.filter(e => e.timestamp - events[0].timestamp >= 1500).length,
+      events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
     );
   });
 
   it('can resume at any time offset', async () => {
-    const actionLength = await this.page.evaluate(() => {
-      const { Replayer } = ((window as unknown) as IWindow).rrweb;
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
       const replayer = new Replayer(events);
       replayer.play(1500);
       replayer.pause();
       replayer.resume(1500);
-      return replayer['timer']['actions'].length;
-    });
+      replayer['timer']['actions'].length;
+    `);
     expect(actionLength).to.equal(
-      events.filter(e => e.timestamp - events[0].timestamp >= 1500).length,
+      events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
     );
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,12 @@
 import { SnapshotState, toMatchSnapshot } from 'jest-snapshot';
 import { NodeType } from 'rrweb-snapshot';
 import { assert } from 'chai';
-import { EventType, IncrementalSource, eventWithTime } from '../src/types';
+import {
+  EventType,
+  IncrementalSource,
+  eventWithTime,
+  MouseInteractions,
+} from '../src/types';
 import * as puppeteer from 'puppeteer';
 
 export async function launchPuppeteer() {
@@ -42,7 +47,7 @@ export function matchSnapshot(
 function stringifySnapshots(snapshots: eventWithTime[]): string {
   return JSON.stringify(
     snapshots
-      .filter(s => {
+      .filter((s) => {
         if (
           s.type === EventType.IncrementalSnapshot &&
           s.data.source === IncrementalSource.MouseMove
@@ -51,7 +56,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
         }
         return true;
       })
-      .map(s => {
+      .map((s) => {
         if (s.type === EventType.Meta) {
           s.data.href = 'about:blank';
         }
@@ -68,7 +73,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
           s.type === EventType.IncrementalSnapshot &&
           s.data.source === IncrementalSource.Mutation
         ) {
-          s.data.attributes.forEach(a => {
+          s.data.attributes.forEach((a) => {
             if (
               'style' in a.attributes &&
               coordinatesReg.test(a.attributes.style!)
@@ -76,7 +81,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
               delete a.attributes.style;
             }
           });
-          s.data.adds.forEach(add => {
+          s.data.adds.forEach((add) => {
             if (
               add.node.type === NodeType.Element &&
               'style' in add.node.attributes &&
@@ -103,3 +108,97 @@ export function assertSnapshot(
   const result = matchSnapshot(stringifySnapshots(snapshots), filename, name);
   assert(result.pass, result.pass ? '' : result.report());
 }
+
+const now = Date.now();
+export const sampleEvents: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1000,
+      height: 800,
+    },
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 3,
+              },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
+            ],
+            id: 2,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: {
+        top: 0,
+        left: 0,
+      },
+    },
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 1,
+      x: 0,
+      y: 0,
+    },
+    timestamp: now + 2000,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 1,
+      x: 0,
+      y: 0,
+    },
+    timestamp: now + 3000,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 1,
+      x: 0,
+      y: 0,
+    },
+    timestamp: now + 4000,
+  },
+];


### PR DESCRIPTION
related to #6

Since the currently 'play at any time offset' implementation is pretty simple,
there are many things we can do to optimize its performance.

In this patch, we do the following optimizations:
1. Ignore some of the events during fast forward.
   For example, when we are going to fast forward to 10 minutes later,
   we do not need to perform mouse movement events during this period.
2. Use a fragment element as the 'virtual parent node'.
   So newly added DOM nodes will be appended to this fragment node,
   and finally being appended into the document as a batch operation.
These changes reduce a lot of time which was spent on reflow/repaint previously.
I've seen a 10 times performance improvement within these approaches.

And there are still some things we can do better but not in this patch.
1. We can build a virtual DOM tree to store the mutations of DOM.
   This will minimize the number of DOM operations.
2. Another thing that may help UX is to make the fast forward process async and cancellable.
   This may make the drag and drop interactions in the player's UI looks smooth.