### PR TITLE
Restore functioning of #200 - this got broken after #242

### DIFF
--- a/test/machine.test.ts
+++ b/test/machine.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { getLastSession } from '../src/replay/machine';
+import { discardPriorSnapshots } from '../src/replay/machine';
 import { sampleEvents } from './utils';
 import { EventType } from '../src/types';
 
@@ -17,13 +17,13 @@ const nextNextEvents = nextEvents.map((e) => ({
 
 describe('get last session', () => {
   it('will return all the events when there is only one session', () => {
-    expect(getLastSession(events, events[0].timestamp)).to.deep.equal(events);
+    expect(discardPriorSnapshots(events, events[0].timestamp)).to.deep.equal(events);
   });
 
   it('will return last session when there is more than one in the events', () => {
     const multiple = events.concat(nextEvents).concat(nextNextEvents);
     expect(
-      getLastSession(
+      discardPriorSnapshots(
         multiple,
         nextNextEvents[nextNextEvents.length - 1].timestamp,
       ),
@@ -33,15 +33,15 @@ describe('get last session', () => {
   it('will return last session when baseline time is future time', () => {
     const multiple = events.concat(nextEvents).concat(nextNextEvents);
     expect(
-      getLastSession(
+      discardPriorSnapshots(
         multiple,
         nextNextEvents[nextNextEvents.length - 1].timestamp + 1000,
       ),
     ).to.deep.equal(nextNextEvents);
   });
 
-  it('will return first session when baseline time is previous time', () => {
-    expect(getLastSession(events, events[0].timestamp - 1000)).to.deep.equal(
+  it('will return all sessions when baseline time is prior time', () => {
+    expect(discardPriorSnapshots(events, events[0].timestamp - 1000)).to.deep.equal(
       events,
     );
   });

--- a/typings/replay/machine.d.ts
+++ b/typings/replay/machine.d.ts
@@ -63,6 +63,7 @@ export declare type PlayerState = {
     value: 'live';
     context: PlayerContext;
 };
+export declare function discardPriorSnapshots(events: eventWithTime[], baselineTime: number): eventWithTime[];
 declare type PlayerAssets = {
     emitter: Emitter;
     getCastFn(event: eventWithTime, isSync: boolean): () => void;


### PR DESCRIPTION
 - What was broken was that it would just play activity from the first page view, but then would stop at the second page view (meta) as actions after that had been discarded
 - This restores the functionality given by the comment 'return the events from last meta to the end.' - we never want to discard events that are after the baseline time
 - I believe 'session' is the incorrect terminology for this function name, as a session in web analytics usually means a series of page views