### PR TITLE
Reenable rewinding after playback has come to an end

### DIFF
--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -212,14 +212,6 @@ export function createPlayerService(
 
           const actions = new Array<actionWithDelay>();
           for (const event of neededEvents) {
-            if (
-              lastPlayedEvent &&
-              lastPlayedEvent.timestamp > baselineTime &&
-              (event.timestamp <= lastPlayedEvent.timestamp ||
-                event === lastPlayedEvent)
-            ) {
-              continue;
-            }
             const isSync = event.timestamp < baselineTime;
             if (isSync && !needCastInSyncMode(event)) {
               continue;


### PR DESCRIPTION
 - problem this fixes: if you play to the end of a recording and then rewind, all events are discarded due to `lastPlayedEvent` being the last event of the recording
 - this block of code was added in 8913bcb9d6bc50850474439b218b85a7e434d6a2 'Live Mode 2' but I can't see any explanation for it
 - if this block of code is to be restored, then I think it deserves it's own commit (explanation). I don't know how to fix it upon restore, maybe resetting \`lastPlayedEvent\` at the end of playback?