### PR TITLE
Reset the `lastPlayedEvent` as it would otherwise be used to discard events

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -217,6 +217,7 @@ export class Replayer {
    */
   public play(timeOffset = 0) {
     if (this.service.state.value === 'ended') {
+      this.service.state.context.lastPlayedEvent = null;
       this.service.send({ type: 'REPLAY' });
     }
     if (this.service.state.value === 'paused') {


### PR DESCRIPTION
Reset the `lastPlayedEvent` as it would otherwise be used to discard events events in machine.ts as follows:

          for (const event of neededEvents) {
            if (
              lastPlayedEvent &&
              lastPlayedEvent.timestamp > baselineTime &&
              (event.timestamp <= lastPlayedEvent.timestamp ||
                event === lastPlayedEvent)
            ) {
              continue;
              }
             const isSync = event.timestamp < baselineTime;