### PR TITLE
Add support for invoking `play` when player is already playing

### DIFF
--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -20,60 +20,60 @@ export type PlayerContext = {
 };
 export type PlayerEvent =
   | {
-      type: 'PLAY';
-      payload: {
-        timeOffset: number;
-      };
-    }
+    type: 'PLAY';
+    payload: {
+      timeOffset: number;
+    };
+  }
   | {
-      type: 'CAST_EVENT';
-      payload: {
-        event: eventWithTime;
-      };
-    }
+    type: 'CAST_EVENT';
+    payload: {
+      event: eventWithTime;
+    };
+  }
   | { type: 'PAUSE' }
   | {
-      type: 'RESUME';
-      payload: {
-        timeOffset: number;
-      };
-    }
+    type: 'RESUME';
+    payload: {
+      timeOffset: number;
+    };
+  }
   | { type: 'END' }
   | { type: 'REPLAY' }
   | { type: 'FAST_FORWARD' }
   | { type: 'BACK_TO_NORMAL' }
   | { type: 'TO_LIVE'; payload: { baselineTime?: number } }
   | {
-      type: 'ADD_EVENT';
-      payload: {
-        event: eventWithTime;
-      };
+    type: 'ADD_EVENT';
+    payload: {
+      event: eventWithTime;
     };
+  };
 export type PlayerState =
   | {
-      value: 'inited';
-      context: PlayerContext;
-    }
+    value: 'inited';
+    context: PlayerContext;
+  }
   | {
-      value: 'playing';
-      context: PlayerContext;
-    }
+    value: 'playing';
+    context: PlayerContext;
+  }
   | {
-      value: 'paused';
-      context: PlayerContext;
-    }
+    value: 'paused';
+    context: PlayerContext;
+  }
   | {
-      value: 'ended';
-      context: PlayerContext;
-    }
+    value: 'ended';
+    context: PlayerContext;
+  }
   | {
-      value: 'skipping';
-      context: PlayerContext;
-    }
+    value: 'skipping';
+    context: PlayerContext;
+  }
   | {
-      value: 'live';
-      context: PlayerContext;
-    };
+    value: 'live';
+    context: PlayerContext;
+  };
 
 /**
  * If the array have multiple meta and fullsnapshot events,
@@ -125,6 +125,10 @@ export function createPlayerService(
             PAUSE: {
               target: 'paused',
               actions: ['pause'],
+            },
+            PLAY: {
+              target: 'playing',
+              actions: ['recordTimeOffset', 'play']
             },
             END: 'ended',
             FAST_FORWARD: 'skipping',
@@ -196,7 +200,7 @@ export function createPlayerService(
           for (const event of neededEvents) {
             if (
               lastPlayedEvent &&
-              lastPlayedEvent.timestamp > baselineTime &&
+              lastPlayedEvent.timestamp < baselineTime &&
               (event.timestamp <= lastPlayedEvent.timestamp ||
                 event === lastPlayedEvent)
             ) {

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -99,4 +99,31 @@ describe('replayer', function (this: ISuite) {
       events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
     );
   });
+
+
+  it('can seek to the future', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(500);
+      replayer.play(1500);
+      replayer['timer']['actions'].length;
+    `);
+    expect(actionLength).to.equal(
+      events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
+    );
+  });
+
+  it('can seek to the past', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(1500);
+      replayer.play(500);
+      replayer['timer']['actions'].length;
+    `);
+    expect(actionLength).to.equal(
+      events.filter((e) => e.timestamp - events[0].timestamp >= 500).length,
+    );
+  });
 });


### PR DESCRIPTION
Looks like calling `play` a second time was broken. I re-implemented it and added some tests.

This now works:
```javascript
      const { Replayer } = rrweb;
      const replayer = new Replayer(events);
      replayer.play(500);
      replayer.play(1500);
```

## Related issues & pull requests

This might make https://github.com/rrweb-io/rrweb/pull/250 redundant, not completely sure.

It fixes some of the things mentioned in https://github.com/rrweb-io/rrweb/pull/198#issuecomment-658895230 including:
 > What if I am in the playing state and wish to jump forward 10s and continue playing