### PR TITLE
Add replayer.seek(timeOffset) to move the player to a moment in time

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -227,6 +227,10 @@ export class Replayer {
     this.emitter.emit(ReplayerEvents.Start);
   }
 
+  public seek(timeOffset = 0) {
+    this.service.send({ type: 'FAST_FORWARD', payload: { timeOffset } });
+  }
+
   public pause() {
     this.service.send({ type: 'PAUSE' });
     this.emitter.emit(ReplayerEvents.Pause);
@@ -397,6 +401,10 @@ export class Replayer {
       const unloadSheets: Set<HTMLLinkElement> = new Set();
       let timer: number;
       let beforeLoadState = this.service.state;
+
+      // no need to wait for stylesheets when we are fast forwarding
+      if (beforeLoadState.matches('skipping')) return;
+
       head
         .querySelectorAll('link[rel="stylesheet"]')
         .forEach((css: HTMLLinkElement) => {

--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -20,60 +20,60 @@ export type PlayerContext = {
 };
 export type PlayerEvent =
   | {
-      type: 'PLAY';
-      payload: {
-        timeOffset: number;
-      };
-    }
+    type: 'PLAY';
+    payload: {
+      timeOffset: number;
+    };
+  }
   | {
-      type: 'CAST_EVENT';
-      payload: {
-        event: eventWithTime;
-      };
-    }
+    type: 'CAST_EVENT';
+    payload: {
+      event: eventWithTime;
+    };
+  }
   | { type: 'PAUSE' }
   | {
-      type: 'RESUME';
-      payload: {
-        timeOffset: number;
-      };
-    }
+    type: 'RESUME';
+    payload: {
+      timeOffset: number;
+    };
+  }
   | { type: 'END' }
   | { type: 'REPLAY' }
   | { type: 'FAST_FORWARD' }
   | { type: 'BACK_TO_NORMAL' }
   | { type: 'TO_LIVE'; payload: { baselineTime?: number } }
   | {
-      type: 'ADD_EVENT';
-      payload: {
-        event: eventWithTime;
-      };
+    type: 'ADD_EVENT';
+    payload: {
+      event: eventWithTime;
     };
+  };
 export type PlayerState =
   | {
-      value: 'inited';
-      context: PlayerContext;
-    }
+    value: 'inited';
+    context: PlayerContext;
+  }
   | {
-      value: 'playing';
-      context: PlayerContext;
-    }
+    value: 'playing';
+    context: PlayerContext;
+  }
   | {
-      value: 'paused';
-      context: PlayerContext;
-    }
+    value: 'paused';
+    context: PlayerContext;
+  }
   | {
-      value: 'ended';
-      context: PlayerContext;
-    }
+    value: 'ended';
+    context: PlayerContext;
+  }
   | {
-      value: 'skipping';
-      context: PlayerContext;
-    }
+    value: 'skipping';
+    context: PlayerContext;
+  }
   | {
-      value: 'live';
-      context: PlayerContext;
-    };
+    value: 'live';
+    context: PlayerContext;
+  };
 
 /**
  * If the array have multiple meta and fullsnapshot events,
@@ -125,6 +125,10 @@ export function createPlayerService(
             PAUSE: {
               target: 'paused',
               actions: ['pause'],
+            },
+            PLAY: {
+              target: 'playing',
+              actions: ['recordTimeOffset', 'play']
             },
             END: 'ended',
             FAST_FORWARD: 'skipping',
@@ -196,7 +200,7 @@ export function createPlayerService(
           for (const event of neededEvents) {
             if (
               lastPlayedEvent &&
-              lastPlayedEvent.timestamp > baselineTime &&
+              lastPlayedEvent.timestamp < baselineTime &&
               (event.timestamp <= lastPlayedEvent.timestamp ||
                 event === lastPlayedEvent)
             ) {

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -99,4 +99,31 @@ describe('replayer', function (this: ISuite) {
       events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
     );
   });
+
+
+  it('can seek to the future', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(500);
+      replayer.play(1500);
+      replayer['timer']['actions'].length;
+    `);
+    expect(actionLength).to.equal(
+      events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
+    );
+  });
+
+  it('can seek to the past', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(1500);
+      replayer.play(500);
+      replayer['timer']['actions'].length;
+    `);
+    expect(actionLength).to.equal(
+      events.filter((e) => e.timestamp - events[0].timestamp >= 500).length,
+    );
+  });
 });

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -101,7 +101,7 @@ describe('replayer', function (this: ISuite) {
   });
 
 
-  it('can seek to the future', async () => {
+  it('can play a second time in the future', async () => {
     const actionLength = await this.page.evaluate(`
       const { Replayer } = rrweb;
       const replayer = new Replayer(events);
@@ -114,7 +114,7 @@ describe('replayer', function (this: ISuite) {
     );
   });
 
-  it('can seek to the past', async () => {
+  it('can play a second time to the past', async () => {
     const actionLength = await this.page.evaluate(`
       const { Replayer } = rrweb;
       const replayer = new Replayer(events);
@@ -125,5 +125,23 @@ describe('replayer', function (this: ISuite) {
     expect(actionLength).to.equal(
       events.filter((e) => e.timestamp - events[0].timestamp >= 500).length,
     );
+  });
+
+  it('can seek', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.seek(2500);
+      replayer['timer']['actions'].length;
+    `);
+    const currentTime = await this.page.evaluate(`
+      replayer.getCurrentTime();
+    `)
+    const currentState = await this.page.evaluate(`
+      replayer['service']['state']['value'];
+    `)
+    expect(actionLength).to.equal(0)
+    expect(currentTime).to.equal(2500);
+    expect(currentState).to.equal('paused');
   });
 });

--- a/typings/replay/index.d.ts
+++ b/typings/replay/index.d.ts
@@ -21,6 +21,7 @@ export declare class Replayer {
     getCurrentTime(): number;
     getTimeOffset(): number;
     play(timeOffset?: number): void;
+    seek(timeOffset?: number): void;
     pause(): void;
     resume(timeOffset?: number): void;
     startLive(baselineTime?: number): void;


### PR DESCRIPTION
Builds on top of https://github.com/rrweb-io/rrweb/pull/264, please review that PR first.

Adds a `seek` method that pauses the player at a given time offset. It's similar to `replayer.play(2500); replayer.pause()` except that it won't trigger a race condition through `waitForStylesheetLoad` (https://github.com/rrweb-io/rrweb/issues/268).

## Example code
```javascript
const { Replayer } = rrweb;
const replayer = new Replayer(events);
replayer.seek(2500); //=> pauses the player at timeOffset 2500
```

Fixes https://github.com/rrweb-io/rrweb/issues/268