### PR TITLE
fix: 修复target 不在parent 中报错 不能播放问题

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -663,7 +663,7 @@ export class Replayer {
         const realParent = this.fragmentParentMap.get(parent);
         if (realParent && realParent.contains(target)) {
           realParent.removeChild(target);
-        } else {
+        } else if (parent.contains(target)) {
           parent.removeChild(target);
         }
       }


### PR DESCRIPTION
在新增节点情况，出现 removeChild 时候，target  不在父元素情况，造成报错，使播放进行不下去。
