### PR TITLE
Add regression tests and `pause(timeOffset)` test

### DIFF
--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -114,4 +114,21 @@ describe('replayer', function (this: ISuite) {
     );
   });
 
+  it('can pause at any time offset', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.pause(2500);
+      replayer['timer']['actions'].length;
+    `);
+    const currentTime = await this.page.evaluate(`
+      replayer.getCurrentTime();
+    `)
+    const currentState = await this.page.evaluate(`
+      replayer['service']['state']['value'];
+    `)
+    expect(actionLength).to.equal(0)
+    expect(currentTime).to.equal(2500);
+    expect(currentState).to.equal('paused');
+  });
 });

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -15,6 +15,8 @@ interface ISuite extends Suite {
 }
 
 describe('replayer', function (this: ISuite) {
+  this.timeout(10_000);
+
   before(async () => {
     this.browser = await launchPuppeteer();
 

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -87,4 +87,31 @@ describe('replayer', function (this: ISuite) {
       events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
     );
   });
+
+  it('can play a second time in the future', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(500);
+      replayer.play(1500);
+      replayer['timer']['actions'].length;
+    `);
+    expect(actionLength).to.equal(
+      events.filter((e) => e.timestamp - events[0].timestamp >= 1500).length,
+    );
+  });
+
+  it('can play a second time to the past', async () => {
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(1500);
+      replayer.play(500);
+      replayer['timer']['actions'].length;
+    `);
+    expect(actionLength).to.equal(
+      events.filter((e) => e.timestamp - events[0].timestamp >= 500).length,
+    );
+  });
+
 });


### PR DESCRIPTION
Port over the tests from #269 and #264 as they can be useful as regression tests.

Includes tests for 
- `play()`-ing multiple times.
- `pause()` at time offset

Also increases timeout as puppeteer has a tendency to take longer than two seconds to start on my 2020 16inch MacBook Pro. (We should probably also do that for `record.test.ts` too)
