### PR TITLE
Use window.top and window.top.document

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -19,6 +19,7 @@ import {
   listenerHandler,
   mutationCallbackParam,
   scrollCallback,
+  IWindow,
 } from '../types';
 import { IframeManager } from './iframe-manager';
 import { ShadowDomManager } from './shadow-dom-manager';
@@ -451,7 +452,7 @@ function record<T = eventWithTime>(
             );
             init();
           },
-          twindow,
+          twindow as IWindow,
         ),
       );
     }

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -2,6 +2,7 @@ import { snapshot, MaskInputOptions, SlimDOMOptions } from 'rrweb-snapshot';
 import { initObservers, mutationBuffers } from './observer';
 import {
   on,
+  getTopWindow,
   getWindowWidth,
   getWindowHeight,
   polyfill,
@@ -66,6 +67,10 @@ function record<T = eventWithTime>(
   if (!emit) {
     throw new Error('emit function is required');
   }
+
+  const twindow = getTopWindow();
+  const tdoc = twindow.document;
+
   // move departed options to new options
   if (mousemoveWait !== undefined && sampling.mousemove === undefined) {
     sampling.mousemove = mousemoveWait;
@@ -209,7 +214,7 @@ function record<T = eventWithTime>(
       wrapEvent({
         type: EventType.Meta,
         data: {
-          href: window.location.href,
+          href: twindow.location.href,
           width: getWindowWidth(),
           height: getWindowHeight(),
         },
@@ -218,7 +223,7 @@ function record<T = eventWithTime>(
     );
 
     mutationBuffers.forEach((buf) => buf.lock()); // don't allow any mirror modifications during snapshotting
-    const [node, idNodeMap] = snapshot(document, {
+    const [node, idNodeMap] = snapshot(tdoc, {
       blockClass,
       blockSelector,
       maskTextClass,
@@ -233,7 +238,7 @@ function record<T = eventWithTime>(
           iframeManager.addIframe(n);
         }
         if (hasShadowRoot(n)) {
-          shadowDomManager.addShadowRoot(n.shadowRoot, document);
+          shadowDomManager.addShadowRoot(n.shadowRoot, tdoc);
         }
       },
       onIframeLoad: (iframe, childSn) => {
@@ -254,18 +259,18 @@ function record<T = eventWithTime>(
           node,
           initialOffset: {
             left:
-              window.pageXOffset !== undefined
-                ? window.pageXOffset
-                : document?.documentElement.scrollLeft ||
-                  document?.body?.parentElement?.scrollLeft ||
-                  document?.body.scrollLeft ||
+              twindow.pageXOffset !== undefined
+                ? twindow.pageXOffset
+                : tdoc?.documentElement.scrollLeft ||
+                  tdoc?.body?.parentElement?.scrollLeft ||
+                  tdoc?.body.scrollLeft ||
                   0,
             top:
-              window.pageYOffset !== undefined
-                ? window.pageYOffset
-                : document?.documentElement.scrollTop ||
-                  document?.body?.parentElement?.scrollTop ||
-                  document?.body.scrollTop ||
+              twindow.pageYOffset !== undefined
+                ? twindow.pageYOffset
+                : tdoc?.documentElement.scrollTop ||
+                  tdoc?.body?.parentElement?.scrollTop ||
+                  tdoc?.body.scrollTop ||
                   0,
           },
         },
@@ -284,7 +289,7 @@ function record<T = eventWithTime>(
             data: {},
           }),
         );
-      }),
+      }, tdoc),
     );
 
     const observe = (doc: Document) => {
@@ -426,11 +431,11 @@ function record<T = eventWithTime>(
 
     const init = () => {
       takeFullSnapshot();
-      handlers.push(observe(document));
+      handlers.push(observe(tdoc));
     };
     if (
-      document.readyState === 'interactive' ||
-      document.readyState === 'complete'
+      tdoc.readyState === 'interactive' ||
+      tdoc.readyState === 'complete'
     ) {
       init();
     } else {
@@ -446,7 +451,7 @@ function record<T = eventWithTime>(
             );
             init();
           },
-          window,
+          twindow,
         ),
       );
     }

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -682,8 +682,9 @@ function initStyleDeclarationObserver(
 
 function initMediaInteractionObserver(
   mediaInteractionCb: mediaInteractionCallback,
-  blockClass: blockClass,
+  doc: Document,
   mirror: Mirror,
+  blockClass: blockClass,
 ): listenerHandler {
   const handler = (type: MediaInteractions) => (event: Event) => {
     const target = getEventTarget(event);
@@ -697,9 +698,9 @@ function initMediaInteractionObserver(
     });
   };
   const handlers = [
-    on('play', handler(MediaInteractions.Play)),
-    on('pause', handler(MediaInteractions.Pause)),
-    on('seeked', handler(MediaInteractions.Seeked)),
+    on('play', handler(MediaInteractions.Play), doc),
+    on('pause', handler(MediaInteractions.Pause), doc),
+    on('seeked', handler(MediaInteractions.Seeked), doc),
   ];
   return () => {
     handlers.forEach((h) => h());
@@ -985,8 +986,9 @@ export function initObservers(
   );
   const mediaInteractionHandler = initMediaInteractionObserver(
     o.mediaInteractionCb,
-    o.blockClass,
+    o.doc,
     o.mirror,
+    o.blockClass,
   );
 
   const styleSheetObserver = initStyleSheetObserver(

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -26,7 +26,7 @@ import {
 export function on(
   type: string,
   fn: EventListenerOrEventListenerObject,
-  target: Document | IWindow = document,
+  target: Document | IWindow,
 ): listenerHandler {
   const options = { capture: true, passive: true };
   target.addEventListener(type, fn, options);

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -207,19 +207,37 @@ export function patch(
   }
 }
 
+export function getTopWindow(): Window {
+  let twindow: Window = window;
+  while (twindow.parent && twindow.parent != twindow) {
+    // check each parent in case the window.top.document fails, but an intermediary one would succeed
+    try {
+      let tdoc = twindow.parent.document;  // this can fail apparently: https://stackoverflow.com/questions/2937118
+      twindow = twindow.parent as Window;
+    } catch (err) {
+      break;
+    }
+  }
+  return twindow;
+}
+
 export function getWindowHeight(): number {
+  const twindow = getTopWindow();
+  const tdoc = twindow.document;
   return (
-    window.innerHeight ||
-    (document.documentElement && document.documentElement.clientHeight) ||
-    (document.body && document.body.clientHeight)
+    twindow.innerHeight ||
+    (tdoc.documentElement && tdoc.documentElement.clientHeight) ||
+    (tdoc.body && tdoc.body.clientHeight)
   );
 }
 
 export function getWindowWidth(): number {
+  const twindow = getTopWindow();
+  const tdoc = twindow.document;
   return (
-    window.innerWidth ||
-    (document.documentElement && document.documentElement.clientWidth) ||
-    (document.body && document.body.clientWidth)
+    twindow.innerWidth ||
+    (tdoc.documentElement && tdoc.documentElement.clientWidth) ||
+    (tdoc.body && tdoc.body.clientWidth)
   );
 }
 

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -2024,7 +2024,7 @@ exports[`iframe 1`] = `
   {
     \\"type\\": 4,
     \\"data\\": {
-      \\"href\\": \\"about:blank\\",
+      \\"href\\": \\"http://localhost:3030/html\\",
       \\"width\\": 1920,
       \\"height\\": 1080
     }

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -557,6 +557,172 @@ exports[`iframe-stylesheet-mutations 1`] = `
 ]"
 `;
 
+exports[`loaded-from-iframe 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank?outer\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [],
+                \\"id\\": 3
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"input\\",
+                    \\"attributes\\": {
+                      \\"type\\": \\"text\\",
+                      \\"size\\": \\"40\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"iframe\\",
+                    \\"attributes\\": {
+                      \\"srcdoc\\": \\"<div>rrweb loaded in here!</div>\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n        </body>\\\\n      </html>\\\\n    \\",
+                        \\"id\\": 9
+                      }
+                    ],
+                    \\"id\\": 8
+                  }
+                ],
+                \\"id\\": 4
+              }
+            ],
+            \\"id\\": 2
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"adds\\": [
+        {
+          \\"parentId\\": 8,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 0,
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"html\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"head\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [],
+                    \\"rootId\\": 10,
+                    \\"id\\": 12
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"body\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"div\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"rrweb loaded in here!\\",
+                            \\"rootId\\": 10,
+                            \\"id\\": 15
+                          }
+                        ],
+                        \\"rootId\\": 10,
+                        \\"id\\": 14
+                      }
+                    ],
+                    \\"rootId\\": 10,
+                    \\"id\\": 13
+                  }
+                ],
+                \\"rootId\\": 10,
+                \\"id\\": 11
+              }
+            ],
+            \\"id\\": 10
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"isAttachIframe\\": true
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 6
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"a\\",
+      \\"isChecked\\": false,
+      \\"id\\": 6
+    }
+  }
+]"
+`;
+
 exports[`nested-stylesheet-rules 1`] = `
 "[
   {

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -719,6 +719,44 @@ exports[`loaded-from-iframe 1`] = `
       \\"isChecked\\": false,
       \\"id\\": 6
     }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 6,
+      \\"positions\\": [
+        {
+          \\"x\\": 147,
+          \\"y\\": 157,
+          \\"id\\": 6,
+          \\"timeOffset\\": 0
+        }
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 1,
+      \\"id\\": 6
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 0,
+      \\"id\\": 6
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 2,
+      \\"id\\": 6
+    }
   }
 ]"
 `;

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -719,44 +719,6 @@ exports[`loaded-from-iframe 1`] = `
       \\"isChecked\\": false,
       \\"id\\": 6
     }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 6,
-      \\"positions\\": [
-        {
-          \\"x\\": 147,
-          \\"y\\": 157,
-          \\"id\\": 6,
-          \\"timeOffset\\": 0
-        }
-      ]
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 1,
-      \\"id\\": 6
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 0,
-      \\"id\\": 6
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 2,
-      \\"id\\": 6
-    }
   }
 ]"
 `;

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -487,6 +487,7 @@ describe('record integration tests', function (this: ISuite) {
   it('should nest record iframe', async () => {
     const page: puppeteer.Page = await this.browser.newPage();
     await page.goto(`http://localhost:3030/html`);
+    await page.waitForTimeout(10);
     await page.setContent(getHtml.call(this, 'main.html'));
 
     await page.waitForTimeout(500);

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -495,8 +495,9 @@ describe('be loaded from an iframe', function (this: ISuite) {
     });
     expect(await this.page.evaluate('typeof rrweb')).to.be.equal('undefined');
     await this.page.type('input', 'a');  // ensuring that typing in outer gets recorded by inner rrweb
+    await this.page.click('input');  // generates 4 events
     await this.page.waitForTimeout(10);
-    expect(this.events.length).to.equal(5);
+    expect(this.events.length).to.equal(9);
     expect(
       this.events.filter(
         (event: eventWithTime) => event.type === EventType.Meta,

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -495,9 +495,14 @@ describe('be loaded from an iframe', function (this: ISuite) {
     });
     expect(await this.page.evaluate('typeof rrweb')).to.be.equal('undefined');
     await this.page.type('input', 'a');  // ensuring that typing in outer gets recorded by inner rrweb
-    await this.page.click('input');  // generates 4 events
-    await this.page.waitForTimeout(10);
-    expect(this.events.length).to.equal(9);
+    if (false) {
+      // problem with non-determinism in 'positions' x/y value here
+      await this.page.click('input');  // generates 4 events
+      await this.page.waitForTimeout(10);
+      expect(this.events.length).to.equal(9);
+    } else {
+      expect(this.events.length).to.equal(5);
+    }
     expect(
       this.events.filter(
         (event: eventWithTime) => event.type === EventType.Meta,

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -434,3 +434,79 @@ describe('record iframes', function (this: ISuite) {
   });
 
 });
+
+const iframeSetup = async function (this: ISuite, content: string) {
+  before(async () => {
+    this.browser = await launchPuppeteer();
+
+    const bundlePath = path.resolve(__dirname, '../dist/rrweb.min.js');
+    this.code = fs.readFileSync(bundlePath, 'utf8');
+  });
+
+  beforeEach(async () => {
+    const page: puppeteer.Page = await this.browser.newPage();
+    await page.goto('about:blank?outer');
+    await page.setContent(content);
+    // page.frames()[0] is the main frame
+    await page.frames()[1].evaluate(this.code);
+    this.page = page;
+    this.events = [];
+    await this.page.exposeFunction('emit', (e: eventWithTime) => {
+      if (e.type === EventType.DomContentLoaded || e.type === EventType.Load) {
+        return;
+      }
+      this.events.push(e);
+    });
+
+    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
+  });
+
+  afterEach(async () => {
+    await this.page.close();
+  });
+
+  after(async () => {
+    await this.browser.close();
+  });
+};
+
+describe('be loaded from an iframe', function (this: ISuite) {
+  this.timeout(10_000);
+
+  iframeSetup.call(
+    this,
+    `
+      <html>
+        <body>
+          <input type="text" size="40" />
+          <iframe srcdoc="<div>rrweb loaded in here!</div>" />
+        </body>
+      </html>
+    `,
+  );
+
+  it('captures activity in outer frame', async () => {
+    await this.page.frames()[1].evaluate(() => {
+      // window here is the iframe window
+      const { record } = ((window as unknown) as IWindow).rrweb;
+      record({
+        emit: ((window.top as unknown) as IWindow).emit,
+      });
+    });
+    expect(await this.page.evaluate('typeof rrweb')).to.be.equal('undefined');
+    await this.page.type('input', 'a');  // ensuring that typing in outer gets recorded by inner rrweb
+    await this.page.waitForTimeout(10);
+    expect(this.events.length).to.equal(5);
+    expect(
+      this.events.filter(
+        (event: eventWithTime) => event.type === EventType.Meta,
+      ).length,
+    ).to.equal(1);
+    expect(
+      this.events.filter(
+        (event: eventWithTime) => event.type === EventType.FullSnapshot,
+      ).length,
+    ).to.equal(1);
+    assertSnapshot(this.events, __filename, 'loaded-from-iframe');
+  });
+});

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -58,9 +58,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
         return true;
       })
       .map((s) => {
-        if (s.type === EventType.Meta) {
-          s.data.href = 'about:blank';
-        }
+
         // FIXME: travis coordinates seems different with my laptop
         const coordinatesReg = /(bottom|top|left|right|width|height): \d+(\.\d+)?px/g;
         if (

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -1,6 +1,6 @@
 import { Mirror, throttleOptions, listenerHandler, hookResetter, blockClass, addedNodeMutation, removedNodeMutation, textMutation, attributeMutation, mutationData, scrollData, inputData, DocumentDimension } from './types';
 import { INode, serializedNodeWithId } from 'rrweb-snapshot';
-export declare function on(type: string, fn: EventListenerOrEventListenerObject, target?: Document | Window): listenerHandler;
+export declare function on(type: string, fn: EventListenerOrEventListenerObject, target: Document | Window): listenerHandler;
 export declare function createMirror(): Mirror;
 export declare let _mirror: Mirror;
 export declare function throttle<T>(func: (arg: T) => void, wait: number, options?: throttleOptions): (arg: T) => void;

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -8,6 +8,7 @@ export declare function hookSetter<T>(target: T, key: string | number | symbol, 
 export declare function patch(source: {
     [key: string]: any;
 }, name: string, replacement: (...args: any[]) => any): () => void;
+export declare function getTopWindow(): Window;
 export declare function getWindowHeight(): number;
 export declare function getWindowWidth(): number;
 export declare function isBlocked(node: Node | null, blockClass: blockClass): boolean;


### PR DESCRIPTION
This pull request is to break out of simple same-domain <iframe>s, i.e. when rrweb.js is loaded from within the iframe.

This is the case for GoDaddy.

I'm not sure whether this is generally a good idea for all of rrweb's users, so maybe it needs further consideration before being accepted?