### PR TITLE
Child nodes without __sn now remove without error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -307,9 +307,11 @@ export class TreeIndex {
     const deepRemoveFromMirror = (id: number) => {
       this.removeIdSet.add(id);
       const node = mirror.getNode(id);
-      node?.childNodes.forEach((childNode) =>
-        deepRemoveFromMirror(((childNode as unknown) as INode).__sn.id),
-      );
+      node?.childNodes.forEach((childNode) => {
+        if ('__sn' in childNode) {
+          deepRemoveFromMirror(((childNode as unknown) as INode).__sn.id)
+        }
+      });
     };
     const deepRemoveFromTreeIndex = (node: TreeNode) => {
       this.removeIdSet.add(node.id);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -202,3 +202,99 @@ export const sampleEvents: eventWithTime[] = [
     timestamp: now + 4000,
   },
 ];
+
+export const sampleStyleSheetRemoveEvents: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1000,
+      height: 800,
+    },
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0,
+        childNodes: [
+          {
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [
+                  {
+                    type: 2,
+                    tagName: "style",
+                    attributes: {
+                      "data-jss": "",
+                      "data-meta": "OverlayDrawer",
+                      _cssText: ".OverlayDrawer-modal-187 { }.OverlayDrawer-paper-188 { width: 100%; }@media (min-width: 48em) {\n  .OverlayDrawer-paper-188 { width: 38rem; }\n}@media (min-width: 48em) {\n}@media (min-width: 48em) {\n}"
+                    },
+                    childNodes: [
+                      {
+                        type: 3,
+                        textContent: "\n",
+                        isStyle: true,
+                        id: 5
+                      },
+                    ],
+                    id: 4
+                  },
+
+                ],
+                id: 3,
+              },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [],
+                id: 6,
+              },
+            ],
+            id: 2,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: {
+        top: 0,
+        left: 0,
+      },
+    },
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [
+        {
+          parentId: 3,
+          id: 4
+        }
+      ],
+      adds: []
+    },
+    timestamp: now + 2000,
+  },
+];


### PR DESCRIPTION
When removing a `<style>` element the text nodes inside don't always have a `__sn` attribute which triggers an error in `deepRemoveFromMirror`. 

This PR fixes that and adds a test to prove that it is fixed.

Fix for https://streamable.com/wjnu23 (20 second mark) from https://github.com/rrweb-io/rrweb/issues/285#issuecomment-678808349.