### PR TITLE
Fix live mode

### DIFF
--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -114,6 +114,10 @@ export function createPlayerService(
               target: 'paused',
               actions: 'castEvent',
             },
+            TO_LIVE: {
+              target: 'live',
+              actions: ['startLive']
+            }
           },
         },
         live: {

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -131,4 +131,16 @@ describe('replayer', function (this: ISuite) {
     expect(currentTime).to.equal(2500);
     expect(currentState).to.equal('paused');
   });
+
+  it('can stream events in live mode', async () => {
+    const status = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events, {
+        liveMode: true
+      });
+      replayer.startLive();
+      replayer.service.state.value;
+    `);
+    expect(status).to.equal('live');
+  })
 });


### PR DESCRIPTION
Looks like live mode broke and it wasn't possible to go from paused (or playing) to live. This fixes that and adds a test to prove it.