### PR TITLE
Sort events upon creation, and keep ordered

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -125,6 +125,8 @@ export class Replayer {
     events: Array<eventWithTime | string>,
     config?: Partial<playerConfig>,
   ) {
+    events.sort((a1, a2) => a1.timestamp - a2.timestamp);
+
     if (!config?.liveMode && events.length < 2) {
       throw new Error('Replayer need at least 2 events.');
     }
@@ -511,6 +513,8 @@ export class Replayer {
         castFn();
       }
       this.service.send({ type: 'CAST_EVENT', payload: { event } });
+
+      // events are kept sorted by timestamp, check if this is the last event
       if (
         event ===
         this.service.state.context.events[

--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -237,7 +237,27 @@ export function createPlayerService(
           if (machineEvent.type === 'ADD_EVENT') {
             const { event } = machineEvent.payload;
             addDelay(event, baselineTime);
-            events.push(event);
+
+            let insertion_index = -1;
+            let start = 0;
+            let end = events.length - 1;
+            while (start <= end) {
+              let mid = Math.floor((start + end) / 2);
+              if (events[mid].timestamp < event.timestamp) {
+                start = mid + 1;
+              } else if (events[mid].timestamp > event.timestamp) {
+                end = mid - 1;
+              } else {
+                insertion_index = mid;
+                break;
+              }
+            }
+            if (insertion_index === -1) {
+              insertion_index = start;
+            }
+            events.splice(insertion_index, 0, event);
+
+
             const isSync = event.timestamp < baselineTime;
             const castFn = getCastFn(event, isSync);
             if (isSync) {

--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -238,21 +238,26 @@ export function createPlayerService(
             const { event } = machineEvent.payload;
             addDelay(event, baselineTime);
 
-            let insertion_index = -1;
-            let start = 0;
             let end = events.length - 1;
-            while (start <= end) {
-              let mid = Math.floor((start + end) / 2);
-              if (events[mid].timestamp <= event.timestamp) {
-                start = mid + 1;
-              } else {
-                end = mid - 1;
+            if (events[end].timestamp <= event.timestamp) {
+              // fast track
+              events.push(event);
+            } else {
+              let insertion_index = -1;
+              let start = 0;
+              while (start <= end) {
+                let mid = Math.floor((start + end) / 2);
+                if (events[mid].timestamp <= event.timestamp) {
+                  start = mid + 1;
+                } else {
+                  end = mid - 1;
+                }
               }
+              if (insertion_index === -1) {
+                insertion_index = start;
+              }
+              events.splice(insertion_index, 0, event);
             }
-            if (insertion_index === -1) {
-              insertion_index = start;
-            }
-            events.splice(insertion_index, 0, event);
 
 
             const isSync = event.timestamp < baselineTime;

--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -243,13 +243,10 @@ export function createPlayerService(
             let end = events.length - 1;
             while (start <= end) {
               let mid = Math.floor((start + end) / 2);
-              if (events[mid].timestamp < event.timestamp) {
+              if (events[mid].timestamp <= event.timestamp) {
                 start = mid + 1;
-              } else if (events[mid].timestamp > event.timestamp) {
-                end = mid - 1;
               } else {
-                insertion_index = mid;
-                break;
+                end = mid - 1;
               }
             }
             if (insertion_index === -1) {

--- a/src/replay/timer.ts
+++ b/src/replay/timer.ts
@@ -34,7 +34,6 @@ export class Timer {
   }
 
   public start() {
-    this.actions.sort((a1, a2) => a1.delay - a2.delay);
     this.timeOffset = 0;
     let lastTimestamp = performance.now();
     const { actions } = this;


### PR DESCRIPTION
Otherwise we risk misidentifying the last event (i.e. calling `finish()` prematurely).

I noticed this when creating a recording which had a custom event at the end of the event list which was coming from a different source, i.e. not generated by rrweb, and had a timestamp earlier in the recording.

This event was getting executed (doAction) at the correct timestamp, but after execution it was identified as the 'last' event, and no further events were being executed.