### PR TITLE
allow fullsnapshot capture to be added along with constructor

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -194,14 +194,17 @@ export class Replayer {
       }, 0);
     }
     if (firstFullsnapshot) {
-      this.rebuildFullSnapshot(
-        firstFullsnapshot as fullSnapshotEvent & { timestamp: number },
-      );
+      setTimeout(() => {
+        this.rebuildFullSnapshot(
+          firstFullsnapshot as fullSnapshotEvent & { timestamp: number },
+        );
+      }, 1);
     }
   }
 
   public on(event: string, handler: Handler) {
     this.emitter.on(event, handler);
+    return this;
   }
 
   public setConfig(config: Partial<playerConfig>) {


### PR DESCRIPTION
Allow `.on` to be chained directly after the constructor so that event handling for the first full snapshot can be added straight after constructor, and that handler will receive the first automatic fullsnapshot build (#216)

Could do with some documentation so you can see:

```
	var rrweb_replayer = new rrwebReplay.Replayer(
		recording
	).on('fullsnapshot-rebuilded', function(fullSnapshot) {
		// do something with first build
	});
```

