### PR TITLE
Catch SecurityErrors when accessing styleSheet rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 node_modules
 package-lock.json
 # yarn.lock

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -849,16 +849,23 @@ export class Replayer {
 
         if (d.adds) {
           d.adds.forEach(({ rule, index }) => {
-            const _index =
-              index === undefined
-                ? undefined
-                : Math.min(index, styleSheet.rules.length);
             try {
-              styleSheet.insertRule(rule, _index);
+              const _index =
+                index === undefined
+                  ? undefined
+                  : Math.min(index, styleSheet.rules.length);
+              try {
+                styleSheet.insertRule(rule, _index);
+              } catch (e) {
+                /**
+                 * sometimes we may capture rules with browser prefix
+                 * insert rule with prefixs in other browsers may cause Error
+                 */
+              }
             } catch (e) {
               /**
-               * sometimes we may capture rules with browser prefix
-               * insert rule with prefixs in other browsers may cause Error
+               * accessing styleSheet rules may cause SecurityError
+               * for specific access control settings
                */
             }
           });


### PR DESCRIPTION
Hello! Thanks for creating this great library!

I'd like to cover one case which happened to us today. When we access a stylesheet rules, it may happen that it throws security error:

```
Uncaught DOMException: Failed to read the 'rules' property from 'CSSStyleSheet'
```

It occurs when we replay a page, which includes an iframe with link to stylesheet that has CORS security rules that we cannot access. I just added a try / catch to handle that because it throws an exception and stops recording.

Please let me know if that makes sense for you. Thanks!