### PR TITLE
fix: sometimes currentTime is smaller than the totalTime when player is finished

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -508,7 +508,7 @@ export class Replayer {
           // defer finish event if the last event is a mouse move
           setTimeout(() => {
             finish();
-          }, Math.max(0, -event.data.positions[0].timeOffset));
+          }, Math.max(0, -event.data.positions[0].timeOffset + 50)); // Add 50 to make sure the timer would check the last mousemove event. Otherwise, the timer may be stopped by the service before checking the last event.
         } else {
           finish();
         }

--- a/src/replay/timer.ts
+++ b/src/replay/timer.ts
@@ -39,7 +39,8 @@ export class Timer {
     let lastTimestamp = performance.now();
     const { actions } = this;
     const self = this;
-    function check(time: number) {
+    function check() {
+      const time = performance.now();
       self.timeOffset += (time - lastTimestamp) * self.speed;
       lastTimestamp = time;
       while (actions.length) {


### PR DESCRIPTION
fix the problem that sometimes return value of getCurrentTime() is negative