### PR TITLE
Scroll replayer iframe on firstFullsnapshot

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -236,6 +236,9 @@ export class Replayer {
         this.rebuildFullSnapshot(
           firstFullsnapshot as fullSnapshotEvent & { timestamp: number },
         );
+        this.iframe.contentWindow!.scrollTo(
+          (firstFullsnapshot as fullSnapshotEvent).data.initialOffset,
+        );
       }, 1);
     }
   }


### PR DESCRIPTION
Currently when starting recording when page is already scrolled down the replayer iframe content won't automatically go down. It is caused by not using scrollTo when first rebuilding full snapshot. 

This PR should fix it