### PR TITLE
Protect against generation of no-change viewport resize events

### DIFF
--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -215,13 +215,19 @@ function initScrollObserver(
 function initViewportResizeObserver(
   cb: viewportResizeCallback,
 ): listenerHandler {
+  let last_h = -1;
+  let last_w = -1;
   const updateDimension = throttle(() => {
     const height = getWindowHeight();
     const width = getWindowWidth();
-    cb({
-      width: Number(width),
-      height: Number(height),
-    });
+    if (last_h !== height || last_w != width) {
+      cb({
+        width: Number(width),
+        height: Number(height),
+      });
+      last_h = height;
+      last_w = width;
+    }
   }, 200);
   return on('resize', updateDimension, window);
 }


### PR DESCRIPTION
I noticed 8 or 10 of these events being generated in a multi-tab browsing session on Chrome 87.0 on Win10.  I'm speculating they were generated as a side effect of changing tabs but I can't recreate.