### PR TITLE
Compact style mutation

### DIFF
--- a/src/record/mutation.ts
+++ b/src/record/mutation.ts
@@ -481,14 +481,15 @@ export default class MutationBuffer {
           }
           for (let i=0; i<target.style.length; i++) {
             let pname = target.style[i];
-            if (target.style.getPropertyValue(pname) !=
-                old.style.getPropertyValue(pname) ||
-                target.style.getPropertyPriority(pname) !=
-                old.style.getPropertyPriority(pname)) {
-              item.attributes['style'][pname] = [
-                target.style.getPropertyValue(pname),
-                target.style.getPropertyPriority(pname)
-              ];
+            const newValue = target.style.getPropertyValue(pname);
+            const newPriority = target.style.getPropertyPriority(pname);
+            if (newValue != old.style.getPropertyValue(pname) ||
+                newPriority != old.style.getPropertyPriority(pname)) {
+              if (newPriority == '') {
+                item.attributes['style'][pname] = newValue;
+              } else {
+                item.attributes['style'][pname] = [newValue, newPriority];
+              }
             }
           }
           for (let i=0; i<old.style.length; i++) {

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1310,18 +1310,28 @@ export class Replayer {
       for (const attributeName in mutation.attributes) {
         if (typeof attributeName === 'string') {
           const value = mutation.attributes[attributeName];
-          try {
-            if (value !== null) {
-              ((target as Node) as Element).setAttribute(attributeName, value);
-            } else {
-              ((target as Node) as Element).removeAttribute(attributeName);
+          if (typeof value === 'string') {
+            try {
+              if (value !== null) {
+                ((target as Node) as Element).setAttribute(attributeName, value);
+              } else {
+                ((target as Node) as Element).removeAttribute(attributeName);
+              }
+            } catch (error) {
+              if (this.config.showWarning) {
+                console.warn(
+                  'An error occurred may due to the checkout feature.',
+                  error,
+                );
+              }
             }
-          } catch (error) {
-            if (this.config.showWarning) {
-              console.warn(
-                'An error occurred may due to the checkout feature.',
-                error,
-              );
+          } else if (attributeName === 'style') {
+            for (var s in value) {
+              if (value[s] === false) {
+                ((target as Node) as Element).style.removeProperty(s);
+              } else {
+                ((target as Node) as Element).style.setProperty(s, value[s][0], value[s][1]);
+              }
             }
           }
         }

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1329,8 +1329,10 @@ export class Replayer {
             for (var s in value) {
               if (value[s] === false) {
                 ((target as Node) as Element).style.removeProperty(s);
-              } else {
+              } else if (Array.isArray(value[s])) {
                 ((target as Node) as Element).style.setProperty(s, value[s][0], value[s][1]);
+              } else {
+                ((target as Node) as Element).style.setProperty(s, value[s]);
               }
             }
           }

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1310,13 +1310,11 @@ export class Replayer {
       for (const attributeName in mutation.attributes) {
         if (typeof attributeName === 'string') {
           const value = mutation.attributes[attributeName];
-          if (typeof value === 'string') {
+          if (value === null) {
+            ((target as Node) as Element).removeAttribute(attributeName);
+          } else if (typeof value === 'string') {
             try {
-              if (value !== null) {
-                ((target as Node) as Element).setAttribute(attributeName, value);
-              } else {
-                ((target as Node) as Element).removeAttribute(attributeName);
-              }
+              ((target as Node) as Element).setAttribute(attributeName, value);
             } catch (error) {
               if (this.config.showWarning) {
                 console.warn(

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,7 +295,7 @@ export type textMutation = {
 };
 
 export type styleAttributeValue = {
-  [key:string]: [string, string] | false;
+  [key:string]: [string, string] | string | false;
 };
 
 export type attributeCursor = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -294,16 +294,20 @@ export type textMutation = {
   value: string | null;
 };
 
+export type styleAttributeValue = {
+  [key:string]: [string, string] | false;
+};
+
 export type attributeCursor = {
   node: Node;
   attributes: {
-    [key: string]: string | null;
+    [key: string]: string | styleAttributeValue | null;
   };
 };
 export type attributeMutation = {
   id: number;
   attributes: {
-    [key: string]: string | null;
+    [key: string]: string | styleAttributeValue | null;
   };
 };
 

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -7428,14 +7428,39 @@ exports[`select2 1`] = `
           \\"id\\": 36,
           \\"attributes\\": {
             \\"id\\": \\"select2-drop\\",
-            \\"style\\": \\"left: Npx; width: Npx; top: Npx; bottom: auto; display: block;\\",
+            \\"style\\": {
+              \\"left\\": [
+                \\"Npx\\",
+                \\"\\"
+              ],
+              \\"width\\": [
+                \\"Npx\\",
+                \\"\\"
+              ],
+              \\"top\\": [
+                \\"Npx\\",
+                \\"\\"
+              ],
+              \\"bottom\\": [
+                \\"auto\\",
+                \\"\\"
+              ],
+              \\"display\\": [
+                \\"block\\",
+                \\"\\"
+              ],
+              \\"position\\": false,
+              \\"visibility\\": false
+            },
             \\"class\\": \\"select2-drop select2-display-none select2-with-searchbox select2-drop-active\\"
           }
         },
         {
           \\"id\\": 70,
           \\"attributes\\": {
-            \\"style\\": \\"\\"
+            \\"style\\": {
+              \\"display\\": false
+            }
           }
         },
         {

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -7429,26 +7429,11 @@ exports[`select2 1`] = `
           \\"attributes\\": {
             \\"id\\": \\"select2-drop\\",
             \\"style\\": {
-              \\"left\\": [
-                \\"Npx\\",
-                \\"\\"
-              ],
-              \\"width\\": [
-                \\"Npx\\",
-                \\"\\"
-              ],
-              \\"top\\": [
-                \\"Npx\\",
-                \\"\\"
-              ],
-              \\"bottom\\": [
-                \\"auto\\",
-                \\"\\"
-              ],
-              \\"display\\": [
-                \\"block\\",
-                \\"\\"
-              ],
+              \\"left\\": \\"Npx\\",
+              \\"width\\": \\"Npx\\",
+              \\"top\\": \\"Npx\\",
+              \\"bottom\\": \\"auto\\",
+              \\"display\\": \\"block\\",
               \\"position\\": false,
               \\"visibility\\": false
             },
@@ -7874,6 +7859,28 @@ exports[`select2 1`] = `
       \\"source\\": 2,
       \\"type\\": 0,
       \\"id\\": 70
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 36,
+          \\"attributes\\": {
+            \\"style\\": {
+              \\"color\\": [
+                \\"black\\",
+                \\"important\\"
+              ]
+            }
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
     }
   }
 ]"

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -184,7 +184,8 @@ describe('record integration tests', function (this: ISuite) {
 
     // toggle the select box
     await page.click('.select2-container', { clickCount: 2, delay: 100 });
-
+    // test storage of !important style
+    await page.evaluate('document.getElementById("select2-drop").setAttribute("style", document.getElementById("select2-drop").style.cssText + "color:black !important")');
     const snapshots = await page.evaluate('window.snapshots');
     assertSnapshot(snapshots, __filename, 'select2');
   });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -75,14 +75,16 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
           s.data.source === IncrementalSource.Mutation
         ) {
           s.data.attributes.forEach((a) => {
-            if (
-              'style' in a.attributes &&
-              coordinatesReg.test(a.attributes.style!)
-            ) {
-              a.attributes.style = a.attributes.style!.replace(
-                coordinatesReg,
-                '$1: Npx',
-              );
+            if ('style' in a.attributes && a.attributes.style && typeof a.attributes.style === 'object') {
+	            for (const [k, v] of Object.entries(a.attributes.style)) {
+		            if (Array.isArray(v)) {
+		              if (coordinatesReg.test(k + ': ' + v[0])) {
+		                // TODO: could round the number here instead depending on what's coming out of various test envs
+		                a.attributes.style[k] = ['Npx', v[1]];
+		              }
+		            }
+		            coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
+	            }
             }
           });
           s.data.adds.forEach((add) => {
@@ -97,6 +99,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
                 '$1: Npx',
               );
             }
+	    coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
           });
         }
         delete s.timestamp;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -82,6 +82,10 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
 		                // TODO: could round the number here instead depending on what's coming out of various test envs
 		                a.attributes.style[k] = ['Npx', v[1]];
 		              }
+		            } else if (typeof v === 'string') {
+		              if (coordinatesReg.test(k + ': ' + v)) {
+		                a.attributes.style[k] = 'Npx';
+		              }
 		            }
 		            coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
 	            }
@@ -99,7 +103,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
                 '$1: Npx',
               );
             }
-	    coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
+            coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
           });
         }
         delete s.timestamp;


### PR DESCRIPTION
I had one recording in the wild that turned into a monster at 12GB.
One of the sources was continuous DOM Mutations caused by a 3rd party 'snow animation' library that was animating individual snowflakes multiple times per second via JavaScript, causing a constant stream of very large mutations.

Each mutation was of the format
` "style":"color: rgb(255, 255, 255); position: absolute; width: 8px; height: 8px; font-family: arial, verdana; overflow: hidden; font-weight: normal; z-index: 0; display: block; bottom: auto; opacity: 1; padding: 0px; margin: 0px; font-size: 10px; line-height: 10px; text-align: center; vertical-align: baseline; left: 242.807px; top: 85.7332px;"`

Even though just the left or top style attributes had changed.
The new format for this part of the attribute mutation looks like:
` "style": {"left": "242.807px", "top": "85.7332px"}`

~There's a threshold to the attribute length before this change applies, currently set at a style attribute length of 25 characters (this value could be tweaked)~ (the threshold would have caused errors, so I've removed it)

Diffs are generated by creating a dummy node to house the old style and then comparing each style (sub)attribute in turn using [getPropertyValue](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyValue) and [getPropertyPriority](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyPriority). Attributes on the old value are also iterated over to see if any of them have been removed.

At playback time, these sub-style mutations are applied via [setProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty) with either a single value argument, or 2 arguments in the case that the `!important` priority flag is present in the change.