### PR TITLE
Tweaks to timings to get tests passing on my dev laptop

### DIFF
--- a/test/record.test.ts
+++ b/test/record.test.ts
@@ -33,6 +33,8 @@ interface IWindow extends Window {
 }
 
 describe('record', function (this: ISuite) {
+  this.timeout(10_000);
+
   before(async () => {
     this.browser = await launchPuppeteer();
 
@@ -138,7 +140,7 @@ describe('record', function (this: ISuite) {
     while (count--) {
       await this.page.type('input', 'a');
     }
-    await this.page.waitFor(500);
+    await this.page.waitFor(300);  // originally 500, but that was resulting in this.events.length==35 on a slower test env
     expect(this.events.length).to.equal(33);
     await this.page.type('input', 'a');
     await this.page.waitFor(10);
@@ -223,7 +225,7 @@ describe('record', function (this: ISuite) {
         styleSheet.insertRule('body { color: #ccc; }');
       }, 10);
     });
-    await this.page.waitFor(10);
+    await this.page.waitFor(50);
     const styleSheetRuleEvents = this.events.filter(
       (e) =>
         e.type === EventType.IncrementalSnapshot &&

--- a/test/record.test.ts
+++ b/test/record.test.ts
@@ -140,11 +140,12 @@ describe('record', function (this: ISuite) {
     while (count--) {
       await this.page.type('input', 'a');
     }
-    await this.page.waitFor(300);  // originally 500, but that was resulting in this.events.length==35 on a slower test env
-    expect(this.events.length).to.equal(33);
+    await this.page.waitFor(300);
+    expect(this.events.length).to.equal(33); // before first automatic snapshot
+    await this.page.waitFor(200);  // could be 33 or 35 events by now depending on speed of test env
     await this.page.type('input', 'a');
     await this.page.waitFor(10);
-    expect(this.events.length).to.equal(36);
+    expect(this.events.length).to.equal(36);  // additionally includes the 2 checkout events
     expect(
       this.events.filter(
         (event: eventWithTime) => event.type === EventType.Meta,


### PR DESCRIPTION
Hopefully this makes tests more deterministic...

This pull request is more to get the conversation started on how variations between test runs should be managed.

In particular, I've added the following comment:

https://github.com/rrweb-io/rrweb/blob/10842b4be98c8bea7c5cf44e042b452069a0b3ae/test/record.test.ts#L143

I'm not sure if the above change is in fact correct; but if not, it would be good to find out what the reason for waiting 500ms here is?