### PR TITLE
Tests: don't delete style attributes in post-processing

### DIFF
--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -5573,6 +5573,7 @@ exports[`select2 1`] = `
           \\"id\\": 36,
           \\"attributes\\": {
             \\"id\\": \\"select2-drop\\",
+            \\"style\\": \\"left: Npx; width: Npx; top: Npx; bottom: auto; display: block;\\",
             \\"class\\": \\"select2-drop select2-display-none select2-with-searchbox select2-drop-active\\"
           }
         },
@@ -5721,7 +5722,8 @@ exports[`select2 1`] = `
             \\"tagName\\": \\"div\\",
             \\"attributes\\": {
               \\"class\\": \\"select2-drop select2-display-none select2-with-searchbox select2-drop-active\\",
-              \\"id\\": \\"select2-drop\\"
+              \\"id\\": \\"select2-drop\\",
+              \\"style\\": \\"left: Npx; width: Npx; top: Npx; bottom: auto; display: block;\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 36
@@ -6033,7 +6035,8 @@ exports[`select2 1`] = `
         {
           \\"id\\": 36,
           \\"attributes\\": {
-            \\"id\\": null
+            \\"id\\": null,
+            \\"style\\": \\"left: Npx; width: Npx; top: Npx; bottom: auto; display: none;\\"
           }
         },
         {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -61,7 +61,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
           s.data.href = 'about:blank';
         }
         // FIXME: travis coordinates seems different with my laptop
-        const coordinatesReg = /(bottom|top|left|right)/;
+        const coordinatesReg = /(bottom|top|left|right|width|height): \d+(\.\d+)?px/g
         if (
           s.type === EventType.IncrementalSnapshot &&
           s.data.source === IncrementalSource.MouseInteraction
@@ -78,7 +78,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
               'style' in a.attributes &&
               coordinatesReg.test(a.attributes.style!)
             ) {
-              delete a.attributes.style;
+              a.attributes.style = a.attributes.style!.replace(coordinatesReg, '$1: Npx');
             }
           });
           s.data.adds.forEach((add) => {
@@ -88,7 +88,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
               typeof add.node.attributes.style === 'string' &&
               coordinatesReg.test(add.node.attributes.style)
             ) {
-              delete add.node.attributes.style;
+              add.node.attributes.style = add.node.attributes.style.replace(coordinatesReg, '$1: Npx');
             }
           });
         }


### PR DESCRIPTION
This one had me stumped for a few days as I didn't realise the test results were post-processed.

Making a separate pull request, but will be basing https://github.com/rrweb-io/rrweb/pull/464 on this