### PR TITLE
fix for 'suspendMutationsDuringSnapshot' #385

### DIFF
--- a/src/record/index.ts
+++ b/src/record/index.ts
@@ -147,7 +147,6 @@ function record<T = eventWithTime>(
     ) {
       // we've got a user initiated event so first we need to apply
       // all DOM changes that have been buffering during paused state
-      mutationBuffer.emit();
       mutationBuffer.unfreeze();
     }
 
@@ -182,7 +181,7 @@ function record<T = eventWithTime>(
     );
 
     let wasFrozen = mutationBuffer.isFrozen();
-    mutationBuffer.freeze(); // don't allow any mirror modifications during snapshotting
+    mutationBuffer.lock();  // don't allow any mirror modifications during snapshotting
     const [node, idNodeMap] = snapshot(document, {
       blockClass,
       blockSelector,
@@ -221,10 +220,7 @@ function record<T = eventWithTime>(
         },
       }),
     );
-    if (!wasFrozen) {
-      mutationBuffer.emit(); // emit anything queued up now
-      mutationBuffer.unfreeze();
-    }
+    mutationBuffer.unlock(); // generate & emit any mutations that happened during snapshotting, as can now apply against the newly built mirror
   }
 
   try {

--- a/src/record/mutation.ts
+++ b/src/record/mutation.ts
@@ -173,20 +173,33 @@ export default class MutationBuffer {
 
   public unfreeze() {
     this.frozen = false;
+    this.emit();
   }
 
   public isFrozen() {
     return this.frozen;
   }
 
+  public lock() {
+    this.locked = true;
+  }
+
+  public unlock() {
+    this.locked = false;
+    this.emit();
+  }
+
   public processMutations = (mutations: mutationRecord[]) => {
     mutations.forEach(this.processMutation);
-    if (!this.frozen) {
-      this.emit();
-    }
+    this.emit();
   };
 
   public emit = () => {
+
+    if (this.frozen || this.locked) {
+      return;
+    }
+
     // delay any modification of the mirror until this function
     // so that the mirror for takeFullSnapshot doesn't get mutated while it's event is being processed
 

--- a/typings/record/mutation.d.ts
+++ b/typings/record/mutation.d.ts
@@ -21,6 +21,8 @@ export default class MutationBuffer {
     freeze(): void;
     unfreeze(): void;
     isFrozen(): boolean;
+    lock(): void;
+    unlock(): void;
     processMutations: (mutations: mutationRecord[]) => void;
     emit: () => void;
     private processMutation;


### PR DESCRIPTION
Discovered that the common case of mouse movement or scrolling happening during `takeFullSnapshot` was causing mutations to be immediately emitted, contrary to the goal of https://github.com/rrweb-io/rrweb/pull/385

Instead create two different types of 'lock' for mutations, one to do with freezes initiated by inactivity (which can be unlocked by any new non-mutation activity) and another lock during fullSnapshot, which can't be unlocked until the fullSnapshot is finished.