### PR TITLE
Fix RangeError: Maximum call stack size exceeded

### DIFF
--- a/src/replay/timer.ts
+++ b/src/replay/timer.ts
@@ -30,7 +30,7 @@ export class Timer {
    * @param actions
    */
   public addActions(actions: actionWithDelay[]) {
-    this.actions.push(...actions);
+    this.actions = this.actions.concat(actions);
   }
 
   public start() {


### PR DESCRIPTION
Saw this line cause issues in production, causing the following error:

```
RangeError Maximum call stack size exceeded
```

I believe this is caused by javascript engine max argument length - see note from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_and_built-in_functions

> The consequences of applying a function with too many arguments (that is, more than tens of thousands of arguments) varies across engines. (The JavaScriptCore engine has hard-coded argument limit of 65536.