### PR TITLE
Added mousemoveCallback threshold option to sampling config.

### DIFF
--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -131,6 +131,8 @@ function initMoveObserver(
 
   const threshold =
     typeof sampling.mousemove === 'number' ? sampling.mousemove : 50;
+  const callbackThreshold =
+    typeof sampling.mousemoveCallback === 'number' ? sampling.mousemoveCallback : 500;
 
   let positions: mousePosition[] = [];
   let timeBaseline: number | null;
@@ -145,7 +147,7 @@ function initMoveObserver(
     );
     positions = [];
     timeBaseline = null;
-  }, 500);
+  }, callbackThreshold);
   const updatePosition = throttle<MouseEvent | TouchEvent>(
     (evt) => {
       const { target } = evt;

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,10 @@ export type SamplingStrategy = Partial<{
    */
   mousemove: boolean | number;
   /**
+   * number is the throttle threshold of mouse/touch move callback
+   */
+  mousemoveCallback: number;
+  /** 
    * false means not to record mouse interaction events
    * can also specify record some kinds of mouse interactions
    */

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -111,6 +111,7 @@ export declare type eventWithTime = event & {
 export declare type blockClass = string | RegExp;
 export declare type SamplingStrategy = Partial<{
     mousemove: boolean | number;
+    mousemoveCallback: number;
     mouseInteraction: boolean | Record<string, boolean | undefined>;
     scroll: number;
     input: 'all' | 'last';


### PR DESCRIPTION
(non-breaking) 
This PR lets you configure the throttle threshold for the mousemove callback. This enables you to adjust the frequency of mousemove events emission. Default remains at 500ms.