### PR TITLE
Add yarn support for installing unreleased rrweb as a dependency 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.vscode
+.idea
+node_modules
+package-lock.json
+yarn.lock
+temp
+*.log

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.14",
   "description": "record and replay the web",
   "scripts": {
-    "prepare": "npm run bundle",
+    "prepack": "npm run bundle",
     "test": "npm run bundle:browser && cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.test.ts",
     "test:watch": "PUPPETEER_HEADLESS=true npm run test -- --watch --watch-extensions js,ts",
     "repl": "npm run bundle:browser && cross-env TS_NODE_CACHE=false TS_NODE_FILES=true ts-node scripts/repl.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.14",
   "description": "record and replay the web",
   "scripts": {
+    "prepare": "npm run prepack",
     "prepack": "npm run bundle",
     "test": "npm run bundle:browser && cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.test.ts",
     "test:watch": "PUPPETEER_HEADLESS=true npm run test -- --watch --watch-extensions js,ts",


### PR DESCRIPTION
Adds support for pointing your package.json to master and installing via yarn.

[Yarn v2 only supports the `prepack` script](https://yarnpkg.com/advanced/rulebook/#packages-should-use-the-prepack-script-to-generate-dist-files-before-publishing) which does pretty much the same thing as `prepare`.
And yarn v1+ needs a `.npmignore` otherwise it will use the `.gitignore` and wipe the bundled code.