### PR TITLE
Handle event undefined in initMoveObserver

### DIFF
--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -202,10 +202,12 @@ function initMouseInteractionObserver(
       if (isBlocked(event.target as Node, blockClass)) {
         return;
       }
+      const e = isTouchEvent(event) ? event.changedTouches[0] : event;
+      if (!e) {
+        return;
+      }
       const id = mirror.getId(event.target as INode);
-      const { clientX, clientY } = isTouchEvent(event)
-        ? event.changedTouches[0]
-        : event;
+      const { clientX, clientY } = e;
       cb({
         type: MouseInteractions[eventKey],
         id,


### PR DESCRIPTION
A quick suggestion for handling a case where this expression:

```
isTouchEvent(event)
        ? event.changedTouches[0]
        : event;
```

returns `undefined`, causing an error when trying to access `clientX`.

Appears to be the cause of this error: https://sentry.io/share/issue/f01259a2c753426cbfccad01c30a102b/

