### PR TITLE
fix: errors of replaying iframe records

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1182,13 +1182,14 @@ export class Replayer {
           : parent.insertBefore(target, null);
       } else {
         /**
-         * When nest recording rrweb player, if the html element of iframe changes, we will get a mutation which adds a new html element here and we need to remove the old html element first to avoid collision.
+         * Sometimes the document changes and the MutationObserver is disconnected, so the removal of child elements can't be detected and recorded. After the change of document, we may get another mutation which adds a new html element, while the old html element still exists in the dom, and we need to remove the old html element first to avoid collision.
          */
         if (parent === targetDoc) {
           while (targetDoc.firstChild) {
             targetDoc.removeChild(targetDoc.firstChild);
           }
         }
+
         parent.appendChild(target);
       }
 

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1118,7 +1118,8 @@ export class Replayer {
         parentInDocument = this.iframe.contentDocument.body.contains(parent);
       }
 
-      if (useVirtualParent && parentInDocument) {
+      // if parent element is an iframe, iframe document can't be appended to virtual parent
+      if (useVirtualParent && parentInDocument && !isIframeINode(parent)) {
         const virtualParent = (document.createDocumentFragment() as unknown) as INode;
         mirror.map[mutation.parentId] = virtualParent;
         this.fragmentParentMap.set(virtualParent, parent);
@@ -1180,6 +1181,14 @@ export class Replayer {
           ? parent.insertBefore(target, next)
           : parent.insertBefore(target, null);
       } else {
+        /**
+         * When nest recording rrweb player, if the html element of iframe changes, we will get a mutation which adds a new html element here and we need to remove the old html element first to avoid collision.
+         */
+        if (parent === targetDoc) {
+          while (targetDoc.firstChild) {
+            targetDoc.removeChild(targetDoc.firstChild);
+          }
+        }
         parent.appendChild(target);
       }
 


### PR DESCRIPTION
error1:
HierarchyRequestError: Failed to execute 'appendChild' on 'Node': Nodes of type '#document' may not be inserted inside nodes of type '#document-fragment'.
code: parent.appendChild(target)

error2:
Uncaught DOMException: Failed to execute 'appendChild' on 'Node': Only one element on document allowed.
code: parent.appendChild(target);