### PR TITLE
Apply CSSRule insertion/deltetion on Flush event

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1608,6 +1608,11 @@ export class Replayer {
           }
           styleNode.sheet?.insertRule(rule.cssText, index);
         });
+        if(styleNode.sheet && styleNode.sheet.rules.length > storedRules.length) {
+          for(let i = styleNode.sheet.rules.length-1; i < storedRules.length - 1; i--) {
+            styleNode.sheet.removeRule(i);
+          }
+        }
       }
     }
   }

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -117,6 +117,8 @@ export class Replayer {
   private treeIndex!: TreeIndex;
   private fragmentParentMap!: Map<INode, INode>;
   private elementStateMap!: Map<INode, ElementState>;
+  // Hold the list of CSSRules during in-memory state restoration
+  private virtualStyleRulesMap!: Map<INode, CSSRule[]>;
 
   private imageMap: Map<eventWithTime, HTMLImageElement> = new Map();
 
@@ -160,6 +162,8 @@ export class Replayer {
     this.treeIndex = new TreeIndex();
     this.fragmentParentMap = new Map<INode, INode>();
     this.elementStateMap = new Map<INode, ElementState>();
+    this.virtualStyleRulesMap = new Map<INode, CSSRule[]>();
+
     this.emitter.on(ReplayerEvents.Flush, () => {
       const { scrollMap, inputMap } = this.treeIndex.flush();
 
@@ -180,8 +184,13 @@ export class Replayer {
         // restore state of elements after they are mounted
         this.restoreState(parent);
       }
+      for (const [node] of this.virtualStyleRulesMap.entries()) {
+        // restore css rules of elements after they are mounted
+        this.restoreNodeSheet(node);
+      }
       this.fragmentParentMap.clear();
       this.elementStateMap.clear();
+      this.virtualStyleRulesMap.clear();
 
       for (const d of scrollMap.values()) {
         this.applyScroll(d);
@@ -913,6 +922,17 @@ export class Replayer {
         const styleEl = (target as Node) as HTMLStyleElement;
         const parent = (target.parentNode as unknown) as INode;
         const usingVirtualParent = this.fragmentParentMap.has(parent);
+
+        /**
+         * Always use existing DOM node, when it's there.
+         * In in-memory replay, there is virtual node, but it's `sheet` will be removed during replacement.
+         * Hence, we re-create it and re-populate it on each run to not miss pre-existing styles and previously inserted
+         */
+        const styleSheet = usingVirtualParent
+          ? new CSSStyleSheet()
+          : styleEl.sheet
+          ? styleEl.sheet
+          : new CSSStyleSheet();
         let placeholderNode;
 
         if (usingVirtualParent) {
@@ -927,9 +947,21 @@ export class Replayer {
           placeholderNode = document.createTextNode('');
           parent.replaceChild(placeholderNode, target);
           domParent!.appendChild(target);
-        }
 
-        const styleSheet: CSSStyleSheet = styleEl.sheet!;
+          if (!this.virtualStyleRulesMap.has(target)) {
+            this.virtualStyleRulesMap.set(
+              target,
+              Array.from(styleEl.sheet?.rules || []),
+            );
+          }
+
+          const existingRules = this.virtualStyleRulesMap.get(target);
+          if (existingRules) {
+            existingRules.forEach((rule, index) => {
+              styleSheet?.insertRule(rule.cssText, index);
+            });
+          }
+        }
 
         if (d.adds) {
           d.adds.forEach(({ rule, index }) => {
@@ -966,11 +998,16 @@ export class Replayer {
             }
           });
         }
-
+        if (usingVirtualParent) {
+          // Update rules list according to new styleSheet
+          this.virtualStyleRulesMap.set(
+            target,
+            Array.from(styleSheet?.rules || []),
+          );
+        }
         if (usingVirtualParent && placeholderNode) {
           parent.replaceChild(target, placeholderNode);
         }
-
         break;
       }
       case IncrementalSource.CanvasMutation: {
@@ -1555,6 +1592,22 @@ export class Replayer {
       const children = parentElement.children;
       for (const child of Array.from(children)) {
         this.restoreState((child as unknown) as INode);
+      }
+    }
+  }
+
+  private restoreNodeSheet(node: INode) {
+    if (node.nodeName === 'STYLE') {
+      const styleNode = (node as unknown) as HTMLStyleElement;
+      if (this.virtualStyleRulesMap.has(node)) {
+        const storedRules = this.virtualStyleRulesMap.get(node);
+        if (!storedRules) return;
+        storedRules.forEach((rule, index) => {
+          if (styleNode?.sheet?.rules[index]) {
+            styleNode.sheet?.deleteRule(index);
+          }
+          styleNode.sheet?.insertRule(rule.cssText, index);
+        });
       }
     }
   }

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1597,22 +1597,25 @@ export class Replayer {
   }
 
   private restoreNodeSheet(node: INode) {
-    if (node.nodeName === 'STYLE') {
-      const styleNode = (node as unknown) as HTMLStyleElement;
-      if (this.virtualStyleRulesMap.has(node)) {
-        const storedRules = this.virtualStyleRulesMap.get(node);
-        if (!storedRules) return;
-        storedRules.forEach((rule, index) => {
-          if (styleNode?.sheet?.rules[index]) {
-            styleNode.sheet?.deleteRule(index);
-          }
-          styleNode.sheet?.insertRule(rule.cssText, index);
-        });
-        if(styleNode.sheet && styleNode.sheet.rules.length > storedRules.length) {
-          for(let i = styleNode.sheet.rules.length-1; i < storedRules.length - 1; i--) {
-            styleNode.sheet.removeRule(i);
-          }
-        }
+    const storedRules = this.virtualStyleRulesMap.get(node);
+    if (node.nodeName !== 'STYLE') return;
+
+    if(!storedRules) return;
+
+    const styleNode = (node as unknown) as HTMLStyleElement;
+
+    storedRules.forEach((rule, index) => {
+      // Esnure consistency of rules list
+      if (styleNode?.sheet?.rules[index]) {
+        styleNode.sheet?.deleteRule(index);
+      }
+      styleNode.sheet?.insertRule(rule.cssText, index);
+    });
+    // Avoid situation, when your Node has more styles, than it should
+    // Otherwise, inserting will be broken
+    if(styleNode.sheet && styleNode.sheet.rules.length > storedRules.length) {
+      for(let i = styleNode.sheet.rules.length-1; i < storedRules.length - 1; i--) {
+        styleNode.sheet.removeRule(i);
       }
     }
   }

--- a/test/events/style-sheet-rule-events.ts
+++ b/test/events/style-sheet-rule-events.ts
@@ -141,6 +141,19 @@ const events: eventWithTime[] = [
     type: EventType.IncrementalSnapshot,
     timestamp: now + 1000,
   },
+  {
+    data: {
+      id: 105,
+      removes: [
+        {
+          index: 2,
+        },
+      ],
+      source: IncrementalSource.StyleSheetRule,
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 2500,
+  },
 ];
 
 export default events;

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -146,6 +146,19 @@ describe('replayer', function (this: ISuite) {
       replayer.play(1500);
       replayer['timer']['actions'].length;
     `);
+
+    const result = await this.page.evaluate(`
+      const rules = Array.from(replayer.iframe.contentDocument.head.children)
+        .filter(x=>x.nodeName === 'STYLE')
+        .reduce((acc, node) => {
+          acc.push(...node.sheet.rules);
+          return acc;
+        }, []);
+
+        rules.some(x=>x.selectorText === ".css-1fbxx79")
+    `);
+
+    expect(result).to.equal(true);
     expect(actionLength).to.equal(
       styleSheetRuleEvents.filter(
         (e) => e.timestamp - styleSheetRuleEvents[0].timestamp >= 1500,

--- a/test/replayer.test.ts
+++ b/test/replayer.test.ts
@@ -183,6 +183,31 @@ describe('replayer', function (this: ISuite) {
     );
   });
 
+  it('can fast forward past StyleSheetRule deletion on virtual elements', async () => {
+    await this.page.evaluate(
+      `events = ${JSON.stringify(styleSheetRuleEvents)}`,
+    );
+    const actionLength = await this.page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.play(2500);
+      replayer['timer']['actions'].length;
+    `);
+
+    const result = await this.page.evaluate(`
+      const rules = Array.from(replayer.iframe.contentDocument.head.children)
+        .filter(x=>x.nodeName === 'STYLE')
+        .reduce((acc, node) => {
+          acc.push(...node.sheet.rules);
+          return acc;
+        }, []);
+
+        rules.some(x=>x.selectorText === ".css-1fbxx79")
+    `);
+
+    expect(result).to.equal(false);
+  });
+
   it('can stream events in live mode', async () => {
     const status = await this.page.evaluate(`
       const { Replayer } = rrweb;


### PR DESCRIPTION
Currently, during the node replacement, the `sheet` property is being automatically assigned to null. 
In order to support virtual sheet mutation, we need to store that sheet in another structure.
We also cannot reuse the existing reference to sheet, as the value at this reference would be removed at the `replaceChild` call.

To avoid that, we will create:
```ts
  private virtualStyleRulesMap!: Map<INode, CSSRule[]>;
```
This rule array map would keep the latest CSSRule array for each node during the virtual processing of events and would ensure, that at the Flush event, `style` node has exact same array of css rules, as the one in memory.


I've also added a test which is able to check, whether the stylesheet rule exists in the sheet after insertion.

Fixes https://github.com/rrweb-io/rrweb/issues/525