### PR TITLE
Don't rebuildFullSnapshot if it's the first run

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -121,7 +121,7 @@ export class Replayer {
   private imageMap: Map<eventWithTime, HTMLImageElement> = new Map();
   
   /** The first time the player is playing. */
-  private firstPlay = false;
+  private firstPlay = true;
                              
   private newDocumentQueue: addedNodeMutation[] = [];
 

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -119,7 +119,10 @@ export class Replayer {
   private elementStateMap!: Map<INode, ElementState>;
 
   private imageMap: Map<eventWithTime, HTMLImageElement> = new Map();
-
+  
+  /** The first time the player is playing. */
+  private firstPlay = false;
+                             
   private newDocumentQueue: addedNodeMutation[] = [];
 
   constructor(
@@ -459,6 +462,11 @@ export class Replayer {
         break;
       case EventType.FullSnapshot:
         castFn = () => {
+          // Don't build a full snapshot during the first play through since we've already built it when the player was mounted.
+          if (this.firstPlay) {
+            this.firstPlay = false;
+            return;
+          }
           this.rebuildFullSnapshot(event, isSync);
           this.iframe.contentWindow!.scrollTo(event.data.initialOffset);
         };


### PR DESCRIPTION
👋  I don't think we need to rebuild the full snapshot during the first play-through since we already do it when we initialize the player.

Before:
- 1 `rebuildFullSnapshot` while initializing the player
- 1 `rebuildFullSnapshot` while processing the `FullSnapshot` event

After:
- 1 `rebuildFullSnapshot` while initializing the player