### PR TITLE
Don't perform newly added actions if player is paused

### DIFF
--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -242,7 +242,7 @@ export function createPlayerService(
             const castFn = getCastFn(event, isSync);
             if (isSync) {
               castFn();
-            } else {
+            } else if (timer.isActive()) {
               timer.addAction({
                 doAction: () => {
                   castFn();
@@ -250,9 +250,6 @@ export function createPlayerService(
                 },
                 delay: event.delay!,
               });
-              if (!timer.isActive()) {
-                timer.start();
-              }
             }
           }
           return { ...ctx, events };


### PR DESCRIPTION
I've a scenario where newly added events which are coming in after the current play position are affecting the player state even when the player is paused.
I believe the correct thing to do (as per this pull request) is not to execute them until the player is resumed.
I see that starting the `timer.start();` line was added as part of #161 but I can't quiet understand what the idea was there?
I've changed it to instead only queue up the event if the timer is currently executing, which makes more sense to me, but I might be missing something?