### PR TITLE
Subscribe to MetaData change

### DIFF
--- a/src/replay/machine.ts
+++ b/src/replay/machine.ts
@@ -78,10 +78,11 @@ export function discardPriorSnapshots(
 type PlayerAssets = {
   emitter: Emitter;
   getCastFn(event: eventWithTime, isSync: boolean): () => void;
+  eventAddedCb: () => void;
 };
 export function createPlayerService(
   context: PlayerContext,
-  { getCastFn, emitter }: PlayerAssets,
+  { getCastFn, emitter, eventAddedCb }: PlayerAssets,
 ) {
   const playerMachine = createMachine<PlayerContext, PlayerEvent, PlayerState>(
     {
@@ -262,7 +263,8 @@ export function createPlayerService(
               }
               events.splice(insertionIndex, 0, event);
             }
-
+            
+            eventAddedCb();
             const isSync = event.timestamp < baselineTime;
             const castFn = getCastFn(event, isSync);
             if (isSync) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -615,3 +615,5 @@ export type LogRecordOptions = {
   stringifyOptions?: StringifyOptions;
   logger?: Logger;
 };
+
+export type MetaDataSubscriberCb = (metaData: playerMetaData) => void;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -203,6 +203,42 @@ export const sampleEvents: eventWithTime[] = [
   },
 ];
 
+export const extraEvents: eventWithTime[] = [
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 1,
+      x: 0,
+      y: 0,
+    },
+    timestamp: now + 4500,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 1,
+      x: 0,
+      y: 0,
+    },
+    timestamp: now + 5000,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 1,
+      x: 0,
+      y: 0,
+    },
+    timestamp: now + 5500,
+  }
+]
+
 export const sampleStyleSheetRemoveEvents: eventWithTime[] = [
   {
     type: EventType.DomContentLoaded,


### PR DESCRIPTION
`setMetaDataSubscriber` allows for listening to metadata changes when new events are added using the replayer's `addEvent` method.
It'd be a convenient way to allow use cases such as this issue: rrweb-io/rrweb-player#62