### PR TITLE
fix: issue #548

### DIFF
--- a/typings/replay/index.d.ts
+++ b/typings/replay/index.d.ts
@@ -55,6 +55,7 @@ export declare class Replayer {
     private hoverElements;
     private isUserInteraction;
     private backToNormal;
+    private restoreRealParent;
     private storeState;
     private restoreState;
     private warnNodeNotFound;


### PR DESCRIPTION
1. Do not use virtual parent optimization if the mutation targets have iframe elements as children. This will cause some performance regression but will be easy to add and ship.
2. If an iframe element has already been a child of a virtual parent, add the virtual parent back to the dom.

@Juice10 Please take a look at this PR.