### PR TITLE
Ascending timestamps

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -131,9 +131,15 @@ function record<T = eventWithTime>(
         e.data.source === IncrementalSource.Mutation
       )
     ) {
+      let mtimestamp = e.timestamp;
+      if ('positions' in e.data && e.data.positions[0].timeOffset) {
+        // assign the mutation timestamp to the beginning
+        // of mouse/touch movement
+        mtimestamp += e.data.positions[0].timeOffset;
+      }
       // we've got a user initiated event so first we need to apply
       // all DOM changes that have been buffering during paused state
-      mutationBuffers.forEach((buf) => buf.unfreeze(e.timestamp));
+      mutationBuffers.forEach((buf) => buf.unfreeze(mtimestamp));
     }
     if (ongoingMove) {
       // emit any ongoing (but throttled) mouse or touch move;

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -1,5 +1,5 @@
 import { snapshot, MaskInputOptions, SlimDOMOptions } from 'rrweb-snapshot';
-import { initObservers, mutationBuffers } from './observer';
+import { initObservers, mutationBuffers, ongoingMove } from './observer';
 import {
   on,
   getWindowWidth,
@@ -131,6 +131,12 @@ function record<T = eventWithTime>(
       // we've got a user initiated event so first we need to apply
       // all DOM changes that have been buffering during paused state
       mutationBuffers.forEach((buf) => buf.unfreeze());
+    }
+    if (ongoingMove) {
+      // emit any ongoing (but throttled) mouse or touch move;
+      // emitting now creates more events, but ensures events are emitted in
+      // sequence without any overlap from the negative Move timeOffset
+      ongoingMove();
     }
 
     emit(((packFn ? packFn(e) : e) as unknown) as T, isCheckout);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -217,9 +217,9 @@ export default class MutationBuffer {
     this.frozen = true;
   }
 
-  public unfreeze() {
+  public unfreeze(now: number) {
     this.frozen = false;
-    this.emit();
+    this.emit(now);
   }
 
   public isFrozen() {
@@ -240,9 +240,13 @@ export default class MutationBuffer {
     this.emit();
   };
 
-  public emit = () => {
+  public emit = (now?: number) => {
     if (this.frozen || this.locked) {
       return;
+    }
+
+    if (typeof now === 'undefined') {
+      now = Date.now();
     }
 
     // delay any modification of the mirror until this function
@@ -428,7 +432,7 @@ export default class MutationBuffer {
     this.droppedSet = new Set<Node>();
     this.movedMap = {};
 
-    this.emissionCallback(payload);
+    this.emissionCallback(payload, now);
   };
 
   private processMutation = (m: mutationRecord) => {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -180,19 +180,20 @@ function initMoveObserver(
     | IncrementalSource.TouchMove
     | IncrementalSource.Drag;
 
-  function moveEmission() {
+  function moveEmission(now: number) {
     if (!positions.length) {
       // already emitted
       return;
     }
     ongoingMove = null;
-    const totalOffset = Date.now() - timeBaseline!;
+    const totalOffset = now - timeBaseline!;
     cb(
       positions.map((p) => {
         p.timeOffset -= totalOffset;
         return p;
       }),
       source,
+      now,
     );
     positions = [];
     timeBaseline = null;
@@ -223,7 +224,7 @@ function initMoveObserver(
         ? IncrementalSource.MouseMove
         : IncrementalSource.TouchMove;
       ongoingMove = moveEmission;
-      throttledMoveEmission();
+      throttledMoveEmission(Date.now());
     },
     threshold,
     {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -335,7 +335,7 @@ export type mutationCallbackParam = {
   isAttachIframe?: true;
 };
 
-export type mutationCallBack = (m: mutationCallbackParam) => void;
+export type mutationCallBack = (m: mutationCallbackParam, timestamp?: number) => void;
 
 export type mousemoveCallBack = (
   p: mousePosition[],

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -343,6 +343,7 @@ export type mousemoveCallBack = (
     | IncrementalSource.MouseMove
     | IncrementalSource.TouchMove
     | IncrementalSource.Drag,
+  timestamp: number,
 ) => void;
 
 export type mousePosition = {

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -46,6 +46,7 @@ export function matchSnapshot(
  * @param snapshots incrementalSnapshotEvent[]
  */
 function stringifySnapshots(snapshots: eventWithTime[]): string {
+  let asc_time = 0;
   return JSON.stringify(
     snapshots
       .filter((s) => {
@@ -109,6 +110,21 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
             }
             coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
           });
+        }
+        if (
+          s.type === EventType.IncrementalSnapshot &&
+            (s.data.source === IncrementalSource.MouseMove
+             || s.data.source === IncrementalSource.TouchMove
+             || s.data.source === IncrementalSource.Drag)
+        ) {
+          s.data.positions.forEach((p) => {
+            let t = s.timestamp + p.timeOffset;
+            assert(asc_time <= t);
+            asc_time = t;
+          });
+        } else {
+          assert(asc_time <= s.timestamp);
+          asc_time = s.timestamp;
         }
         delete s.timestamp;
         return s;


### PR DESCRIPTION
This started with the idea that we don't want 'overlapping' events, i.e. a mouse click event followed by a mousemove event whose negative timestamps put the start of the mouse movement before the click.

This is important in the logical processing of a series of events so that we don't have to consider the next event when processing the current event e.g. in building up a graphical timeline.

It could also be important in streaming 'live' events to a player, as although a mousemove can still introduce up to 500ms lag, it now can't result in an out-of-order situation where that click is played back before a mousemove that should precede it.

There seem to be no tests that recreate the mouse movement due to the mentioned difficulty with 'random' mouse movements in the headless browser.  I've added a test (via util.py) to check that timestamps are weakly ascending before we strip them out, but that didn't catch anything prior to these changes.  Any advice on how to increase the test coverage for this commit appreciated!