### PR TITLE
Disable full snapshot rebuild after first event

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -462,9 +462,10 @@ export class Replayer {
       case EventType.FullSnapshot:
         castFn = () => {
           // Don't build a full snapshot during the first play through since we've already built it when the player was mounted.
-          if (this.firstPlayedEvent && this.firstPlayedEvent === event) {
+          if (this.firstPlayedEvent) {
             return;
           }
+          this.firstPlayedEvent = event
           this.rebuildFullSnapshot(event, isSync);
           this.iframe.contentWindow!.scrollTo(event.data.initialOffset);
         };


### PR DESCRIPTION
Currently full snapshot is built even after first event has already been played. 
This leads to bugs such as media playback crash when media has already started playing. #573 