### PR TITLE
Fix order of ternary expression for mouse move source type

### DIFF
--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -209,10 +209,10 @@ function initMoveObserver(
         timeOffset: Date.now() - timeBaseline,
       });
       wrappedCb(
-        evt instanceof MouseEvent
-          ? IncrementalSource.MouseMove
-          : evt instanceof DragEvent
+        evt instanceof DragEvent
           ? IncrementalSource.Drag
+          : evt instanceof MouseEvent
+          ? IncrementalSource.MouseMove
           : IncrementalSource.TouchMove,
       );
     },


### PR DESCRIPTION
DragEvent is inherited from MouseEvent so the first expression evaluates to true for both MouseEvent and DragEvent which fills in incorrect source for the event.

Doesn't affect the re-player since everything except the source is same and it's played correctly as mouse moves as expected.

Due the inheritance between the events, we should first check the instance type for the sub event.