### PR TITLE
Handle Drag events in replayer

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -783,6 +783,7 @@ export class Replayer {
         this.applyMutation(d, isSync);
         break;
       }
+      case IncrementalSource.Drag:
       case IncrementalSource.MouseMove:
         if (isSync) {
           const lastPosition = d.positions[d.positions.length - 1];

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -784,6 +784,7 @@ export class Replayer {
         break;
       }
       case IncrementalSource.Drag:
+      case IncrementalSource.TouchMove:
       case IncrementalSource.MouseMove:
         if (isSync) {
           const lastPosition = d.positions[d.positions.length - 1];


### PR DESCRIPTION
Drag events are not handled in replayer.
This doesn't break the replay but the mouse movement during a 'drag' is skipped directly to the event.

Drag and MouseMove for the replayer is identical, so this source type can fallback to MouseMove. 