### PR TITLE
Test that the observer is monitoring changes on the <html> element itself

### DIFF
--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -27,7 +27,9 @@ exports[`attributes 1`] = `
           {
             \\"type\\": 2,
             \\"tagName\\": \\"html\\",
-            \\"attributes\\": {},
+            \\"attributes\\": {
+              \\"class\\": \\"test\\"
+            },
             \\"childNodes\\": [
               {
                 \\"type\\": 2,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -163,6 +163,7 @@ describe('record integration tests', function (this: ISuite) {
       li.setAttribute('foo', 'bar');
       document.body.removeChild(ul);
       document.body.setAttribute('test', 'true');
+      document.documentElement.className = 'test';
     });
 
     const snapshots = await page.evaluate('window.snapshots');


### PR DESCRIPTION
I'm running into this problem where mutations are missed on the <html> element, e.g. important ones where a class is added to the html element to blank out the screen, and then subsequently removed when content has loaded... recording just stays blank.

Creating this pull request to confirm problem is in rrweb (my local test environment hasn't been working)