### PR TITLE
add allowIframe option

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "@xstate/fsm": "^1.4.0",
     "fflate": "^0.4.4",
     "mitt": "^1.1.3",
-    "rrweb-snapshot": "^1.1.4"
+    "rrweb-snapshot": "^1.1.5"
   }
 }

--- a/src/record/index.ts
+++ b/src/record/index.ts
@@ -59,6 +59,7 @@ function record<T = eventWithTime>(
     recordCanvas = false,
     collectFonts = false,
     plugins,
+    keepIframeSrcFn = () => false,
   } = options;
   // runtime checks for user options
   if (!emit) {
@@ -236,6 +237,7 @@ function record<T = eventWithTime>(
       onIframeLoad: (iframe, childSn) => {
         iframeManager.attachIframe(iframe, childSn);
       },
+      keepIframeSrcFn,
     });
 
     if (!node) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,7 @@ export type recordOptions<T> = {
   plugins?: RecordPlugin[];
   // departed, please use sampling options
   mousemoveWait?: number;
+  keepIframeSrcFn?: KeepIframeSrcFn;
 };
 
 export type observerParam = {
@@ -552,3 +553,5 @@ export type ElementState = {
   // [scrollLeft,scrollTop]
   scroll?: [number, number];
 };
+
+export type KeepIframeSrcFn = (src: string) => boolean;

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -147,6 +147,7 @@ export declare type recordOptions<T> = {
     collectFonts?: boolean;
     plugins?: RecordPlugin[];
     mousemoveWait?: number;
+    keepIframeSrcFn?: KeepIframeSrcFn;
 };
 export declare type observerParam = {
     mutationCb: mutationCallBack;
@@ -417,4 +418,5 @@ export declare type MaskTextFn = (text: string) => string;
 export declare type ElementState = {
     scroll?: [number, number];
 };
+export declare type KeepIframeSrcFn = (src: string) => boolean;
 export {};


### PR DESCRIPTION
This PR fixes #585 
Additional option allows iframes to retain `src` attribute. This option allong with `custom-events` can be used to replay content of iframes that is blocked by `same-origin-policy` such as youtube iframes.
By using below function I was able to replay content from youtube:
```
function allowIframe (src: string): boolean {
    try {
        const url = new URL(src);
        return url.origin === `https://www.youtube.com`;
    } catch {
        return false;
    }
}  
```