### PR TITLE
implement video seek feature

### DIFF
--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -483,7 +483,7 @@ function initMediaInteractionObserver(
   mirror: Mirror,
 ): listenerHandler {
   const handler = (type: MediaInteractions ) => (event: Event) => {
-    const { target } = event;
+    const target = getEventTarget(event);
     if (!target || isBlocked(target as Node, blockClass)) {
       return;
     }

--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -482,17 +482,24 @@ function initMediaInteractionObserver(
   blockClass: blockClass,
   mirror: Mirror,
 ): listenerHandler {
-  const handler = (type: 'play' | 'pause') => (event: Event) => {
-    const target = getEventTarget(event);
+  const handler = (type: MediaInteractions ) => (event: Event) => {
+    const { target } = event;
     if (!target || isBlocked(target as Node, blockClass)) {
       return;
     }
     mediaInteractionCb({
-      type: type === 'play' ? MediaInteractions.Play : MediaInteractions.Pause,
+      type,
       id: mirror.getId(target as INode),
+      attributes: {
+        currentTime: (target as HTMLMediaElement).currentTime
+      },
     });
   };
-  const handlers = [on('play', handler('play')), on('pause', handler('pause'))];
+  const handlers = [
+    on('play', handler(MediaInteractions.Play)), 
+    on('pause', handler(MediaInteractions.Pause)), 
+    on('seeked', handler(MediaInteractions.Seeked))
+  ];
   return () => {
     handlers.forEach((h) => h());
   };

--- a/src/record/observer.ts
+++ b/src/record/observer.ts
@@ -490,9 +490,7 @@ function initMediaInteractionObserver(
     mediaInteractionCb({
       type,
       id: mirror.getId(target as INode),
-      attributes: {
-        currentTime: (target as HTMLMediaElement).currentTime
-      },
+      currentTime: (target as HTMLMediaElement).currentTime
     });
   };
   const handlers = [

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -910,14 +910,14 @@ export class Replayer {
             mediaEl.pause();
           }
           if (d.type === MediaInteractions.Play) {
-            mediaEl.currentTime = d.attributes.currentTime;
+            mediaEl.currentTime = d.currentTime as number;
             // remove listener for 'canplay' event because play() is async and returns a promise
             // i.e. media will evntualy start to play when data is loaded
             // 'canplay' event fires even when currentTime attribute changes which may lead to 
             // unexpeted behavior
             mediaEl.play();
           } else if (d.type === MediaInteractions.Seeked) {
-            mediaEl.currentTime = d.attributes.currentTime;
+            mediaEl.currentTime = d.currentTime as number;
           }
         } catch (error) {
           if (this.config.showWarning) {

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -910,13 +910,14 @@ export class Replayer {
             mediaEl.pause();
           }
           if (d.type === MediaInteractions.Play) {
-            if (mediaEl.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
-              mediaEl.play();
-            } else {
-              mediaEl.addEventListener('canplay', () => {
-                mediaEl.play();
-              });
-            }
+            mediaEl.currentTime = d.attributes.currentTime;
+            // remove listener for 'canplay' event because play() is async and returns a promise
+            // i.e. media will evntualy start to play when data is loaded
+            // 'canplay' event fires even when currentTime attribute changes which may lead to 
+            // unexpeted behavior
+            mediaEl.play();
+          } else if (d.type === MediaInteractions.Seeked) {
+            mediaEl.currentTime = d.attributes.currentTime;
           }
         } catch (error) {
           if (this.config.showWarning) {

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -906,18 +906,18 @@ export class Replayer {
         }
         const mediaEl = (target as Node) as HTMLMediaElement;
         try {
+          if (d.currentTime) {
+            mediaEl.currentTime = d.currentTime;
+          }
           if (d.type === MediaInteractions.Pause) {
             mediaEl.pause();
           }
           if (d.type === MediaInteractions.Play) {
-            mediaEl.currentTime = d.currentTime as number;
             // remove listener for 'canplay' event because play() is async and returns a promise
             // i.e. media will evntualy start to play when data is loaded
             // 'canplay' event fires even when currentTime attribute changes which may lead to 
             // unexpeted behavior
             mediaEl.play();
-          } else if (d.type === MediaInteractions.Seeked) {
-            mediaEl.currentTime = d.currentTime as number;
           }
         } catch (error) {
           if (this.config.showWarning) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -474,11 +474,15 @@ export type inputCallback = (v: inputValue & { id: number }) => void;
 export const enum MediaInteractions {
   Play,
   Pause,
+  Seeked,
 }
 
 export type mediaInteractionParam = {
   type: MediaInteractions;
   id: number;
+  attributes: {
+    currentTime: number
+  };
 };
 
 export type mediaInteractionCallback = (p: mediaInteractionParam) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -480,9 +480,7 @@ export const enum MediaInteractions {
 export type mediaInteractionParam = {
   type: MediaInteractions;
   id: number;
-  attributes: {
-    currentTime: number
-  };
+  currentTime?: number
 };
 
 export type mediaInteractionCallback = (p: mediaInteractionParam) => void;

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -340,9 +340,7 @@ export declare const enum MediaInteractions {
 export declare type mediaInteractionParam = {
     type: MediaInteractions;
     id: number;
-    attributes: {
-        currentTime: number;
-    };
+    currentTime?: number;
 };
 export declare type mediaInteractionCallback = (p: mediaInteractionParam) => void;
 export declare type DocumentDimension = {

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -334,11 +334,15 @@ export declare type inputCallback = (v: inputValue & {
 }) => void;
 export declare const enum MediaInteractions {
     Play = 0,
-    Pause = 1
+    Pause = 1,
+    Seeked = 2
 }
 export declare type mediaInteractionParam = {
     type: MediaInteractions;
     id: number;
+    attributes: {
+        currentTime: number;
+    };
 };
 export declare type mediaInteractionCallback = (p: mediaInteractionParam) => void;
 export declare type DocumentDimension = {


### PR DESCRIPTION
Listening for `seeked` event helps to synchronize media content between recorded and replayed page.