### PR TITLE
Fix an incorrected finish which halted playback prematurely

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -493,13 +493,16 @@ export class Replayer {
       this.service.send({ type: 'CAST_EVENT', payload: { event } });
 
       // events are kept sorted by timestamp, check if this is the last event
+      let last_index = this.service.state.context.events.length - 1;
       if (
         event ===
-        this.service.state.context.events[
-          this.service.state.context.events.length - 1
-        ]
+        this.service.state.context.events[last_index]
       ) {
         const finish = () => {
+          if (last_index < this.service.state.context.events.length - 1) {
+            // more events have been added since the setTimeout
+            return;
+          }
           this.backToNormal();
           this.service.send('END');
           this.emitter.emit(ReplayerEvents.Finish);


### PR DESCRIPTION
The scenario was that there were events being rapidly added to the recording.

I could only recreate it happening in this setTimeout/mousemove code path, but can't see why it wouldn't also apply to the [non setTimeout call to](https://github.com/statcounter/rrweb/blob/123c78aba390daadf7015e79b16d59c3791e86a9/src/replay/index.ts#L520) `finish();`:

Just wanted to check I'm missing something;

Should the approach instead be to restart the requestAnimationFrame timer after an addEvent on a finished replay?

