### PR TITLE
Ignore firstFullSnapshot once only after initial 'poster' build

### DIFF
--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -90,7 +90,7 @@ export class Replayer {
 
   private mirror: Mirror = createMirror();
 
-  private firstFullSnapshot: eventWithTime | null = null;
+  private firstFullSnapshot: eventWithTime | true | null = null;
 
   private newDocumentQueue: addedNodeMutation[] = [];
 

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -208,6 +208,7 @@ export class Replayer {
       setTimeout(() => {
         // when something has been played, there is no need to rebuild poster
         if (this.firstFullSnapshot) {
+          // true if any other fullSnapshot has been executed by Timer already
           return;
         }
         this.firstFullSnapshot = firstFullsnapshot;
@@ -431,12 +432,13 @@ export class Replayer {
         castFn = () => {
           if (this.firstFullSnapshot) {
             if (this.firstFullSnapshot === event) {
-              // we've already built it when the player was mounted.
+              // we've already built this exact FullSnapshot when the player was mounted, and haven't built any other FullSnapshot since
+              this.firstFullSnapshot = true; // forget as we might need to re-execute this FullSnapshot later e.g. to rebuild after scrubbing
               return;
             }
           } else {
             // Timer (requestAnimationFrame) can be faster than setTimeout(..., 1)
-            this.firstFullSnapshot = event;
+            this.firstFullSnapshot = true;
           }
           this.rebuildFullSnapshot(event, isSync);
           this.iframe.contentWindow!.scrollTo(event.data.initialOffset);

--- a/typings/replay/index.d.ts
+++ b/typings/replay/index.d.ts
@@ -20,7 +20,7 @@ export declare class Replayer {
     private elementStateMap;
     private imageMap;
     private mirror;
-    private firstPlayedEvent;
+    private firstFullSnapshot;
     private newDocumentQueue;
     constructor(events: Array<eventWithTime | string>, config?: Partial<playerConfig>);
     on(event: string, handler: Handler): this;


### PR DESCRIPTION
~I believe the Timer was immediately started and reached the snapshot before the setTimeout returned.~

Actually that probably wasn't the case, but this includes a guard against that which prevents the 'poster' build if *any* FullSnapshot has already been built.