### PR TITLE
Add type checking to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ install:
   - yarn
 
 script:
+  - tsc --noEmit
   - xvfb-run --server-args="-screen 0 1920x1080x24" npm test

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/inquirer": "0.0.43",
     "@types/jsdom": "^16.2.12",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.11.7",
+    "@types/node": "^12.20.16",
     "@types/puppeteer": "^5.4.3",
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.2.tgz#d25295f9e4ca5989a2c610754dc02a9721235eeb"
   integrity sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==
 
-"@types/node@^10.11.7":
-  version "10.17.42"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.42.tgz#90dd71b26fe4f4e2929df6b07e72ef2e9648a173"
-  integrity sha512-HElxYF7C/MSkuvlaHB2c+82zhXiuO49Cq056Dol8AQuTph7oJtduo2n6J8rFa+YhJyNgQ/Lm20ZaxqD0vxU0+Q==
+"@types/node@^12.20.16":
+  version "12.20.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.16.tgz#1acf34f6456208f495dac0434dd540488d17f991"
+  integrity sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==
 
 "@types/parse5@*":
   version "6.0.0"


### PR DESCRIPTION
I tried to build master and realised code had crept in that doesn't pass typescript's type checking.
This pr adds typescript type checking as one of the steps on CI so we don't accidentally merge PRs that don't pass the type checker.