### PR TITLE
Snapshot es only

### DIFF
--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -7,6 +7,7 @@
     "prepack": "npm run bundle && npm run typings",
     "test": "cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.ts",
     "bundle": "rollup --config",
+    "bundle:es-only": "cross-env ES_ONLY=true rollup --config",
     "typings": "tsc -d --declarationDir typings"
   },
   "repository": {

--- a/packages/rrweb-snapshot/rollup.config.js
+++ b/packages/rrweb-snapshot/rollup.config.js
@@ -6,7 +6,20 @@ function toMinPath(path) {
   return path.replace(/\.js$/, '.min.js');
 }
 
-export default [
+let configs = [
+  // ES module - for building rrweb
+  {
+    input: './src/index.ts',
+    plugins: [typescript()],
+    output: [
+      {
+        format: 'esm',
+        file: pkg.module,
+      },
+    ],
+  },
+];
+let extra_configs = [
   // browser
   {
     input: './src/index.ts',
@@ -42,17 +55,7 @@ export default [
       },
     ],
   },
-  // ES module
-  {
-    input: './src/index.ts',
-    plugins: [typescript()],
-    output: [
-      {
-        format: 'esm',
-        file: pkg.module,
-      },
-    ],
-  },
+  // ES module (packed)
   {
     input: './src/index.ts',
     plugins: [typescript(), terser()],
@@ -65,3 +68,9 @@ export default [
     ],
   },
 ];
+
+if (!process.env.ES_ONLY) {
+  configs.push(...extra_configs);
+}
+
+export default configs;


### PR DESCRIPTION
The new `yarn bundle:es-only` in packages/rrweb-snapshot is the only output needed in order to build rrweb.
This option could be used as part of a new root level build process if you only want to output the rrweb record/replay javascript.