### PR TITLE
The desktop pointer cursor is not representative of mobile

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -939,6 +939,10 @@ export class Replayer {
                 touchActive: touchActive,
               };
             } else {
+              if (d.type === MouseInteractions.TouchStart) {
+                // don't draw a trail as user has lifted finger and is placing at a new point
+                this.tailPositions.length = 0;
+              }
               this.moveAndHover(d.x, d.y, d.id, isSync, d);
               if (d.type === MouseInteractions.Click) {
                 /*
@@ -954,6 +958,7 @@ export class Replayer {
                 void this.mouse.offsetWidth;
                 this.mouse.classList.add('active');
               } else if (d.type === MouseInteractions.TouchStart) {
+                void this.mouse.offsetWidth;  // needed for the position update of moveAndHover to apply without the .touch-active transition
                 this.mouse.classList.add('touch-active');
               } else if (d.type === MouseInteractions.TouchEnd) {
                 this.mouse.classList.remove('touch-active');

--- a/packages/rrweb/src/replay/styles/style.css
+++ b/packages/rrweb/src/replay/styles/style.css
@@ -5,11 +5,12 @@
   position: absolute;
   width: 20px;
   height: 20px;
-  transition: 0.05s linear;
+  transition: left 0.05s linear, top 0.05s linear;
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;
   background-image: url('data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9JzMwMHB4JyB3aWR0aD0nMzAwcHgnICBmaWxsPSIjMDAwMDAwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGRhdGEtbmFtZT0iTGF5ZXIgMSIgdmlld0JveD0iMCAwIDUwIDUwIiB4PSIwcHgiIHk9IjBweCI+PHRpdGxlPkRlc2lnbl90bnA8L3RpdGxlPjxwYXRoIGQ9Ik00OC43MSw0Mi45MUwzNC4wOCwyOC4yOSw0NC4zMywxOEExLDEsMCwwLDAsNDQsMTYuMzlMMi4zNSwxLjA2QTEsMSwwLDAsMCwxLjA2LDIuMzVMMTYuMzksNDRhMSwxLDAsMCwwLDEuNjUuMzZMMjguMjksMzQuMDgsNDIuOTEsNDguNzFhMSwxLDAsMCwwLDEuNDEsMGw0LjM4LTQuMzhBMSwxLDAsMCwwLDQ4LjcxLDQyLjkxWm0tNS4wOSwzLjY3TDI5LDMyYTEsMSwwLDAsMC0xLjQxLDBsLTkuODUsOS44NUwzLjY5LDMuNjlsMzguMTIsMTRMMzIsMjcuNThBMSwxLDAsMCwwLDMyLDI5TDQ2LjU5LDQzLjYyWiI+PC9wYXRoPjwvc3ZnPg==');
+  border-color: transparent;  /* otherwise we transition from black when .touch-device class is added */
 }
 .replayer-mouse::after {
   content: '';
@@ -24,6 +25,27 @@
 .replayer-mouse.active::after {
   animation: click 0.2s ease-in-out 1;
 }
+.replayer-mouse.touch-device {
+  background-image: none;  /* there's no passive cursor on touch-only screens */
+  width: 70px;
+  height: 70px;
+  border-width: 4px;
+  border-style: solid;
+  border-radius: 100%;
+  margin-left: -37px;
+  margin-top: -37px;
+  border-color: rgba(73, 80, 246, 0);
+  transition: left 0.05s linear, top 0.05s linear, border-color 0.2s ease-in-out;
+}
+.replayer-mouse.touch-device.touch-active {
+  border-color: rgba(73, 80, 246, 1);
+}
+.replayer-mouse.touch-device::after {
+  opacity: 0;  /* there's no passive cursor on touch-only screens */
+}
+.replayer-mouse.touch-device.active::after {
+  animation: touch-click 0.2s ease-in-out 1;
+}
 .replayer-mouse-tail {
   position: absolute;
   pointer-events: none;
@@ -32,6 +54,19 @@
 @keyframes click {
   0% {
     opacity: 0.3;
+    width: 20px;
+    height: 20px;
+  }
+  50% {
+    opacity: 0.5;
+    width: 10px;
+    height: 10px;
+  }
+}
+
+@keyframes touch-click {
+  0% {
+    opacity: 0;
     width: 20px;
     height: 20px;
   }

--- a/packages/rrweb/src/replay/styles/style.css
+++ b/packages/rrweb/src/replay/styles/style.css
@@ -35,10 +35,11 @@
   margin-left: -37px;
   margin-top: -37px;
   border-color: rgba(73, 80, 246, 0);
-  transition: left 0.05s linear, top 0.05s linear, border-color 0.2s ease-in-out;
+  transition: left 0s linear, top 0s linear, border-color 0.2s ease-in-out;
 }
 .replayer-mouse.touch-device.touch-active {
   border-color: rgba(73, 80, 246, 1);
+  transition: left 0.25s linear, top 0.25s linear, border-color 0.2s ease-in-out;
 }
 .replayer-mouse.touch-device::after {
   opacity: 0;  /* there's no passive cursor on touch-only screens */

--- a/packages/rrweb/src/replay/styles/style.css
+++ b/packages/rrweb/src/replay/styles/style.css
@@ -16,9 +16,9 @@
   display: inline-block;
   width: 20px;
   height: 20px;
-  border-radius: 10px;
   background: rgb(73, 80, 246);
-  transform: translate(-10px, -10px);
+  border-radius: 100%;
+  transform: translate(-50%, -50%);
   opacity: 0.3;
 }
 .replayer-mouse.active::after {
@@ -34,14 +34,10 @@
     opacity: 0.3;
     width: 20px;
     height: 20px;
-    border-radius: 10px;
-    transform: translate(-10px, -10px);
   }
   50% {
     opacity: 0.5;
     width: 10px;
     height: 10px;
-    border-radius: 5px;
-    transform: translate(-5px, -5px);
   }
 }

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -352,16 +352,11 @@ export type mousePosition = {
   timeOffset: number;
 };
 
-type mousePos = {
+export type mouseMovePos = {
   x: number;
   y: number;
   id: number;
   debugData: incrementalData;
-};
-
-export type mouseState = {
-  pos?: mousePos;
-  touchActive?: boolean;
 };
 
 export enum MouseInteractions {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -370,6 +370,7 @@ export enum MouseInteractions {
   TouchStart,
   TouchMove_Departed, // we will start a separate observer for touch move event
   TouchEnd,
+  TouchCancel,
 }
 
 type mouseInteractionParam = {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -352,6 +352,13 @@ export type mousePosition = {
   timeOffset: number;
 };
 
+export type mouseState = {
+  x: number;
+  y: number;
+  id: number;
+  debugData: incrementalData;
+};
+
 export enum MouseInteractions {
   MouseUp,
   MouseDown,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -352,11 +352,16 @@ export type mousePosition = {
   timeOffset: number;
 };
 
-export type mouseState = {
+type mousePos = {
   x: number;
   y: number;
   id: number;
   debugData: incrementalData;
+};
+
+export type mouseState = {
+  pos?: mousePos;
+  touchActive?: boolean;
 };
 
 export enum MouseInteractions {

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -314,38 +314,6 @@ export function polyfill(win = window) {
   }
 }
 
-export function needCastInSyncMode(event: eventWithTime): boolean {
-  switch (event.type) {
-    case EventType.DomContentLoaded:
-    case EventType.Load:
-    case EventType.Custom:
-      return false;
-    case EventType.FullSnapshot:
-    case EventType.Meta:
-    case EventType.Plugin:
-      return true;
-    default:
-      break;
-  }
-
-  switch (event.data.source) {
-    case IncrementalSource.MouseMove:
-    case IncrementalSource.MouseInteraction:
-    case IncrementalSource.TouchMove:
-    case IncrementalSource.MediaInteraction:
-      return false;
-    case IncrementalSource.ViewportResize:
-    case IncrementalSource.StyleSheetRule:
-    case IncrementalSource.Scroll:
-    case IncrementalSource.Input:
-      return true;
-    default:
-      break;
-  }
-
-  return true;
-}
-
 export type TreeNode = {
   id: number;
   mutation: addedNodeMutation;

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -15,7 +15,6 @@ export declare function isIgnored(n: Node | INode): boolean;
 export declare function isAncestorRemoved(target: INode, mirror: Mirror): boolean;
 export declare function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent;
 export declare function polyfill(win?: Window & typeof globalThis): void;
-export declare function needCastInSyncMode(event: eventWithTime): boolean;
 export declare type TreeNode = {
     id: number;
     mutation: addedNodeMutation;


### PR DESCRIPTION
The desktop pointer cursor is not representative of what is happening on a mobile device.

Instead, check a recording for any presence of a Touch event, and switch to a touch visualisation mode for the entire recording.
(for now, we use this mode even for mixed touch/mouse devices - this could be improved upon in future)

Show a round circle representing the users' finger which is visible only between TouchStart and TouchEnd events
Again this can be evolved upon, but this change should be a good start in the right direction.