### PR TITLE
Batch apply synchronous events

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -472,7 +472,13 @@ export class Replayer {
       castFn();
     }
     if (this.mousePos !== null) {
-      this.moveAndHover(this.mousePos.x, this.mousePos.y, this.mousePos.id, true, this.mousePos.debugData);
+      this.moveAndHover(
+        this.mousePos.x,
+        this.mousePos.y,
+        this.mousePos.id,
+        true,
+        this.mousePos.debugData,
+      );
       this.mousePos = null;
     }
   }
@@ -1510,7 +1516,13 @@ export class Replayer {
     }
   }
 
-  private moveAndHover(x: number, y: number, id: number, isSync: boolean, debugData: incrementalData) {
+  private moveAndHover(
+    x: number,
+    y: number,
+    id: number,
+    isSync: boolean,
+    debugData: incrementalData,
+  ) {
     const target = this.mirror.getNode(id);
     if (!target) {
       return this.debugNodeNotFound(debugData, id);

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -352,6 +352,13 @@ export type mousePosition = {
   timeOffset: number;
 };
 
+export type mouseState = {
+  x: number;
+  y: number;
+  id: number;
+  debugData: incrementalData;
+};
+
 export enum MouseInteractions {
   MouseUp,
   MouseDown,

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -314,38 +314,6 @@ export function polyfill(win = window) {
   }
 }
 
-export function needCastInSyncMode(event: eventWithTime): boolean {
-  switch (event.type) {
-    case EventType.DomContentLoaded:
-    case EventType.Load:
-    case EventType.Custom:
-      return false;
-    case EventType.FullSnapshot:
-    case EventType.Meta:
-    case EventType.Plugin:
-      return true;
-    default:
-      break;
-  }
-
-  switch (event.data.source) {
-    case IncrementalSource.MouseMove:
-    case IncrementalSource.MouseInteraction:
-    case IncrementalSource.TouchMove:
-    case IncrementalSource.MediaInteraction:
-      return false;
-    case IncrementalSource.ViewportResize:
-    case IncrementalSource.StyleSheetRule:
-    case IncrementalSource.Scroll:
-    case IncrementalSource.Input:
-      return true;
-    default:
-      break;
-  }
-
-  return true;
-}
-
 export type TreeNode = {
   id: number;
   mutation: addedNodeMutation;

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -15,7 +15,6 @@ export declare function isIgnored(n: Node | INode): boolean;
 export declare function isAncestorRemoved(target: INode, mirror: Mirror): boolean;
 export declare function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent;
 export declare function polyfill(win?: Window & typeof globalThis): void;
-export declare function needCastInSyncMode(event: eventWithTime): boolean;
 export declare type TreeNode = {
     id: number;
     mutation: addedNodeMutation;


### PR DESCRIPTION
 - this is a move towards a new approach of how we 'fast forward' through events, i.e. the behaviour with `sync = true`
 - the new `applyEventsSynchronously` function could be the place we'd initialize an rrdom object and apply mutation updates to it
 - there may be further optimizations enabled by `applyEventsSynchronously` e.g. executing `applyScroll` only once per element for a batch of events