### PR TITLE
impl #650, CSS declaration observer

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -352,6 +352,16 @@ function record<T = eventWithTime>(
                 },
               }),
             ),
+          styleDeclarationCb: (r) =>
+            wrappedEmit(
+              wrapEvent({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.StyleDeclaration,
+                  ...r,
+                },
+              }),
+            ),
           canvasMutationCb: (p) =>
             wrappedEmit(
               wrapEvent({

--- a/packages/rrweb/src/replay/virtual-styles.ts
+++ b/packages/rrweb/src/replay/virtual-styles.ts
@@ -4,6 +4,8 @@ export enum StyleRuleType {
   Insert,
   Remove,
   Snapshot,
+  SetProperty,
+  RemoveProperty,
 }
 
 type InsertRule = {
@@ -19,8 +21,22 @@ type SnapshotRule = {
   type: StyleRuleType.Snapshot;
   cssTexts: string[];
 };
+type SetPropertyRule = {
+  type: StyleRuleType.SetProperty;
+  index: number[];
+  property: string;
+  value: string | null;
+  priority: string | undefined;
+};
+type RemovePropertyRule = {
+  type: StyleRuleType.RemoveProperty;
+  index: number[];
+  property: string;
+};
 
-export type VirtualStyleRules = Array<InsertRule | RemoveRule | SnapshotRule>;
+export type VirtualStyleRules = Array<
+  InsertRule | RemoveRule | SnapshotRule | SetPropertyRule | RemovePropertyRule
+>;
 export type VirtualStyleRulesMap = Map<INode, VirtualStyleRules>;
 
 export function getNestedRule(
@@ -88,6 +104,18 @@ export function applyVirtualStyleRulesToNode(
       }
     } else if (rule.type === StyleRuleType.Snapshot) {
       restoreSnapshotOfStyleRulesToNode(rule.cssTexts, styleNode);
+    } else if (rule.type === StyleRuleType.SetProperty) {
+      const nativeRule = (getNestedRule(
+        styleNode.sheet!.cssRules,
+        rule.index,
+      ) as unknown) as CSSStyleRule;
+      nativeRule.style.setProperty(rule.property, rule.value, rule.priority);
+    } else if (rule.type === StyleRuleType.RemoveProperty) {
+      const nativeRule = (getNestedRule(
+        styleNode.sheet!.cssRules,
+        rule.index,
+      ) as unknown) as CSSStyleRule;
+      nativeRule.style.removeProperty(rule.property);
     }
   });
 }

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -90,6 +90,7 @@ export enum IncrementalSource {
   Font,
   Log,
   Drag,
+  StyleDeclaration,
 }
 
 export type mutationData = {
@@ -129,6 +130,10 @@ export type styleSheetRuleData = {
   source: IncrementalSource.StyleSheetRule;
 } & styleSheetRuleParam;
 
+export type styleDeclarationData = {
+  source: IncrementalSource.StyleDeclaration;
+} & styleDeclarationParam;
+
 export type canvasMutationData = {
   source: IncrementalSource.CanvasMutation;
 } & canvasMutationParam;
@@ -147,7 +152,8 @@ export type incrementalData =
   | mediaInteractionData
   | styleSheetRuleData
   | canvasMutationData
-  | fontData;
+  | fontData
+  | styleDeclarationData;
 
 export type event =
   | domContentLoadedEvent
@@ -244,6 +250,7 @@ export type observerParam = {
   maskTextFn?: MaskTextFn;
   inlineStylesheet: boolean;
   styleSheetRuleCb: styleSheetRuleCallback;
+  styleDeclarationCb: styleDeclarationCallback;
   canvasMutationCb: canvasMutationCallback;
   fontCb: fontCallback;
   sampling: SamplingStrategy;
@@ -271,6 +278,7 @@ export type hooksParam = {
   input?: inputCallback;
   mediaInteaction?: mediaInteractionCallback;
   styleSheetRule?: styleSheetRuleCallback;
+  styleDeclaration?: styleDeclarationCallback;
   canvasMutation?: canvasMutationCallback;
   font?: fontCallback;
 };
@@ -406,6 +414,21 @@ export type styleSheetRuleParam = {
 };
 
 export type styleSheetRuleCallback = (s: styleSheetRuleParam) => void;
+
+export type styleDeclarationParam = {
+  id: number;
+  index: number[];
+  set?: {
+    property: string;
+    value: string | null;
+    priority: string | undefined;
+  };
+  remove?: {
+    property: string;
+  };
+};
+
+export type styleDeclarationCallback = (s: styleDeclarationParam) => void;
 
 export type canvasMutationCallback = (p: canvasMutationParam) => void;
 


### PR DESCRIPTION
# CSS declaration observer

## The Issue

There are browser APIs that can modify the value of CSS declaration by setting property and removing property. So we need to observe these changes and replay them.

## The implementation

The CSS  declaration observer was implemented in the general pattern and follow the latest design of @Juice10, e.g, using array index to handle nesting and store changes in virtual style when using a fragment.

## Decisions

Two small designs do not fit well but can be improved in the following patches, without blocking this feature.

1. `getNestedRule` not return `CSSGroupingRule`, but in this scenario, it can return `CSSStyleRule`.
2. The naming of states in the virtual style module is `XXXRule`, so it's a little confusing to naming an operation to CSS rule.
