### PR TITLE
improve config definition in the console plugin

### DIFF
--- a/packages/rrweb/src/plugins/console/record/index.ts
+++ b/packages/rrweb/src/plugins/console/record/index.ts
@@ -19,7 +19,7 @@ export type StringifyOptions = {
 };
 
 type LogRecordOptions = {
-  level?: LogLevel[] | undefined;
+  level?: LogLevel[];
   lengthThreshold?: number;
   stringifyOptions?: StringifyOptions;
   logger?: Logger;

--- a/packages/rrweb/src/plugins/console/replay/index.ts
+++ b/packages/rrweb/src/plugins/console/replay/index.ts
@@ -13,8 +13,8 @@ import {
 type ReplayLogger = Partial<Record<LogLevel, (data: LogData) => void>>;
 
 type LogReplayConfig = {
-  level?: LogLevel[] | undefined;
-  replayLogger: ReplayLogger | undefined;
+  level?: LogLevel[];
+  replayLogger?: ReplayLogger;
 };
 
 const ORIGINAL_ATTRIBUTE_NAME = '__rrweb_original__';

--- a/packages/rrweb/typings/plugins/console/record/index.d.ts
+++ b/packages/rrweb/typings/plugins/console/record/index.d.ts
@@ -5,7 +5,7 @@ export declare type StringifyOptions = {
     depthOfLimit: number;
 };
 declare type LogRecordOptions = {
-    level?: LogLevel[] | undefined;
+    level?: LogLevel[];
     lengthThreshold?: number;
     stringifyOptions?: StringifyOptions;
     logger?: Logger;

--- a/packages/rrweb/typings/plugins/console/replay/index.d.ts
+++ b/packages/rrweb/typings/plugins/console/replay/index.d.ts
@@ -2,8 +2,8 @@ import { LogLevel, LogData } from '../record';
 import { ReplayPlugin } from '../../../types';
 declare type ReplayLogger = Partial<Record<LogLevel, (data: LogData) => void>>;
 declare type LogReplayConfig = {
-    level?: LogLevel[] | undefined;
-    replayLogger: ReplayLogger | undefined;
+    level?: LogLevel[];
+    replayLogger?: ReplayLogger;
 };
 export declare const getReplayConsolePlugin: (options?: LogReplayConfig) => ReplayPlugin;
 export {};


### PR DESCRIPTION
One user encountered a type problem(https://rrweb.slack.com/archives/C01BYDC5C93/p1631683830050900). It turns out that definition of LogReplayConfig isn't perfect