### PR TITLE
Docs: Prefer yarn over npm in Contribute Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Since we want the record and replay sides to share a strongly typed data structu
 [Typescript handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
 
 1. Fork the rrweb component repository you want to patch.
-2. Run `npm install` to install required dependencies.
+2. Run `yarn install` to install required dependencies.
 3. Patch the code and pass all the tests.
 4. Push the code and create a pull request.
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -58,7 +58,7 @@ rrweb 主要由 3 部分组成：
 [Typescript 手册](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
 
 1. Fork 需要修改的 rrweb 组件仓库
-2. `npm install` 安装所需依赖
+2. `yarn install` 安装所需依赖
 3. 修改代码并通过测试
 4. 提交代码，创建 pull request
 


### PR DESCRIPTION
We are using yarn.lock files so contributors should also use yarn to install everything.