### PR TITLE
Set the blockClass element's background color to the inherited color

### DIFF
--- a/packages/rrweb/src/replay/styles/inject-style.ts
+++ b/packages/rrweb/src/replay/styles/inject-style.ts
@@ -1,5 +1,5 @@
 const rules: (blockClass: string) => string[] = (blockClass: string) => [
-  `.${blockClass} { background: #ccc }`,
+  `.${blockClass} { background: currentColor }`,
   'noscript { display: none !important; }',
 ];
 

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -43,7 +43,7 @@ file-frame-2
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: currentColor; }
+.rr-block { background: currentcolor; }
 
 noscript { display: none !important; }
 
@@ -91,7 +91,7 @@ file-frame-2
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: currentColor; }
+.rr-block { background: currentcolor; }
 
 noscript { display: none !important; }
 
@@ -138,7 +138,7 @@ file-frame-5
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: currentColor; }
+.rr-block { background: currentcolor; }
 
 noscript { display: none !important; }
 
@@ -216,7 +216,7 @@ file-frame-5
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: currentColor; }
+.rr-block { background: currentcolor; }
 
 noscript { display: none !important; }
 
@@ -296,7 +296,7 @@ file-frame-5
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: currentColor; }
+.rr-block { background: currentcolor; }
 
 noscript { display: none !important; }
 

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -43,7 +43,7 @@ file-frame-2
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: rgb(204, 204, 204); }
+.rr-block { background: currentColor; }
 
 noscript { display: none !important; }
 
@@ -91,7 +91,7 @@ file-frame-2
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: rgb(204, 204, 204); }
+.rr-block { background: currentColor; }
 
 noscript { display: none !important; }
 
@@ -138,7 +138,7 @@ file-frame-5
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: rgb(204, 204, 204); }
+.rr-block { background: currentColor; }
 
 noscript { display: none !important; }
 
@@ -216,7 +216,7 @@ file-frame-5
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: rgb(204, 204, 204); }
+.rr-block { background: currentColor; }
 
 noscript { display: none !important; }
 
@@ -296,7 +296,7 @@ file-frame-5
 file-cid-0
 @charset \\"utf-8\\";
 
-.rr-block { background: rgb(204, 204, 204); }
+.rr-block { background: currentColor; }
 
 noscript { display: none !important; }
 


### PR DESCRIPTION
Changes an element that has the `blockClass` from having a background color of `#ccc` to `currentColor`. Setting it to `currentColor` will set the background color to the same value as `color`.

I think this is a nicer default because visually, this will work across all color themes. 