### PR TITLE
VSCode Workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode
+.vscode/*
+!/.vscode/monorepo.code-workspace
 .idea
 node_modules
 package-lock.json

--- a/.vscode/monorepo.code-workspace
+++ b/.vscode/monorepo.code-workspace
@@ -17,5 +17,12 @@
       "path": "../packages/rrweb-snapshot"
     }
   ],
-  "settings": {}
+  "settings": {
+    "jest.disabledWorkspaceFolders": [
+      "Monorepo",
+      "rrweb",
+      "rrweb-snapshot",
+      "rrweb-player"
+    ]
+  }
 }

--- a/.vscode/monorepo.code-workspace
+++ b/.vscode/monorepo.code-workspace
@@ -1,0 +1,21 @@
+{
+  "folders": [
+    {
+      "name": "Monorepo",
+      "path": ".."
+    },
+    {
+      "path": "../packages/rrdom"
+    },
+    {
+      "path": "../packages/rrweb"
+    },
+    {
+      "path": "../packages/rrweb-player"
+    },
+    {
+      "path": "../packages/rrweb-snapshot"
+    }
+  ],
+  "settings": {}
+}


### PR DESCRIPTION
Adds vscode workspace https://code.visualstudio.com/docs/editor/workspaces
In vscode if you go to File > Open Workspace and open the .vscode/monorepo.code-workspace your files will be split into different sections based on what package they fall under:

![image](https://user-images.githubusercontent.com/4106/136033088-cdcff175-38f3-484c-960b-a19561f3bf35.png)

This also include rrdom (which will be empty for most people until we merge the rrdom branch)