### PR TITLE
Adds PostHog as users to the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,17 @@ In addition to adding integration tests and unit tests, rrweb also provides a RE
 
 ## Who's using rrweb
 
-<p align="center">
-  <a href="http://www.smartx.com/" target="_blank">
-    <img width="260px" src="https://www.rrweb.io/logos/smartx.png">
-  </a>
-</p>
+<table>
+  <tr>
+    <td align="center">
+      <a href="http://www.smartx.com/" target="_blank">
+        <img width="260px" src="https://www.rrweb.io/logos/smartx.png">
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://posthog.com?utm_source=rrweb&utm_medium=sponsorship&utm_campaign=open-source-sponsorship" target="_blank">
+        <img width="260px" src="https://www.rrweb.io/logos/posthog.png">
+      </a>
+    </td>
+  </tr>
+</table>

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -115,8 +115,17 @@ rrweb 主要由 3 部分组成：
 
 ## Who's using rrweb
 
-<p align="center">
-  <a href="http://www.smartx.com/" target="_blank">
-    <img width="260px" src="https://www.rrweb.io/logos/smartx.png">
-  </a>
-</p>
+<table>
+  <tr>
+    <td align="center">
+      <a href="http://www.smartx.com/" target="_blank">
+        <img width="260px" src="https://www.rrweb.io/logos/smartx.png">
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://posthog.com?utm_source=rrweb&utm_medium=sponsorship&utm_campaign=open-source-sponsorship" target="_blank">
+        <img width="260px" src="https://www.rrweb.io/logos/posthog.png">
+      </a>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
Depends on https://github.com/rrweb-io/web/pull/7 being merged for the PostHog image that's referred to in this PR.

Updated the "Who's using rrweb" to be a table to match the "Core Team Member" struture.