### PR TITLE
fix(rrweb-snapshot): don't exclude @import CSS rules from the output when an exception is thrown

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -49,9 +49,13 @@ function getCssRulesString(s: CSSStyleSheet): string | null {
 }
 
 function getCssRuleString(rule: CSSRule): string {
-  return isCSSImportRule(rule)
-    ? getCssRulesString(rule.styleSheet) || ''
-    : rule.cssText;
+  let cssStringified = rule.cssText;
+  if (isCSSImportRule(rule)) {
+    try {
+      cssStringified = getCssRulesString(rule.styleSheet) || cssStringified;
+    } catch {}
+  }
+  return cssStringified;
 }
 
 function isCSSImportRule(rule: CSSRule): rule is CSSImportRule {


### PR DESCRIPTION
Do not exclude @import CSS rules from the output when an exception is thrown and use `CSSRule.cssText` instead.

[rrweb-snapshot](https://github.com/rrweb-io/rrweb/blob/53492c1ee4bfac647ac15aaa0c4c563235ea978b/packages/rrweb-snapshot/src/snapshot.ts#L44) [throws a `SecurityError` exception](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet#properties) when parses `@import` CSS rules, that point out to an external domain and are declared within a CSS file.

_page.html:_

```html
<link rel="stylesheet" href="styles.css" />
```

_styles.css:_

```css
/* this rule will be excluded from rrweb-snapshot output */
@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
```

The fix is meant to fix this problem and keep the original CSS line if another issue happens while serializing an `@import` CSS rule.

A repository with an example of the issue: https://github.com/hvpavel/rrweb-snapshot-css-import-issue.