### PR TITLE
don't reference old rrweb-snapshot 

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -74,6 +74,6 @@
     "@xstate/fsm": "^1.4.0",
     "fflate": "^0.4.4",
     "mitt": "^1.1.3",
-    "rrweb-snapshot": "^1.1.8"
+    "rrweb-snapshot": "file:../rrweb-snapshot"
   }
 }


### PR DESCRIPTION
Ensure an `npm update` in this folder doesn't cause an old version of rrweb-snapshot package to be installed, which will take precedence over the monorepo one