### PR TITLE
fix: if handleProgressClick invoked after finished, start from where …

### DIFF
--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -165,6 +165,7 @@
       percent = 1;
     }
     const timeOffset = meta.totalTime * percent;
+    finished = false
     goto(timeOffset);
   };
 


### PR DESCRIPTION
If the player finishes playing and user clicks the progress-bar the recording always starts from beginning, not from where user intended. The idea is to set `finished = false` whenever `handleProgressClick` is invoked