### PR TITLE
Don't throw away information about the iframe src

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -509,7 +509,7 @@ function serializeNode(
       }
       // iframe
       if (tagName === 'iframe' && !keepIframeSrcFn(attributes.src as string)) {
-        if (!(n as HTMLIFrameElement).contentWindow) {
+        if (!(n as HTMLIFrameElement).contentDocument) {
           // we can't record it directly as we can't see into it
           // preserve the src attribute so a decision can be taken at replay time
           attributes.rr_src = attributes.src;


### PR DESCRIPTION
I didn't realize that the iframe src attribute was being dropped after the record-iframe changes.  I also wasn't paying enough attention as would have thought that the function added in #592 would have preserved it by default.

I think as a general rule we shouldn't be dropping any attributes like this that are present in the source.
If this change was already in place, then #592 could have been conceived as a YouTube plugin that works at playback time.
Another thing this PR could enable would be displaying a placeholder box at playback time with the URL displayed within.