### PR TITLE
rrweb: replace onerror with addEventListener('error',handler) in the rrweb console plugin

### DIFF
--- a/packages/rrweb/src/plugins/console/record/index.ts
+++ b/packages/rrweb/src/plugins/console/record/index.ts
@@ -124,29 +124,21 @@ function initLogObserver(
   // add listener to thrown errors
   if (logOptions.level!.includes('error')) {
     if (window) {
-      const originalOnError = window.onerror;
-      window.onerror = (
-        msg: Event | string,
-        file: string,
-        line: number,
-        col: number,
-        error: Error,
-      ) => {
-        if (originalOnError) {
-          originalOnError.apply(this, [msg, file, line, col, error]);
-        }
+      const errorHandler = (event: ErrorEvent) => {
+        const { message, error } = event;
         const trace: string[] = ErrorStackParser.parse(
           error,
         ).map((stackFrame: StackFrame) => stackFrame.toString());
-        const payload = [stringify(msg, logOptions.stringifyOptions)];
+        const payload = [stringify(message, logOptions.stringifyOptions)];
         cb({
           level: 'error',
           trace,
           payload,
         });
       };
+      window.addEventListener('error', errorHandler);
       cancelHandlers.push(() => {
-        window.onerror = originalOnError;
+        if (window) window.removeEventListener('error', errorHandler);
       });
     }
   }


### PR DESCRIPTION
1. The main reason for changing the API:
    window.onerror can be easily overwritten by other code, such as a JavaScript Framework, or even another JS error reporting tool. 
    [reference](https://rrweb.slack.com/archives/C01BYDC5C93/p1636329495025900?thread_ts=1636069678.022300&cid=C01BYDC5C93)
2. The main browser compatibility concern: error event isn't supported by IE11, but IE11 supports the mutation observer API.
    reference:
    [caniuse error event](https://caniuse.com/mdn-api_eventsource_error_event)
    [caniuse mutation observer](https://caniuse.com/?search=mutation%20observer)

@userback PTAL