### PR TITLE
Small regex fix for older browsers

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -64,7 +64,7 @@ function escapeRegExp(str: string) {
 }
 
 const HOVER_SELECTOR = /([^\\]):hover/;
-const HOVER_SELECTOR_GLOBAL = new RegExp(HOVER_SELECTOR, 'g');
+const HOVER_SELECTOR_GLOBAL = new RegExp(HOVER_SELECTOR.source, 'g');
 export function addHoverClass(cssText: string, cache: BuildCache): string {
   const cachedStyle = cache?.stylesWithHoverClass.get(cssText);
   if (cachedStyle) return cachedStyle;

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -16,7 +16,7 @@ import { isElement, isShadowRoot, maskInputValue } from './utils';
 import { values } from 'puppeteer/DeviceDescriptors';
 
 let _id = 1;
-const tagNameRegex = RegExp('[^a-z0-9-_:]');
+const tagNameRegex = new RegExp('[^a-z0-9-_:]');
 
 export const IGNORED_NODE = -2;
 


### PR DESCRIPTION
Hi guys!

I made a tiny change to the regexes to allow rrWeb to run on older browsers.
The issue is: `"can't supply flags when constructing one RegExp from another"`, so I'm fixing it here.
I hope you'll accept it, I'm already using it in a custom browser.

Thanks!