### PR TITLE
Fix bug where style.opacity was incorrectly deleted when set to zero

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -504,10 +504,7 @@ export default class MutationBuffer {
             }
           }
           for (const pname of Array.from(old.style)) {
-            if (
-              target.style.getPropertyValue(pname) === '' ||
-              !target.style.getPropertyValue(pname) // covering potential non-standard browsers
-            ) {
+            if (target.style.getPropertyValue(pname) === '') {  // "if not set, returns the empty string"
               styleObj[pname] = false; // delete
             }
           }


### PR DESCRIPTION
 - this had the effect of making things visible which should have been invisible
 - not sure what I was thinking with 'potentially non-standard browsers', maybe I thought I was covering return values from getPropertyValue of null or false. Could potentially add explicit tests for null or false, but as there is no evidence for these non-standard browsers, leaving as-is