### PR TITLE
Fix inline image issues

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -228,15 +228,23 @@ function buildNode(
             };
           } else if (tagName === 'img' && name === 'rr_dataURL') {
             const image = node as HTMLImageElement;
+            image.removeAttribute(name);
             if (!image.currentSrc.startsWith('data:')) {
               // Backup original img src. It may not have been set yet.
               image.setAttribute(
                 'rrweb-original-src',
-                n.attributes['src'] as string,
+                n.attributes.src as string,
               );
               image.src = value;
             }
-            image.removeAttribute(name);
+            if (n.attributes.srcset) {
+              // Backup original img srcset
+              image.setAttribute(
+                'rrweb-original-srcset',
+                n.attributes.srcset as string,
+              );
+              image.removeAttribute('srcset');
+            }
           }
 
           if (name === 'rr_width') {

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -214,7 +214,8 @@ function buildNode(
               n.attributes.srcset &&
               n.attributes.rr_dataURL
             ) {
-              // ignore img srcset here, it will be used below
+              // backup original img srcset
+              node.setAttribute('rrweb-original-srcset', n.attributes.srcset as string);
             } else {
               node.setAttribute(name, value);
             }
@@ -241,13 +242,6 @@ function buildNode(
                 n.attributes.src as string,
               );
               image.src = value;
-            }
-            if (n.attributes.srcset) {
-              // Backup original img srcset
-              image.setAttribute(
-                'rrweb-original-srcset',
-                n.attributes.srcset as string,
-              );
             }
           }
 

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -209,6 +209,12 @@ function buildNode(
               n.attributes.href.endsWith('.js')
             ) {
               // ignore
+            } else if (
+              tagName === 'img' &&
+              n.attributes.srcset &&
+              n.attributes.rr_dataURL
+            ) {
+              // ignore img srcset here, it will be used below
             } else {
               node.setAttribute(name, value);
             }
@@ -228,7 +234,6 @@ function buildNode(
             };
           } else if (tagName === 'img' && name === 'rr_dataURL') {
             const image = node as HTMLImageElement;
-            image.removeAttribute(name);
             if (!image.currentSrc.startsWith('data:')) {
               // Backup original img src. It may not have been set yet.
               image.setAttribute(
@@ -243,7 +248,6 @@ function buildNode(
                 'rrweb-original-srcset',
                 n.attributes.srcset as string,
               );
-              image.removeAttribute('srcset');
             }
           }
 
@@ -269,6 +273,7 @@ function buildNode(
           }
         }
       }
+
       if (n.isShadowHost) {
         /**
          * Since node is newly rebuilt, it should be a normal element

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -513,13 +513,15 @@ function serializeNode(
           canvasCtx = canvasService.getContext('2d');
         }
         const image = n as HTMLImageElement;
-        const oldValue = image.crossOrigin;
-        image.crossOrigin = 'anonymous';
         const recordInlineImage = () => {
+          const oldValue = image.crossOrigin;
           try {
             canvasService!.width = image.naturalWidth;
             canvasService!.height = image.naturalHeight;
             canvasCtx!.drawImage(image, 0, 0);
+            // see this article about crossorigin = "anonymous"
+            // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+            image.crossOrigin = 'anonymous';
             attributes.rr_dataURL = canvasService!.toDataURL();
           } catch (err) {
             console.warn(

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -513,15 +513,13 @@ function serializeNode(
           canvasCtx = canvasService.getContext('2d');
         }
         const image = n as HTMLImageElement;
+        const oldValue = image.crossOrigin;
+        image.crossOrigin = 'anonymous';
         const recordInlineImage = () => {
-          const oldValue = image.crossOrigin;
           try {
             canvasService!.width = image.naturalWidth;
             canvasService!.height = image.naturalHeight;
             canvasCtx!.drawImage(image, 0, 0);
-            // see this article about crossorigin = "anonymous"
-            // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
-            image.crossOrigin = 'anonymous';
             attributes.rr_dataURL = canvasService!.toDataURL();
           } catch (err) {
             console.warn(


### PR DESCRIPTION
This PR fixes 2 issues:

- ~fix `img.complete` being false, which breaks inline image feature completely~ EDIT: this solution was not good, see the comments
It seems that immediately after you set `image.crossOrigin = 'anonymous'` the image becomes "not loaded yet", which breaks the logic. It's easy to check just by adding a quick `console.log('IMAGE:', img, img.complete, img.naturalWidth, img.naturalHeight)` just before this if condition: https://github.com/rrweb-io/rrweb/blob/b0dc3885d9bfbe4fb54f7f2a1256cbe0c1c359f2/packages/rrweb-snapshot/src/snapshot.ts#L534-L535
I moved that logic just before we call `toDataURL()` just like this article says: https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image

- remove `srcset` which overwrites the `src` and breaks restoring images that have `srcset`

ping @Mark-Fenng because you have the context of this feature from previous PR.