### PR TITLE
fix: an error when I stop the recording process

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -26,13 +26,13 @@ export class CanvasManager {
   private mirror: Mirror;
 
   private mutationCb: canvasMutationCallback;
-  private resetObservers: listenerHandler;
+  private resetObservers?: listenerHandler;
   private frozen: boolean = false;
   private locked: boolean = false;
 
   public reset() {
     this.pendingCanvasMutations.clear();
-    this.resetObservers();
+    this.resetObservers && this.resetObservers();
   }
 
   public freeze() {


### PR DESCRIPTION
### bug
When the option 'recordCanvas' was false and I stopped the recording process, I got this error:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/27533910/152729974-35eca6f3-e285-471b-b7d8-ff7dba59d4c4.png">


### reason
When 'recordCanvas' is false, the CanvasManager is created but `resetObservers` isn't initiated. When I stop recording, `resetObservers` is still executed, which is actually undefined.
