### PR TITLE
close all pages to avoid EPERM error on Windows 10

### DIFF
--- a/packages/rrweb/scripts/repl.js
+++ b/packages/rrweb/scripts/repl.js
@@ -139,6 +139,8 @@ function getCode() {
     });
 
     emitter.once('done', async (shouldReplay) => {
+      const pages = await browser.pages();
+      await Promise.all(pages.map((page) => page.close()));
       await browser.close();
       if (shouldReplay) {
         await replay(url, shouldReplay === 'replayWithFakeURL');


### PR DESCRIPTION
This is to fix the EPERM error on Windows 10 after finishing a session.

`PS C:\Users\alexdehe.ng\Desktop\rrweb> npm run repl

> repl
> cd packages/rrweb && npm run repl


> rrweb@1.1.1 repl
> npm run bundle:browser && node scripts/repl.js


> rrweb@1.1.1 bundle:browser
> cross-env BROWSER_ONLY=true rollup --config


./src/index.ts → dist/rrweb.min.js...
created dist/rrweb.min.js in 8.2s

./src/plugins/console/record/index.ts → dist/plugins/console-record.min.js...
created dist/plugins/console-record.min.js in 5s
? Enter the url you want to record, e.g https://react-redux.realworld.io:  http://localhost:8080/ta/Admin.login 
Going to open http://localhost:8080/ta/Admin.login...
Ready to record. You can do any interaction on the page.
? Once you want to finish the recording, choose the following to start replay:  Start replay (default)
? Persistently store these recorded events? (Y/n) y[Error: EPERM: operation not permitted, unlink 'C:\Users\alexdehe.ng\AppData\Local\Temp\puppeteer_dev_chrome_profile-JHam0F\CrashpadMetrics-active.pma'] {
  errno: -4048,
  code: 'EPERM',
  syscall: 'unlink',
  path: 'C:\\Users\\alexdehe.ng\\AppData\\Local\\Temp\\puppeteer_dev_chrome_profile-JHam0F\\CrashpadMetrics-active.pma'
}
? Persistently store these recorded events? Yes`
