### PR TITLE
improve captured message of Error object

### DIFF
--- a/packages/rrweb/src/plugins/console/record/stringify.ts
+++ b/packages/rrweb/src/plugins/console/record/stringify.ts
@@ -137,7 +137,9 @@ export function stringify(
       }
       return value.nodeName;
     } else if (value instanceof Error) {
-      return value.name + ': ' + value.message;
+      return value.stack
+        ? value.stack + '\nEnd of stack for Error object'
+        : value.name + ': ' + value.message;
     }
     return value;
   });

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -7816,7 +7816,7 @@ exports[`record integration tests should record console messages 1`] = `
           \\"__puppeteer_evaluation_script__:19:37\\"
         ],
         \\"payload\\": [
-          \\"\\\\\\"TypeError: a message\\\\\\"\\"
+          \\"\\\\\\"TypeError: a message\\\\\\\\n    at __puppeteer_evaluation_script__:19:41\\\\\\\\nEnd of stack for Error object\\\\\\"\\"
         ]
       }
     }


### PR DESCRIPTION
try to fix this problem:
https://github.com/rrweb-io/rrweb/issues/814#issuecomment-1033735775
I'm not sure whether we should record the stack for an Error object.