### PR TITLE
Update doc to use yarn to use REPL

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -398,7 +398,7 @@ And there are three rrweb-replayer event will be emitted in the same way:
 
 You can also play with rrweb by using the REPL testing tool which does not need installation.
 
-Run `npm run repl` to launch a browser and ask for a URL you want to test on the CLI:
+Run `yarn repl` to launch a browser and ask for a URL you want to test on the CLI:
 
 ```
 Enter the url you want to record, e.g https://react-redux.realworld.io:

--- a/guide.zh_CN.md
+++ b/guide.zh_CN.md
@@ -396,7 +396,7 @@ replayer.on(EVENT_NAME, (payload) => {
 
 在不安装 rrweb 的情况下，也可以通过使用 REPL 工具试用 rrweb 录制 web 应用。
 
-运行 `npm run repl`，将会启动浏览器并在命令行要求输入一个测试的 url：
+运行 `yarn repl`，将会启动浏览器并在命令行要求输入一个测试的 url：
 
 ```
 Enter the url you want to record, e.g https://react-redux.realworld.io:


### PR DESCRIPTION
The docs referred to using `npm run repl` to launch REPL however that would cause the following error during playback of recordings
```[Error: ENOENT: no such file or directory, open '<path>/rrweb/packages/rrweb/dist/rrweb.min.css'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '<path>/rrweb/packages/rrweb/dist/rrweb.min.css'
}
```

The issue is fixed by using `yarn repl`