### PR TITLE
Use the built in .closest method to checked for blocked class

### DIFF
--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -230,7 +230,11 @@ export function isBlocked(node: Node | null, blockClass: blockClass): boolean {
   if (node.nodeType === node.ELEMENT_NODE) {
     let needBlock = false;
     if (typeof blockClass === 'string') {
-      needBlock = (node as HTMLElement).classList.contains(blockClass);
+      if ((node as HTMLElement).closest !== undefined) {
+        return (node as HTMLElement).closest('.' + blockClass) !== null;
+      } else {
+        needBlock = (node as HTMLElement).classList.contains(blockClass);
+      }
     } else {
       (node as HTMLElement).classList.forEach((className) => {
         if (blockClass.test(className)) {


### PR DESCRIPTION
Transfer recursive parent class checking into the browser engine for an expected performance improvement.
I've seen `isBlocked` come up in profilers but don't have a badly performing example to hand for direct comparison when I came up with this today.
A very minor benefit is that this commit will prevent the recursive isBlocked method from showing up lots of times in profiling!

https://developer.mozilla.org/en-US/docs/Web/API/Element/closest available on all modern browsers