### PR TITLE
Avoid triggering a CSP (content security policy) error

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -462,7 +462,7 @@ export default class MutationBuffer {
     if (isIgnored(m.target, this.mirror)) {
       return;
     }
-    const unattachedDoc = new Document(); // avoid upsetting original document from a Content Security point of view
+    const unattachedDoc = document.implementation.createHTMLDocument(); // avoid upsetting original document from a Content Security point of view
     switch (m.type) {
       case 'characterData': {
         const value = m.target.textContent;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -462,7 +462,14 @@ export default class MutationBuffer {
     if (isIgnored(m.target, this.mirror)) {
       return;
     }
-    const unattachedDoc = document.implementation.createHTMLDocument(); // avoid upsetting original document from a Content Security point of view
+    let unattachedDoc;
+    try {
+      // avoid upsetting original document from a Content Security point of view
+      unattachedDoc = document.implementation.createHTMLDocument();
+    } catch (e) {
+      // fallback to more direct method
+      unattachedDoc = this.doc;
+    }
     switch (m.type) {
       case 'characterData': {
         const value = m.target.textContent;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -462,6 +462,7 @@ export default class MutationBuffer {
     if (isIgnored(m.target, this.mirror)) {
       return;
     }
+    const unattachedDoc = new Document(); // avoid upsetting original document from a Content Security point of view
     switch (m.type) {
       case 'characterData': {
         const value = m.target.textContent;
@@ -543,7 +544,7 @@ export default class MutationBuffer {
         }
 
         if (attributeName === 'style') {
-          const old = this.doc.createElement('span');
+          const old = unattachedDoc.createElement('span');
           if (m.oldValue) {
             old.setAttribute('style', m.oldValue);
           }


### PR DESCRIPTION
Fix for #816 with `.setAttribute('style')` — see CSP style-src: unsafe-inline