### PR TITLE
Remove INode (`node.__sn`) and use Mirror as source of truth

### DIFF
--- a/packages/rrweb-snapshot/README.md
+++ b/packages/rrweb-snapshot/README.md
@@ -37,4 +37,4 @@ There are several things will be done during rebuild:
 
 #### buildNodeWithSN
 
-`buildNodeWithSN` will build DOM from serialized node and store serialized information in `__sn` property.
+`buildNodeWithSN` will build DOM from serialized node and store serialized information in the `mirror.getMeta(node)`.

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -4,11 +4,9 @@ import {
   NodeType,
   tagMap,
   elementNode,
-  idNodeMap,
-  INode,
   BuildCache,
 } from './types';
-import { isElement } from './utils';
+import { isElement, Mirror } from './utils';
 
 const tagMap: tagMap = {
   script: 'noscript',
@@ -215,7 +213,10 @@ function buildNode(
               n.attributes.rr_dataURL
             ) {
               // backup original img srcset
-              node.setAttribute('rrweb-original-srcset', n.attributes.srcset as string);
+              node.setAttribute(
+                'rrweb-original-srcset',
+                n.attributes.srcset as string,
+              );
             } else {
               node.setAttribute(name, value);
             }
@@ -307,16 +308,16 @@ export function buildNodeWithSN(
   n: serializedNodeWithId,
   options: {
     doc: Document;
-    map: idNodeMap;
+    mirror: Mirror;
     skipChild?: boolean;
     hackCss: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: Node) => unknown;
     cache: BuildCache;
   },
-): INode | null {
+): Node | null {
   const {
     doc,
-    map,
+    mirror,
     skipChild = false,
     hackCss = true,
     afterAppend,
@@ -328,7 +329,7 @@ export function buildNodeWithSN(
   }
   if (n.rootId) {
     console.assert(
-      ((map[n.rootId] as unknown) as Document) === doc,
+      ((mirror.getNode(n.rootId) as unknown) as Document) === doc,
       'Target document should has the same root id.',
     );
   }
@@ -362,8 +363,7 @@ export function buildNodeWithSN(
     node = doc;
   }
 
-  (node as INode).__sn = n;
-  map[n.id] = node as INode;
+  mirror.add(node, n.id, n);
 
   if (
     (n.type === NodeType.Document || n.type === NodeType.Element) &&
@@ -372,7 +372,7 @@ export function buildNodeWithSN(
     for (const childN of n.childNodes) {
       const childNode = buildNodeWithSN(childN, {
         doc,
-        map,
+        mirror,
         skipChild: false,
         hackCss,
         afterAppend,
@@ -394,24 +394,24 @@ export function buildNodeWithSN(
     }
   }
 
-  return node as INode;
+  return node as Node;
 }
 
-function visit(idNodeMap: idNodeMap, onVisit: (node: INode) => void) {
-  function walk(node: INode) {
+function visit(mirror: Mirror, onVisit: (node: Node) => void) {
+  function walk(node: Node) {
     onVisit(node);
   }
 
-  for (const key in idNodeMap) {
-    if (idNodeMap[key]) {
-      walk(idNodeMap[key]);
+  for (const id of mirror.getIds()) {
+    if (mirror.has(id)) {
+      walk(mirror.getNode(id)!);
     }
   }
 }
 
-function handleScroll(node: INode) {
-  const n = node.__sn;
-  if (n.type !== NodeType.Element) {
+function handleScroll(node: Node, mirror: Mirror) {
+  const n = mirror.getMeta(node);
+  if (n?.type !== NodeType.Element) {
     return;
   }
   const el = (node as Node) as HTMLElement;
@@ -433,29 +433,36 @@ function rebuild(
   n: serializedNodeWithId,
   options: {
     doc: Document;
-    onVisit?: (node: INode) => unknown;
+    onVisit?: (node: Node) => unknown;
     hackCss?: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: Node) => unknown;
     cache: BuildCache;
+    mirror: Mirror;
   },
-): [Node | null, idNodeMap] {
-  const { doc, onVisit, hackCss = true, afterAppend, cache } = options;
-  const idNodeMap: idNodeMap = {};
+): Node | null {
+  const {
+    doc,
+    onVisit,
+    hackCss = true,
+    afterAppend,
+    cache,
+    mirror = new Mirror(),
+  } = options;
   const node = buildNodeWithSN(n, {
     doc,
-    map: idNodeMap,
+    mirror,
     skipChild: false,
     hackCss,
     afterAppend,
     cache,
   });
-  visit(idNodeMap, (visitedNode) => {
+  visit(mirror, (visitedNode) => {
     if (onVisit) {
       onVisit(visitedNode);
     }
-    handleScroll(visitedNode);
+    handleScroll(visitedNode, mirror);
   });
-  return [node, idNodeMap];
+  return node;
 }
 
 export default rebuild;

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -411,7 +411,7 @@ function serializeNode(
   } = options;
   // Only record root id when document object is not the base document
   let rootId: number | undefined;
-  const docId = nodeIdMap.get(n);
+  const docId = nodeIdMap.get(doc);
   if (docId) {
     rootId = docId === 1 ? undefined : docId;
   }

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -67,19 +67,20 @@ export type tagMap = {
   [key: string]: string;
 };
 
+// @deprecated
 export interface INode extends Node {
-  __sn: serializedNodeWithId | serializedNode;
+  __sn: serializedNodeWithId;
 }
 
 export interface ICanvas extends HTMLCanvasElement {
   __context: string;
 }
 
-export type idNodeMap = {
-  [key: number]: INode;
-};
+export type idNodeMap = Map<number, Node>;
 
 export type nodeIdMap = WeakMap<Node, number>;
+
+export type nodeMetaMap = WeakMap<Node, serializedNode>;
 
 export type MaskInputOptions = Partial<{
   color: boolean;

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -68,7 +68,7 @@ export type tagMap = {
 };
 
 export interface INode extends Node {
-  __sn: serializedNodeWithId;
+  __sn: serializedNodeWithId | serializedNode;
 }
 
 export interface ICanvas extends HTMLCanvasElement {
@@ -78,6 +78,8 @@ export interface ICanvas extends HTMLCanvasElement {
 export type idNodeMap = {
   [key: number]: INode;
 };
+
+export type nodeIdMap = WeakMap<Node, number>;
 
 export type MaskInputOptions = Partial<{
   color: boolean;

--- a/packages/rrweb-snapshot/tsconfig.json
+++ b/packages/rrweb-snapshot/tsconfig.json
@@ -6,6 +6,7 @@
     "strictNullChecks": true,
     "removeComments": true,
     "preserveConstEnums": true,
+    "target": "es6",
     "rootDir": "src",
     "outDir": "build",
     "lib": ["es6", "dom"]

--- a/packages/rrweb-snapshot/typings/rebuild.d.ts
+++ b/packages/rrweb-snapshot/typings/rebuild.d.ts
@@ -1,19 +1,21 @@
-import { serializedNodeWithId, idNodeMap, INode, BuildCache } from './types';
+import { serializedNodeWithId, BuildCache } from './types';
+import { Mirror } from './utils';
 export declare function addHoverClass(cssText: string, cache: BuildCache): string;
 export declare function createCache(): BuildCache;
 export declare function buildNodeWithSN(n: serializedNodeWithId, options: {
     doc: Document;
-    map: idNodeMap;
+    mirror: Mirror;
     skipChild?: boolean;
     hackCss: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: Node) => unknown;
     cache: BuildCache;
-}): INode | null;
+}): Node | null;
 declare function rebuild(n: serializedNodeWithId, options: {
     doc: Document;
-    onVisit?: (node: INode) => unknown;
+    onVisit?: (node: Node) => unknown;
     hackCss?: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: Node) => unknown;
     cache: BuildCache;
-}): [Node | null, idNodeMap];
+    mirror: Mirror;
+}): Node | null;
 export default rebuild;

--- a/packages/rrweb-snapshot/typings/snapshot.d.ts
+++ b/packages/rrweb-snapshot/typings/snapshot.d.ts
@@ -1,4 +1,4 @@
-import { serializedNodeWithId, INode, idNodeMap, MaskInputOptions, SlimDOMOptions, DataURLOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn } from './types';
+import { serializedNodeWithId, INode, idNodeMap, nodeIdMap, MaskInputOptions, SlimDOMOptions, DataURLOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn } from './types';
 export declare const IGNORED_NODE = -2;
 export declare function absoluteToStylesheet(cssText: string | null, href: string): string;
 export declare function absoluteToDoc(doc: Document, attributeValue: string): string;
@@ -8,6 +8,7 @@ export declare function needMaskingText(node: Node | null, maskTextClass: string
 export declare function serializeNodeWithId(n: Node | INode, options: {
     doc: Document;
     map: idNodeMap;
+    nodeIdMap: nodeIdMap;
     blockClass: string | RegExp;
     blockSelector: string | null;
     maskTextClass: string | RegExp;
@@ -45,7 +46,7 @@ declare function snapshot(n: Document, options?: {
     onIframeLoad?: (iframeINode: INode, node: serializedNodeWithId) => unknown;
     iframeLoadTimeout?: number;
     keepIframeSrcFn?: KeepIframeSrcFn;
-}): [serializedNodeWithId | null, idNodeMap];
+}): [serializedNodeWithId | null, nodeIdMap];
 export declare function visitSnapshot(node: serializedNodeWithId, onVisit: (node: serializedNodeWithId) => unknown): void;
 export declare function cleanupSnapshot(): void;
 export default snapshot;

--- a/packages/rrweb-snapshot/typings/snapshot.d.ts
+++ b/packages/rrweb-snapshot/typings/snapshot.d.ts
@@ -1,14 +1,14 @@
-import { serializedNodeWithId, INode, idNodeMap, nodeIdMap, MaskInputOptions, SlimDOMOptions, DataURLOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn } from './types';
+import { serializedNodeWithId, MaskInputOptions, SlimDOMOptions, DataURLOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn } from './types';
+import { Mirror } from './utils';
 export declare const IGNORED_NODE = -2;
 export declare function absoluteToStylesheet(cssText: string | null, href: string): string;
 export declare function absoluteToDoc(doc: Document, attributeValue: string): string;
 export declare function transformAttribute(doc: Document, tagName: string, name: string, value: string): string;
 export declare function _isBlockedElement(element: HTMLElement, blockClass: string | RegExp, blockSelector: string | null): boolean;
 export declare function needMaskingText(node: Node | null, maskTextClass: string | RegExp, maskTextSelector: string | null): boolean;
-export declare function serializeNodeWithId(n: Node | INode, options: {
+export declare function serializeNodeWithId(n: Node, options: {
     doc: Document;
-    map: idNodeMap;
-    nodeIdMap: nodeIdMap;
+    mirror: Mirror;
     blockClass: string | RegExp;
     blockSelector: string | null;
     maskTextClass: string | RegExp;
@@ -24,11 +24,12 @@ export declare function serializeNodeWithId(n: Node | INode, options: {
     inlineImages?: boolean;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
-    onSerialize?: (n: INode) => unknown;
-    onIframeLoad?: (iframeINode: INode, node: serializedNodeWithId) => unknown;
+    onSerialize?: (n: Node) => unknown;
+    onIframeLoad?: (iframeNode: HTMLIFrameElement, node: serializedNodeWithId) => unknown;
     iframeLoadTimeout?: number;
 }): serializedNodeWithId | null;
 declare function snapshot(n: Document, options?: {
+    mirror?: Mirror;
     blockClass?: string | RegExp;
     blockSelector?: string | null;
     maskTextClass?: string | RegExp;
@@ -42,11 +43,11 @@ declare function snapshot(n: Document, options?: {
     inlineImages?: boolean;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
-    onSerialize?: (n: INode) => unknown;
-    onIframeLoad?: (iframeINode: INode, node: serializedNodeWithId) => unknown;
+    onSerialize?: (n: Node) => unknown;
+    onIframeLoad?: (iframeNode: Node, node: serializedNodeWithId) => unknown;
     iframeLoadTimeout?: number;
     keepIframeSrcFn?: KeepIframeSrcFn;
-}): [serializedNodeWithId | null, nodeIdMap];
+}): serializedNodeWithId | null;
 export declare function visitSnapshot(node: serializedNodeWithId, onVisit: (node: serializedNodeWithId) => unknown): void;
 export declare function cleanupSnapshot(): void;
 export default snapshot;

--- a/packages/rrweb-snapshot/typings/types.d.ts
+++ b/packages/rrweb-snapshot/typings/types.d.ts
@@ -53,15 +53,14 @@ export declare type tagMap = {
     [key: string]: string;
 };
 export interface INode extends Node {
-    __sn: serializedNodeWithId | serializedNode;
+    __sn: serializedNodeWithId;
 }
 export interface ICanvas extends HTMLCanvasElement {
     __context: string;
 }
-export declare type idNodeMap = {
-    [key: number]: INode;
-};
+export declare type idNodeMap = Map<number, Node>;
 export declare type nodeIdMap = WeakMap<Node, number>;
+export declare type nodeMetaMap = WeakMap<Node, serializedNode>;
 export declare type MaskInputOptions = Partial<{
     color: boolean;
     date: boolean;

--- a/packages/rrweb-snapshot/typings/types.d.ts
+++ b/packages/rrweb-snapshot/typings/types.d.ts
@@ -53,7 +53,7 @@ export declare type tagMap = {
     [key: string]: string;
 };
 export interface INode extends Node {
-    __sn: serializedNodeWithId;
+    __sn: serializedNodeWithId | serializedNode;
 }
 export interface ICanvas extends HTMLCanvasElement {
     __context: string;
@@ -61,6 +61,7 @@ export interface ICanvas extends HTMLCanvasElement {
 export declare type idNodeMap = {
     [key: number]: INode;
 };
+export declare type nodeIdMap = WeakMap<Node, number>;
 export declare type MaskInputOptions = Partial<{
     color: boolean;
     date: boolean;

--- a/packages/rrweb-snapshot/typings/utils.d.ts
+++ b/packages/rrweb-snapshot/typings/utils.d.ts
@@ -1,6 +1,21 @@
-import { INode, MaskInputFn, MaskInputOptions } from './types';
-export declare function isElement(n: Node | INode): n is Element;
+import { MaskInputFn, MaskInputOptions, serializedNode } from './types';
+export declare function isElement(n: Node): n is Element;
 export declare function isShadowRoot(n: Node): n is ShadowRoot;
+export declare class Mirror {
+    private idNodeMap;
+    private nodeIdMap;
+    private nodeMetaMap;
+    getId(n: Node | undefined | null): number;
+    getNode(id: number): Node | null;
+    getIds(): IterableIterator<number>;
+    getMeta(n: Node): serializedNode | null;
+    removeNodeFromMap(n: Node): void;
+    has(id: number): boolean;
+    hasNode(node: Node): boolean;
+    add(n: Node, id: number, meta?: serializedNode): void;
+    reset(): void;
+}
+export declare function createMirror(): Mirror;
 export declare function maskInputValue({ maskInputOptions, tagName, type, value, maskInputFn, }: {
     maskInputOptions: MaskInputOptions;
     tagName: string;

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -1,4 +1,4 @@
-import { serializedNodeWithId, INode } from 'rrweb-snapshot';
+import { Mirror, serializedNodeWithId } from 'rrweb-snapshot';
 import { mutationCallBack } from '../types';
 
 export class IframeManager {
@@ -18,11 +18,15 @@ export class IframeManager {
     this.loadListener = cb;
   }
 
-  public attachIframe(iframeEl: INode, childSn: serializedNodeWithId) {
+  public attachIframe(
+    iframeEl: Node,
+    childSn: serializedNodeWithId,
+    mirror: Mirror,
+  ) {
     this.mutationCb({
       adds: [
         {
-          parentId: iframeEl.__sn.id,
+          parentId: mirror.getId(iframeEl),
           nextId: null,
           node: childSn,
         },

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -1,11 +1,11 @@
 import {
-  INode,
   serializeNodeWithId,
   transformAttribute,
   IGNORED_NODE,
   isShadowRoot,
   needMaskingText,
   maskInputValue,
+  Mirror,
 } from 'rrweb-snapshot';
 import {
   mutationRecord,
@@ -13,7 +13,6 @@ import {
   attributeCursor,
   removedNodeMutation,
   addedNodeMutation,
-  Mirror,
   styleAttributeValue,
   observerParam,
   MutationBufferParam,
@@ -23,8 +22,8 @@ import {
   isBlocked,
   isAncestorRemoved,
   isIgnored,
-  isIframeINode,
   hasShadowRoot,
+  isSerializedIframe,
 } from '../utils';
 
 type DoubleLinkedListNode = {
@@ -39,6 +38,7 @@ type NodeInLinkedList = Node & {
 function isNodeInLinkedList(n: Node | NodeInLinkedList): n is NodeInLinkedList {
   return '__ln' in n;
 }
+
 class DoubleLinkedList {
   public length = 0;
   public head: DoubleLinkedListNode | null = null;
@@ -117,9 +117,6 @@ class DoubleLinkedList {
 }
 
 const moveKey = (id: number, parentId: number) => `${id}@${parentId}`;
-function isINode(n: Node | INode): n is INode {
-  return '__sn' in n;
-}
 
 /**
  * controls behaviour of a MutationObserver
@@ -255,7 +252,7 @@ export default class MutationBuffer {
       let nextId: number | null = IGNORED_NODE; // slimDOM: ignored
       while (nextId === IGNORED_NODE) {
         ns = ns && ns.nextSibling;
-        nextId = ns && this.mirror.getId((ns as unknown) as INode);
+        nextId = ns && this.mirror.getId(ns);
       }
       return nextId;
     };
@@ -277,15 +274,15 @@ export default class MutationBuffer {
         return;
       }
       const parentId = isShadowRoot(n.parentNode)
-        ? this.mirror.getId((shadowHost as unknown) as INode)
-        : this.mirror.getId((n.parentNode as Node) as INode);
+        ? this.mirror.getId(shadowHost)
+        : this.mirror.getId(n.parentNode);
       const nextId = getNextId(n);
       if (parentId === -1 || nextId === -1) {
         return addList.addNode(n);
       }
       let sn = serializeNodeWithId(n, {
         doc: this.doc,
-        map: this.mirror.map,
+        mirror: this.mirror,
         blockClass: this.blockClass,
         blockSelector: this.blockSelector,
         maskTextClass: this.maskTextClass,
@@ -299,7 +296,7 @@ export default class MutationBuffer {
         recordCanvas: this.recordCanvas,
         inlineImages: this.inlineImages,
         onSerialize: (currentN) => {
-          if (isIframeINode(currentN)) {
+          if (isSerializedIframe(currentN, this.mirror)) {
             this.iframeManager.addIframe(currentN);
           }
           if (hasShadowRoot(n)) {
@@ -307,10 +304,8 @@ export default class MutationBuffer {
           }
         },
         onIframeLoad: (iframe, childSn) => {
-          this.iframeManager.attachIframe(iframe, childSn);
-          this.shadowDomManager.observeAttachShadow(
-            (iframe as Node) as HTMLIFrameElement,
-          );
+          this.iframeManager.attachIframe(iframe, childSn, this.mirror);
+          this.shadowDomManager.observeAttachShadow(iframe);
         },
       });
       if (sn) {
@@ -323,7 +318,7 @@ export default class MutationBuffer {
     };
 
     while (this.mapRemoves.length) {
-      this.mirror.removeNodeFromMap(this.mapRemoves.shift() as INode);
+      this.mirror.removeNodeFromMap(this.mapRemoves.shift()!);
     }
 
     for (const n of this.movedSet) {
@@ -353,9 +348,7 @@ export default class MutationBuffer {
     while (addList.length) {
       let node: DoubleLinkedListNode | null = null;
       if (candidate) {
-        const parentId = this.mirror.getId(
-          (candidate.value.parentNode as Node) as INode,
-        );
+        const parentId = this.mirror.getId(candidate.value.parentNode);
         const nextId = getNextId(candidate.value);
         if (parentId !== -1 && nextId !== -1) {
           node = candidate;
@@ -366,9 +359,7 @@ export default class MutationBuffer {
           const _node = addList.get(index)!;
           // ensure _node is defined before attempting to find value
           if (_node) {
-            const parentId = this.mirror.getId(
-              (_node.value.parentNode as Node) as INode,
-            );
+            const parentId = this.mirror.getId(_node.value.parentNode);
             const nextId = getNextId(_node.value);
             if (parentId !== -1 && nextId !== -1) {
               node = _node;
@@ -396,14 +387,14 @@ export default class MutationBuffer {
     const payload = {
       texts: this.texts
         .map((text) => ({
-          id: this.mirror.getId(text.node as INode),
+          id: this.mirror.getId(text.node),
           value: text.value,
         }))
         // text mutation's id was not in the mirror map means the target node has been removed
         .filter((text) => this.mirror.has(text.id)),
       attributes: this.attributes
         .map((attribute) => ({
-          id: this.mirror.getId(attribute.node as INode),
+          id: this.mirror.getId(attribute.node),
           attributes: attribute.attributes,
         }))
         // attribute mutation's id was not in the mirror map means the target node has been removed
@@ -434,7 +425,7 @@ export default class MutationBuffer {
   };
 
   private processMutation = (m: mutationRecord) => {
-    if (isIgnored(m.target)) {
+    if (isIgnored(m.target, this.mirror)) {
       return;
     }
     switch (m.type) {
@@ -528,11 +519,14 @@ export default class MutationBuffer {
       case 'childList': {
         m.addedNodes.forEach((n) => this.genAdds(n, m.target));
         m.removedNodes.forEach((n) => {
-          const nodeId = this.mirror.getId(n as INode);
+          const nodeId = this.mirror.getId(n);
           const parentId = isShadowRoot(m.target)
-            ? this.mirror.getId((m.target.host as unknown) as INode)
-            : this.mirror.getId(m.target as INode);
-          if (isBlocked(m.target, this.blockClass) || isIgnored(n)) {
+            ? this.mirror.getId(m.target.host)
+            : this.mirror.getId(m.target);
+          if (
+            isBlocked(m.target, this.blockClass) ||
+            isIgnored(n, this.mirror)
+          ) {
             return;
           }
           // removed node has not been serialized yet, just remove it from the Set
@@ -547,7 +541,7 @@ export default class MutationBuffer {
              * newly added node will be serialized without child nodes.
              * TODO: verify this
              */
-          } else if (isAncestorRemoved(m.target as INode, this.mirror)) {
+          } else if (isAncestorRemoved(m.target, this.mirror)) {
             /**
              * If parent id was not in the mirror map any more, it
              * means the parent node has already been removed. So
@@ -575,22 +569,23 @@ export default class MutationBuffer {
     }
   };
 
-  private genAdds = (n: Node | INode, target?: Node | INode) => {
+  private genAdds = (n: Node, target?: Node) => {
     // parent was blocked, so we can ignore this node
     if (target && isBlocked(target, this.blockClass)) {
       return;
     }
-    if (isINode(n)) {
-      if (isIgnored(n)) {
+
+    if (this.mirror.getMeta(n)) {
+      if (isIgnored(n, this.mirror)) {
         return;
       }
       this.movedSet.add(n);
       let targetId: number | null = null;
-      if (target && isINode(target)) {
-        targetId = target.__sn.id;
+      if (target && this.mirror.getMeta(target)) {
+        targetId = this.mirror.getId(target);
       }
-      if (targetId) {
-        this.movedMap[moveKey(n.__sn.id, targetId)] = true;
+      if (targetId && targetId !== -1) {
+        this.movedMap[moveKey(this.mirror.getId(n), targetId)] = true;
       }
     } else {
       this.addedSet.add(n);
@@ -600,7 +595,7 @@ export default class MutationBuffer {
     // if this node is blocked `serializeNode` will turn it into a placeholder element
     // but we have to remove it's children otherwise they will be added as placeholders too
     if (!isBlocked(n, this.blockClass))
-      n.childNodes.forEach((childN) => this.genAdds(childN));
+      (n as Node).childNodes.forEach((childN) => this.genAdds(childN));
   };
 }
 
@@ -624,7 +619,7 @@ function isParentRemoved(
   if (!parentNode) {
     return false;
   }
-  const parentId = mirror.getId((parentNode as Node) as INode);
+  const parentId = mirror.getId(parentNode);
   if (removes.some((r) => r.id === parentId)) {
     return true;
   }

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -1,4 +1,4 @@
-import { INode, MaskInputOptions, maskInputValue } from 'rrweb-snapshot';
+import { MaskInputOptions, maskInputValue } from 'rrweb-snapshot';
 import { FontFaceSet } from 'css-font-loading-module';
 import {
   throttle,
@@ -173,7 +173,7 @@ function initMoveObserver({
       positions.push({
         x: clientX,
         y: clientY,
-        id: mirror.getId(target as INode),
+        id: mirror.getId(target as Node),
         timeOffset: Date.now() - timeBaseline,
       });
       // it is possible DragEvent is undefined even on devices
@@ -228,7 +228,7 @@ function initMouseInteractionObserver({
       if (!e) {
         return;
       }
-      const id = mirror.getId(target as INode);
+      const id = mirror.getId(target);
       const { clientX, clientY } = e;
       mouseInteractionCb({
         type: MouseInteractions[eventKey],
@@ -270,7 +270,7 @@ export function initScrollObserver({
     if (!target || isBlocked(target as Node, blockClass)) {
       return;
     }
-    const id = mirror.getId(target as INode);
+    const id = mirror.getId(target as Node);
     if (target === doc) {
       const scrollEl = (doc.scrollingElement || doc.documentElement)!;
       scrollCb({
@@ -408,7 +408,7 @@ function initInputObserver({
       lastInputValue.isChecked !== v.isChecked
     ) {
       lastInputValueMap.set(target, v);
-      const id = mirror.getId(target as INode);
+      const id = mirror.getId(target as Node);
       inputCb({
         ...v,
         id,
@@ -497,7 +497,7 @@ function initStyleSheetObserver(
     rule: string,
     index?: number,
   ) {
-    const id = mirror.getId(this.ownerNode as INode);
+    const id = mirror.getId(this.ownerNode);
     if (id !== -1) {
       styleSheetRuleCb({
         id,
@@ -509,7 +509,7 @@ function initStyleSheetObserver(
 
   const deleteRule = win.CSSStyleSheet.prototype.deleteRule;
   win.CSSStyleSheet.prototype.deleteRule = function (index: number) {
-    const id = mirror.getId(this.ownerNode as INode);
+    const id = mirror.getId(this.ownerNode);
     if (id !== -1) {
       styleSheetRuleCb({
         id,
@@ -554,7 +554,7 @@ function initStyleSheetObserver(
     };
 
     type.prototype.insertRule = function (rule: string, index?: number) {
-      const id = mirror.getId(this.parentStyleSheet.ownerNode as INode);
+      const id = mirror.getId(this.parentStyleSheet.ownerNode);
       if (id !== -1) {
         styleSheetRuleCb({
           id,
@@ -573,7 +573,7 @@ function initStyleSheetObserver(
     };
 
     type.prototype.deleteRule = function (index: number) {
-      const id = mirror.getId(this.parentStyleSheet.ownerNode as INode);
+      const id = mirror.getId(this.parentStyleSheet.ownerNode);
       if (id !== -1) {
         styleSheetRuleCb({
           id,
@@ -605,9 +605,7 @@ function initStyleDeclarationObserver(
     value: string,
     priority: string,
   ) {
-    const id = mirror.getId(
-      (this.parentRule?.parentStyleSheet?.ownerNode as unknown) as INode,
-    );
+    const id = mirror.getId(this.parentRule?.parentStyleSheet?.ownerNode);
     if (id !== -1) {
       styleDeclarationCb({
         id,
@@ -627,9 +625,7 @@ function initStyleDeclarationObserver(
     this: CSSStyleDeclaration,
     property: string,
   ) {
-    const id = mirror.getId(
-      (this.parentRule?.parentStyleSheet?.ownerNode as unknown) as INode,
-    );
+    const id = mirror.getId(this.parentRule?.parentStyleSheet?.ownerNode);
     if (id !== -1) {
       styleDeclarationCb({
         id,
@@ -663,7 +659,7 @@ function initMediaInteractionObserver({
       const { currentTime, volume, muted } = target as HTMLMediaElement;
       mediaInteractionCb({
         type,
-        id: mirror.getId(target as INode),
+        id: mirror.getId(target as Node),
         currentTime,
         volume,
         muted,

--- a/packages/rrweb/src/record/observers/canvas/2d.ts
+++ b/packages/rrweb/src/record/observers/canvas/2d.ts
@@ -1,11 +1,10 @@
-import { INode } from 'rrweb-snapshot';
+import { Mirror } from 'rrweb-snapshot';
 import {
   blockClass,
   CanvasContext,
   canvasManagerMutationCallback,
   IWindow,
   listenerHandler,
-  Mirror,
 } from '../../../types';
 import { hookSetter, isBlocked, patch } from '../../../utils';
 
@@ -36,7 +35,7 @@ export default function initCanvas2DMutationObserver(
             this: CanvasRenderingContext2D,
             ...args: Array<unknown>
           ) {
-            if (!isBlocked((this.canvas as unknown) as INode, blockClass)) {
+            if (!isBlocked(this.canvas, blockClass)) {
               // Using setTimeout as getImageData + JSON.stringify can be heavy
               // and we'd rather not block the main thread
               setTimeout(() => {

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -1,4 +1,4 @@
-import { INode } from 'rrweb-snapshot';
+import { Mirror } from 'rrweb-snapshot';
 import {
   blockClass,
   canvasManagerMutationCallback,
@@ -7,7 +7,6 @@ import {
   canvasMutationWithType,
   IWindow,
   listenerHandler,
-  Mirror,
 } from '../../../types';
 import initCanvas2DMutationObserver from './2d';
 import initCanvasContextObserver from './canvas';
@@ -126,7 +125,7 @@ export class CanvasManager {
   flushPendingCanvasMutations() {
     this.pendingCanvasMutations.forEach(
       (values: canvasMutationCommand[], canvas: HTMLCanvasElement) => {
-        const id = this.mirror.getId((canvas as unknown) as INode);
+        const id = this.mirror.getId(canvas);
         this.flushPendingCanvasMutationFor(canvas, id);
       },
     );

--- a/packages/rrweb/src/record/observers/canvas/canvas.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas.ts
@@ -1,4 +1,4 @@
-import { INode, ICanvas } from 'rrweb-snapshot';
+import { ICanvas } from 'rrweb-snapshot';
 import { blockClass, IWindow, listenerHandler } from '../../../types';
 import { isBlocked, patch } from '../../../utils';
 
@@ -17,7 +17,7 @@ export default function initCanvasContextObserver(
           contextType: string,
           ...args: Array<unknown>
         ) {
-          if (!isBlocked((this as unknown) as INode, blockClass)) {
+          if (!isBlocked(this, blockClass)) {
             if (!('__context' in this))
               (this as ICanvas).__context = contextType;
           }

--- a/packages/rrweb/src/record/observers/canvas/webgl.ts
+++ b/packages/rrweb/src/record/observers/canvas/webgl.ts
@@ -1,4 +1,4 @@
-import { INode } from 'rrweb-snapshot';
+import { Mirror } from 'rrweb-snapshot';
 import {
   blockClass,
   CanvasContext,
@@ -6,7 +6,6 @@ import {
   canvasMutationWithType,
   IWindow,
   listenerHandler,
-  Mirror,
 } from '../../../types';
 import { hookSetter, isBlocked, patch } from '../../../utils';
 import { saveWebGLVar, serializeArgs } from './serialize-args';
@@ -32,8 +31,8 @@ function patchGLPrototype(
         return function (this: typeof prototype, ...args: Array<unknown>) {
           const result = original.apply(this, args);
           saveWebGLVar(result, win, prototype);
-          if (!isBlocked((this.canvas as unknown) as INode, blockClass)) {
-            const id = mirror.getId((this.canvas as unknown) as INode);
+          if (!isBlocked(this.canvas, blockClass)) {
+            const id = mirror.getId(this.canvas);
 
             const recordArgs = serializeArgs([...args], win, prototype);
             const mutation: canvasMutationWithType = {

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -1,12 +1,12 @@
 import {
   mutationCallBack,
-  Mirror,
   scrollCallback,
   MutationBufferParam,
   SamplingStrategy,
 } from '../types';
 import { initMutationObserver, initScrollObserver } from './observer';
 import { patch } from '../utils';
+import { Mirror } from 'rrweb-snapshot';
 
 type BypassOptions = Omit<
   MutationBufferParam,

--- a/packages/rrweb/src/replay/virtual-styles.ts
+++ b/packages/rrweb/src/replay/virtual-styles.ts
@@ -1,5 +1,3 @@
-import { INode } from 'rrweb-snapshot';
-
 export enum StyleRuleType {
   Insert,
   Remove,
@@ -37,7 +35,7 @@ type RemovePropertyRule = {
 export type VirtualStyleRules = Array<
   InsertRule | RemoveRule | SnapshotRule | SetPropertyRule | RemovePropertyRule
 >;
-export type VirtualStyleRulesMap = Map<INode, VirtualStyleRules>;
+export type VirtualStyleRulesMap = Map<Node, VirtualStyleRules>;
 
 export function getNestedRule(
   rules: CSSRuleList,
@@ -173,7 +171,7 @@ export function storeCSSRules(
     const cssTexts = Array.from(
       (parentElement as HTMLStyleElement).sheet?.cssRules || [],
     ).map((rule) => rule.cssText);
-    virtualStyleRulesMap.set((parentElement as unknown) as INode, [
+    virtualStyleRulesMap.set(parentElement, [
       {
         type: StyleRuleType.Snapshot,
         cssTexts,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -1,6 +1,6 @@
 import {
   serializedNodeWithId,
-  idNodeMap,
+  Mirror,
   INode,
   MaskInputOptions,
   SlimDOMOptions,
@@ -571,11 +571,13 @@ export type DocumentDimension = {
   absoluteScale: number;
 };
 
-export type Mirror = {
-  map: idNodeMap;
-  getId: (n: INode) => number;
+export type DeprecatedMirror = {
+  map: {
+    [key: number]: INode;
+  };
+  getId: (n: Node) => number;
   getNode: (id: number) => INode | null;
-  removeNodeFromMap: (n: INode) => void;
+  removeNodeFromMap: (n: Node) => void;
   has: (id: number) => boolean;
   reset: () => void;
 };

--- a/packages/rrweb/typings/record/iframe-manager.d.ts
+++ b/packages/rrweb/typings/record/iframe-manager.d.ts
@@ -1,4 +1,4 @@
-import { serializedNodeWithId, INode } from 'rrweb-snapshot';
+import { Mirror, serializedNodeWithId } from 'rrweb-snapshot';
 import { mutationCallBack } from '../types';
 export declare class IframeManager {
     private iframes;
@@ -9,5 +9,5 @@ export declare class IframeManager {
     });
     addIframe(iframeEl: HTMLIFrameElement): void;
     addLoadListener(cb: (iframeEl: HTMLIFrameElement) => unknown): void;
-    attachIframe(iframeEl: INode, childSn: serializedNodeWithId): void;
+    attachIframe(iframeEl: Node, childSn: serializedNodeWithId, mirror: Mirror): void;
 }

--- a/packages/rrweb/typings/record/index.d.ts
+++ b/packages/rrweb/typings/record/index.d.ts
@@ -1,9 +1,10 @@
+import { Mirror } from 'rrweb-snapshot';
 import { eventWithTime, recordOptions, listenerHandler } from '../types';
 declare function record<T = eventWithTime>(options?: recordOptions<T>): listenerHandler | undefined;
 declare namespace record {
     var addCustomEvent: <T>(tag: string, payload: T) => void;
     var freezePage: () => void;
     var takeFullSnapshot: (isCheckout?: boolean | undefined) => void;
-    var mirror: import("../types").Mirror;
+    var mirror: Mirror;
 }
 export default record;

--- a/packages/rrweb/typings/record/observers/canvas/2d.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/2d.d.ts
@@ -1,2 +1,3 @@
-import { blockClass, canvasManagerMutationCallback, IWindow, listenerHandler, Mirror } from '../../../types';
+import { Mirror } from 'rrweb-snapshot';
+import { blockClass, canvasManagerMutationCallback, IWindow, listenerHandler } from '../../../types';
 export default function initCanvas2DMutationObserver(cb: canvasManagerMutationCallback, win: IWindow, blockClass: blockClass, mirror: Mirror): listenerHandler;

--- a/packages/rrweb/typings/record/observers/canvas/canvas-manager.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/canvas-manager.d.ts
@@ -1,4 +1,5 @@
-import { blockClass, canvasMutationCallback, IWindow, Mirror } from '../../../types';
+import { Mirror } from 'rrweb-snapshot';
+import { blockClass, canvasMutationCallback, IWindow } from '../../../types';
 export declare type RafStamps = {
     latestId: number;
     invokeId: number | null;

--- a/packages/rrweb/typings/record/observers/canvas/webgl.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/webgl.d.ts
@@ -1,2 +1,3 @@
-import { blockClass, canvasManagerMutationCallback, IWindow, listenerHandler, Mirror } from '../../../types';
+import { Mirror } from 'rrweb-snapshot';
+import { blockClass, canvasManagerMutationCallback, IWindow, listenerHandler } from '../../../types';
 export default function initCanvasWebGLMutationObserver(cb: canvasManagerMutationCallback, win: IWindow, blockClass: blockClass, mirror: Mirror): listenerHandler;

--- a/packages/rrweb/typings/record/shadow-dom-manager.d.ts
+++ b/packages/rrweb/typings/record/shadow-dom-manager.d.ts
@@ -1,4 +1,5 @@
-import { mutationCallBack, Mirror, scrollCallback, MutationBufferParam, SamplingStrategy } from '../types';
+import { mutationCallBack, scrollCallback, MutationBufferParam, SamplingStrategy } from '../types';
+import { Mirror } from 'rrweb-snapshot';
 declare type BypassOptions = Omit<MutationBufferParam, 'doc' | 'mutationCb' | 'mirror' | 'shadowDomManager'> & {
     sampling: SamplingStrategy;
 };
@@ -7,6 +8,7 @@ export declare class ShadowDomManager {
     private scrollCb;
     private bypassOptions;
     private mirror;
+    private restorePatches;
     constructor(options: {
         mutationCb: mutationCallBack;
         scrollCb: scrollCallback;
@@ -14,5 +16,7 @@ export declare class ShadowDomManager {
         mirror: Mirror;
     });
     addShadowRoot(shadowRoot: ShadowRoot, doc: Document): void;
+    observeAttachShadow(iframeElement: HTMLIFrameElement): void;
+    reset(): void;
 }
 export {};

--- a/packages/rrweb/typings/replay/index.d.ts
+++ b/packages/rrweb/typings/replay/index.d.ts
@@ -1,6 +1,7 @@
+import { Mirror } from 'rrweb-snapshot';
 import { Timer } from './timer';
 import { createPlayerService, createSpeedService } from './machine';
-import { eventWithTime, playerConfig, playerMetaData, Handler, Mirror } from '../types';
+import { eventWithTime, playerConfig, playerMetaData, Handler } from '../types';
 import './styles/style.css';
 export declare class Replayer {
     wrapper: HTMLDivElement;
@@ -59,6 +60,7 @@ export declare class Replayer {
     private applyMutation;
     private applyScroll;
     private applyInput;
+    private applyText;
     private legacy_resolveMissingNode;
     private moveAndHover;
     private drawMouseTail;

--- a/packages/rrweb/typings/replay/virtual-styles.d.ts
+++ b/packages/rrweb/typings/replay/virtual-styles.d.ts
@@ -1,4 +1,3 @@
-import { INode } from 'rrweb-snapshot';
 export declare enum StyleRuleType {
     Insert = 0,
     Remove = 1,
@@ -32,7 +31,7 @@ declare type RemovePropertyRule = {
     property: string;
 };
 export declare type VirtualStyleRules = Array<InsertRule | RemoveRule | SnapshotRule | SetPropertyRule | RemovePropertyRule>;
-export declare type VirtualStyleRulesMap = Map<INode, VirtualStyleRules>;
+export declare type VirtualStyleRulesMap = Map<Node, VirtualStyleRules>;
 export declare function getNestedRule(rules: CSSRuleList, position: number[]): CSSGroupingRule;
 export declare function getPositionsAndIndex(nestedIndex: number[]): {
     positions: number[];

--- a/packages/rrweb/typings/types.d.ts
+++ b/packages/rrweb/typings/types.d.ts
@@ -1,4 +1,4 @@
-import { serializedNodeWithId, idNodeMap, INode, MaskInputOptions, SlimDOMOptions, MaskInputFn, MaskTextFn } from 'rrweb-snapshot';
+import { serializedNodeWithId, Mirror, INode, MaskInputOptions, SlimDOMOptions, MaskInputFn, MaskTextFn } from 'rrweb-snapshot';
 import { PackFn, UnpackFn } from './packer/base';
 import { IframeManager } from './record/iframe-manager';
 import { ShadowDomManager } from './record/shadow-dom-manager';
@@ -401,11 +401,13 @@ export declare type DocumentDimension = {
     relativeScale: number;
     absoluteScale: number;
 };
-export declare type Mirror = {
-    map: idNodeMap;
-    getId: (n: INode) => number;
+export declare type DeprecatedMirror = {
+    map: {
+        [key: number]: INode;
+    };
+    getId: (n: Node) => number;
     getNode: (id: number) => INode | null;
-    removeNodeFromMap: (n: INode) => void;
+    removeNodeFromMap: (n: Node) => void;
     has: (id: number) => boolean;
     reset: () => void;
 };
@@ -494,4 +496,5 @@ declare global {
     }
 }
 export declare type IWindow = Window & typeof globalThis;
+export declare type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 export {};

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -1,8 +1,7 @@
-import { Mirror, throttleOptions, listenerHandler, hookResetter, blockClass, addedNodeMutation, removedNodeMutation, textMutation, attributeMutation, mutationData, scrollData, inputData, DocumentDimension, IWindow } from './types';
-import { INode, serializedNodeWithId } from 'rrweb-snapshot';
+import { throttleOptions, listenerHandler, hookResetter, blockClass, addedNodeMutation, removedNodeMutation, textMutation, attributeMutation, mutationData, scrollData, inputData, DocumentDimension, IWindow, DeprecatedMirror } from './types';
+import { Mirror } from 'rrweb-snapshot';
 export declare function on(type: string, fn: EventListenerOrEventListenerObject, target?: Document | IWindow): listenerHandler;
-export declare function createMirror(): Mirror;
-export declare let _mirror: Mirror;
+export declare let _mirror: DeprecatedMirror;
 export declare function throttle<T>(func: (arg: T) => void, wait: number, options?: throttleOptions): (arg: T) => void;
 export declare function hookSetter<T>(target: T, key: string | number | symbol, d: PropertyDescriptor, isRevoked?: boolean, win?: Window & typeof globalThis): hookResetter;
 export declare function patch(source: {
@@ -11,8 +10,8 @@ export declare function patch(source: {
 export declare function getWindowHeight(): number;
 export declare function getWindowWidth(): number;
 export declare function isBlocked(node: Node | null, blockClass: blockClass): boolean;
-export declare function isIgnored(n: Node | INode): boolean;
-export declare function isAncestorRemoved(target: INode, mirror: Mirror): boolean;
+export declare function isIgnored(n: Node, mirror: Mirror): boolean;
+export declare function isAncestorRemoved(target: Node, mirror: Mirror): boolean;
 export declare function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent;
 export declare function polyfill(win?: Window & typeof globalThis): void;
 export declare type TreeNode = {
@@ -54,14 +53,10 @@ declare type ResolveTree = {
 };
 export declare function queueToResolveTrees(queue: addedNodeMutation[]): ResolveTree[];
 export declare function iterateResolveTree(tree: ResolveTree, cb: (mutation: addedNodeMutation) => unknown): void;
-declare type HTMLIFrameINode = HTMLIFrameElement & {
-    __sn: serializedNodeWithId;
-};
 export declare type AppendedIframe = {
     mutationInQueue: addedNodeMutation;
-    builtNode: HTMLIFrameINode;
+    builtNode: HTMLIFrameElement;
 };
-export declare function isIframeINode(node: INode | ShadowRoot): node is HTMLIFrameINode;
 export declare function getBaseDimension(node: Node, rootIframe: Node): DocumentDimension;
 export declare function hasShadowRoot<T extends Node>(n: T): n is T & {
     shadowRoot: ShadowRoot;


### PR DESCRIPTION
Currently we can't record rrweb with rrweb because both the replay and recording use the `node.__sn` attribute which causes id collisions.

To move away from `INode`'s (nodes with `__sn` attribute) this PR uses the `Mirror` to save all serialized data, and id numbers.

This PR could potentially make it easier for multiple rrweb recordings to happen at the same time without the recording sessions needing to use the exact same ids for the same nodes.

### Breaking change
The mirror was moved to rrweb-snapshot, has its own class, and the `map` attribute isn't supported anymore. We could create a `.map` fallback to help with backward compatibility.