### PR TITLE
Fix issue with scrolling not working

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -9,6 +9,7 @@ import {
   on,
   getWindowWidth,
   getWindowHeight,
+  getWindowScroll,
   polyfill,
   hasShadowRoot,
   isSerializedIframe,
@@ -296,22 +297,7 @@ function record<T = eventWithTime>(
         type: EventType.FullSnapshot,
         data: {
           node,
-          initialOffset: {
-            left:
-              window.pageXOffset !== undefined
-                ? window.pageXOffset
-                : document?.documentElement.scrollLeft ||
-                  document?.body?.parentElement?.scrollLeft ||
-                  document?.body.scrollLeft ||
-                  0,
-            top:
-              window.pageYOffset !== undefined
-                ? window.pageYOffset
-                : document?.documentElement.scrollTop ||
-                  document?.body?.parentElement?.scrollTop ||
-                  document?.body.scrollTop ||
-                  0,
-          },
+          initialOffset: getWindowScroll(window),
         },
       }),
     );

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -4,6 +4,7 @@ import {
   throttle,
   on,
   hookSetter,
+  getWindowScroll,
   getWindowHeight,
   getWindowWidth,
   isBlocked,
@@ -272,11 +273,11 @@ export function initScrollObserver({
     }
     const id = mirror.getId(target as Node);
     if (target === doc) {
-      const scrollEl = (doc.scrollingElement || doc.documentElement)!;
+      const scrollLeftTop = getWindowScroll(doc.defaultView);
       scrollCb({
         id,
-        x: scrollEl.scrollLeft,
-        y: scrollEl.scrollTop,
+        x: scrollLeftTop.left,
+        y: scrollLeftTop.top,
       });
     } else {
       scrollCb({

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -169,6 +169,28 @@ export function patch(
   }
 }
 
+export function getWindowScroll(win): number {
+  const doc = win.document;
+  return {
+    left:
+      doc.scrollingElement ? doc.scrollingElement.scrollLeft
+      : win.pageXOffset !== undefined
+      ? win.pageXOffset
+      : doc?.documentElement.scrollLeft ||
+      doc?.body?.parentElement?.scrollLeft ||
+      doc?.body.scrollLeft ||
+      0,
+    top:
+      doc.scrollingElement ? doc.scrollingElement.scrollTop
+      : win.pageYOffset !== undefined
+      ? win.pageYOffset
+      : doc?.documentElement.scrollTop ||
+      doc?.body?.parentElement?.scrollTop ||
+      doc?.body.scrollTop ||
+      0,
+  }
+}
+
 export function getWindowHeight(): number {
   return (
     window.innerHeight ||


### PR DESCRIPTION
Fix issue where only indication I could see in any attribute that the document was scrolling was on `window.pageYOffset`, so we hadn't been able to replay scrolling

Website was https://www.malibal.com/boutique/pc/configurePrd.asp?idproduct=2061

I've no idea what conditions make this the case.