### PR TITLE
Perf: Apply the latest text mutation only

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -52,6 +52,7 @@ import {
   getBaseDimension,
   hasShadowRoot,
   isSerializedIframe,
+  uniqueTextMutations,
 } from '../utils';
 import getInjectStyleRules from './styles/inject-style';
 import './styles/style.css';
@@ -179,9 +180,10 @@ export class Replayer {
       this.fragmentParentMap.forEach((parent, frag) =>
         this.restoreRealParent(frag, parent),
       );
+
       // apply text needs to happen before virtual style rules gets applied
       // as it can overwrite the contents of a stylesheet
-      for (const d of mutationData.texts) {
+      for (const d of uniqueTextMutations(mutationData.texts)) {
         this.applyText(d, mutationData);
       }
 
@@ -1613,7 +1615,7 @@ export class Replayer {
       Object.assign(this.legacy_missingNodeRetryMap, legacy_missingNodeMap);
     }
 
-    d.texts.forEach((mutation) => {
+    uniqueTextMutations(d.texts).forEach((mutation) => {
       let target = this.mirror.getNode(mutation.id);
       if (!target) {
         if (d.removes.find((r) => r.id === mutation.id)) {

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -594,12 +594,16 @@ export function hasShadowRoot<T extends Node>(
  * @returns {textMutation[]} The filtered text mutations.
  */
 export function uniqueTextMutations(mutations: textMutation[]): textMutation[] {
-  const textMuatationsMap = new Map<number, textMutation>();
-  mutations
-    .slice()
-    .reverse()
-    .forEach((text) => {
-      if (!textMuatationsMap.has(text.id)) textMuatationsMap.set(text.id, text);
-    });
-  return Array.from(textMuatationsMap.values());
+  const idSet = new Set<number>();
+  const uniqueMutations: textMutation[] = [];
+
+  for (let i = mutations.length; i--; ) {
+    const mutation = mutations[i];
+    if (!idSet.has(mutation.id)) {
+      uniqueMutations.push(mutation);
+      idSet.add(mutation.id);
+    }
+  }
+
+  return uniqueMutations;
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -587,3 +587,19 @@ export function hasShadowRoot<T extends Node>(
 ): n is T & { shadowRoot: ShadowRoot } {
   return Boolean(((n as unknown) as Element)?.shadowRoot);
 }
+
+/**
+ * Returns the latest mutation in the queue for each node.
+ * @param  {textMutation[]} mutations The text mutations to filter.
+ * @returns {textMutation[]} The filtered text mutations.
+ */
+export function uniqueTextMutations(mutations: textMutation[]): textMutation[] {
+  const textMuatationsMap = new Map<number, textMutation>();
+  mutations
+    .slice()
+    .reverse()
+    .forEach((text) => {
+      if (!textMuatationsMap.has(text.id)) textMuatationsMap.set(text.id, text);
+    });
+  return Array.from(textMuatationsMap.values());
+}

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -10,6 +10,7 @@ export declare function patch(source: {
 export declare function getWindowHeight(): number;
 export declare function getWindowWidth(): number;
 export declare function isBlocked(node: Node | null, blockClass: blockClass): boolean;
+export declare function isSerialized(n: Node, mirror: Mirror): boolean;
 export declare function isIgnored(n: Node, mirror: Mirror): boolean;
 export declare function isAncestorRemoved(target: Node, mirror: Mirror): boolean;
 export declare function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent;
@@ -62,4 +63,5 @@ export declare function getBaseDimension(node: Node, rootIframe: Node): Document
 export declare function hasShadowRoot<T extends Node>(n: T): n is T & {
     shadowRoot: ShadowRoot;
 };
+export declare function getUniqueTextMutations(mutations: textMutation[]): textMutation[];
 export {};


### PR DESCRIPTION
Some frameworks dynamically append styles to a stylesheet via `styleEl.textContent = styleEl.textContent + newStyleRules`
This can end up in a barrage of expanding text mutations on the same element.

This PR makes sure only the last `textContent` change gets applied, as any earlier `textContent` changes would be overwritten anyway.