### PR TITLE
test: add a test case for StyleSheet mutation exceptions while fast-forwarding

### DIFF
--- a/packages/rrweb/test/events/style-sheet-text-mutation.ts
+++ b/packages/rrweb/test/events/style-sheet-text-mutation.ts
@@ -1,0 +1,178 @@
+import { EventType, eventWithTime, IncrementalSource } from '../../src/types';
+
+const now = Date.now();
+const events: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1000,
+      height: 800,
+    },
+    timestamp: now + 100,
+  },
+  // full snapshot
+  {
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          { id: 2, name: 'html', type: 1, publicId: '', systemId: '' },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: { lang: 'en' },
+            childNodes: [
+              {
+                id: 4,
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 101,
+                    type: 2,
+                    tagName: 'style',
+                    attributes: {},
+                    childNodes: [
+                      {
+                        id: 102,
+                        type: 3,
+                        isStyle: true,
+                        textContent: '\n.css-added-at-100 {color: yellow;}\n',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 107,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: { top: 0, left: 0 },
+    },
+    type: EventType.FullSnapshot,
+    timestamp: now + 100,
+  },
+  // mutation that adds an element
+  {
+    data: {
+      adds: [
+        {
+          node: {
+            id: 108,
+            type: 2,
+            tagName: 'div',
+            attributes: {},
+            childNodes: [],
+          },
+          nextId: null,
+          parentId: 107,
+        },
+      ],
+      texts: [],
+      source: IncrementalSource.Mutation,
+      removes: [],
+      attributes: [],
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 500,
+  },
+  // adds a StyleSheetRule by inserting
+  {
+    data: {
+      id: 101,
+      adds: [
+        {
+          rule: '.css-added-at-1000-overwritten-at-1500 {color:red;}',
+        },
+      ],
+      source: IncrementalSource.StyleSheetRule,
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 1000,
+  },
+  // adds a StyleSheetRule by adding a text
+  {
+    data: {
+      adds: [
+        {
+          node: {
+            type: 3,
+            textContent: '.css-added-at-1500-deleted-at-2500 {color: yellow;}',
+            id: 109,
+          },
+          nextId: null,
+          parentId: 101,
+        },
+      ],
+      texts: [],
+      source: IncrementalSource.Mutation,
+      removes: [],
+      attributes: [],
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 1500,
+  },
+  // adds a StyleSheetRule by inserting
+  {
+    data: {
+      id: 101,
+      adds: [
+        {
+          rule: '.css-added-at-2000-overwritten-at-2500 {color: blue;}',
+        },
+      ],
+      source: IncrementalSource.StyleSheetRule,
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 2000,
+  },
+  // deletes a StyleSheetRule by removing the text
+  {
+    data: {
+      texts: [],
+      attributes: [],
+      removes: [{ parentId: 101, id: 109 }],
+      adds: [],
+      source: IncrementalSource.Mutation,
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 2500,
+  },
+  // adds a StyleSheetRule by inserting
+  {
+    data: {
+      id: 101,
+      adds: [
+        {
+          rule: '.css-added-at-3000 {color: red;}',
+        },
+      ],
+      source: IncrementalSource.StyleSheetRule,
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 3000,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -255,24 +255,27 @@ describe('replayer', function () {
     expect(result).toEqual(true);
   });
 
-  it('should delete all inserted StyleSheetRules by adding a text to style element while fast-forwarding', async () => {
+  it('should overwrite all StyleSheetRules by appending a text node to stylesheet element while fast-forwarding', async () => {
     await page.evaluate(`events = ${JSON.stringify(StyleSheetTextMutation)}`);
     const result = await page.evaluate(`
       const { Replayer } = rrweb;
       const replayer = new Replayer(events);
       replayer.pause(1600);
-      let rules = [...replayer.iframe.contentDocument.styleSheets].map(
+      const rules = [...replayer.iframe.contentDocument.styleSheets].map(
         (sheet) => [...sheet.rules],
       ).flat();
       rules.some((x) => x.selectorText === '.css-added-at-1000-overwritten-at-1500');
     `);
     expect(result).toEqual(false);
+  });
 
-    await page.evaluate('replayer.play(0);');
-    await waitForRAF(page);
-    await page.evaluate(`
+  it('should apply fast-forwarded StyleSheetRules that came after appending text node to stylesheet element', async () => {
+    await page.evaluate(`events = ${JSON.stringify(StyleSheetTextMutation)}`);
+    const result = await page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
       replayer.pause(2100);
-      rules = [...replayer.iframe.contentDocument.styleSheets].map(
+      const rules = [...replayer.iframe.contentDocument.styleSheets].map(
         (sheet) => [...sheet.rules],
       ).flat();
       rules.some((x) => x.selectorText === '.css-added-at-2000-overwritten-at-2500');
@@ -280,24 +283,27 @@ describe('replayer', function () {
     expect(result).toEqual(true);
   });
 
-  it("should delete all inserted StyleSheetRules by removing style element's textContent while fast-forwarding", async () => {
+  it('should overwrite all StyleSheetRules by removing text node from stylesheet element while fast-forwarding', async () => {
     await page.evaluate(`events = ${JSON.stringify(StyleSheetTextMutation)}`);
     const result = await page.evaluate(`
       const { Replayer } = rrweb;
       const replayer = new Replayer(events);
       replayer.pause(2600);
-      let rules = [...replayer.iframe.contentDocument.styleSheets].map(
+      const rules = [...replayer.iframe.contentDocument.styleSheets].map(
         (sheet) => [...sheet.rules],
       ).flat();
       rules.some((x) => x.selectorText === '.css-added-at-2000-overwritten-at-2500');
     `);
     expect(result).toEqual(false);
+  });
 
-    await page.evaluate('replayer.play(0);');
-    await waitForRAF(page);
-    await page.evaluate(`
+  it('should apply fast-forwarded StyleSheetRules that came after removing text node from stylesheet element', async () => {
+    await page.evaluate(`events = ${JSON.stringify(StyleSheetTextMutation)}`);
+    const result = await page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
       replayer.pause(3100);
-      rules = [...replayer.iframe.contentDocument.styleSheets].map(
+      const rules = [...replayer.iframe.contentDocument.styleSheets].map(
         (sheet) => [...sheet.rules],
       ).flat();
       rules.some((x) => x.selectorText === '.css-added-at-3000');


### PR DESCRIPTION
This PR is related to a bug that @Juice10 and I found at the last core team meeting. 
<img width="542" alt="image" src="https://user-images.githubusercontent.com/27533910/166884410-92bbc6c7-8404-4f79-9135-9d8534b5b6ab.png">
The added test case can reproduce the problem but I haven't found a solution yet. So that the CI will absolutely fail and it is expected.

The reason for this bug is similar to PR #865. When childNodes of a style element are mutated (append or remove), all applied stylesheet rules programmatically are lost automatically. 