### PR TITLE
Added null check on iframe.contentWindow

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -263,7 +263,7 @@ export class Replayer {
         this.rebuildFullSnapshot(
           firstFullsnapshot as fullSnapshotEvent & { timestamp: number },
         );
-        this.iframe.contentWindow!.scrollTo(
+        this.iframe.contentWindow?.scrollTo(
           (firstFullsnapshot as fullSnapshotEvent).data.initialOffset,
         );
       }, 1);


### PR DESCRIPTION
Getting this error "cannot read property on null (reading scrollTo)". Stacktrace shows error on this line.
<img width="1280" alt="Screen Shot 2022-06-14 at 1 23 47 PM" src="https://user-images.githubusercontent.com/65953692/173548620-aa4818a2-5a18-43e0-aa43-eecb7e096ae5.png">
