### PR TITLE
update cssom package to rrweb self-owned package 'rrweb-cssom'

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "lint": "yarn run concurrently --success=all -r -m=1 'yarn run markdownlint docs' 'yarn eslint packages/*/src --ext .ts,.tsx,.js,.jsx,.svelte'"
   },
   "resolutions": {
-    "**/jsdom/cssom": "^0.5.0"
+    "**/jsdom/cssom": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz"
   }
 }

--- a/packages/rrdom/test/diff.test.ts
+++ b/packages/rrdom/test/diff.test.ts
@@ -1194,7 +1194,7 @@ describe('diff algorithm for rrdom', () => {
 
     // JSDOM/CSSOM is currently broken for this test
     // remove '.skip' once https://github.com/NV/CSSOM/pull/113#issue-712485075 is merged
-    it.skip('should insert rule at index [0,0] and keep existing rules', () => {
+    it('should insert rule at index [0,0] and keep existing rules', () => {
       document.write(`
         <style>
           @media {
@@ -1210,10 +1210,6 @@ describe('diff algorithm for rrdom', () => {
         { cssText, index: [0, 0], type: StyleRuleType.Insert },
       ];
       applyVirtualStyleRulesToNode(styleEl, virtualStyleRules);
-
-      console.log(
-        Array.from((styleEl.sheet?.cssRules[0] as CSSMediaRule).cssRules),
-      );
 
       expect(
         (styleEl.sheet?.cssRules[0] as CSSMediaRule).cssRules?.length,

--- a/packages/rrdom/test/diff.test.ts
+++ b/packages/rrdom/test/diff.test.ts
@@ -1192,8 +1192,6 @@ describe('diff algorithm for rrdom', () => {
       expect(styleEl.sheet?.cssRules[0].cssText).toEqual('div {color: black;}');
     });
 
-    // JSDOM/CSSOM is currently broken for this test
-    // remove '.skip' once https://github.com/NV/CSSOM/pull/113#issue-712485075 is merged
     it('should insert rule at index [0,0] and keep existing rules', () => {
       document.write(`
         <style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,7 +3878,11 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-cssom@^0.4.4, cssom@^0.5.0:
+cssom@^0.4.4, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
+
+cssom@^0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz"
   integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==


### PR DESCRIPTION
### motivation
JSDOM/CSSOM is currently broken for one test case `should insert a rule at index [0,0] and keep existing rules` in rrdom package.

@Juice10 has created a pull request for the official repository https://github.com/NV/CSSOM/pull/113. Unfortunately, this PR hasn't been merged till now. So that the broken test case has to be always skipped.

Finally, we choose to fork and publish our own CSSOM package to work around.

https://github.com/rrweb-io/CSSOM
https://www.npmjs.com/package/rrweb-cssom

### effect
Before this PR:
<img width="547" alt="iShot_2022-06-30_23 52 16" src="https://user-images.githubusercontent.com/27533910/176697486-554c0de7-93bf-4f0c-9082-c2a319363d88.png">

After the PR applied:
<img width="404" alt="iShot_2022-06-30_23 52 32" src="https://user-images.githubusercontent.com/27533910/176697591-057c8e4d-ed05-464d-96c4-4435333cb772.png">

