### PR TITLE
add special handling for undefined console content

### DIFF
--- a/packages/rrweb/src/plugins/console/record/stringify.ts
+++ b/packages/rrweb/src/plugins/console/record/stringify.ts
@@ -117,9 +117,8 @@ export function stringify(
       }
       /* END of the FORK */
 
-      if (value === null || value === undefined) {
-        return value;
-      }
+      if (value === null) return value;
+      if (value === undefined) return 'undefined';
       if (shouldIgnore(value as object)) {
         return toString(value as object);
       }


### PR DESCRIPTION
This PR is going to fix issue #877.
All `undefined` console content will be stringified as string 'undefined'.

The effect of `undefined` in the replaying side looks like the screenshot below:
<img width="759" alt="image" src="https://user-images.githubusercontent.com/27533910/178254266-20526882-0e87-478b-8770-b218fcf6db5b.png">
