### PR TITLE
Fix <use> to use local resource instead of absolute path

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -248,7 +248,8 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || (name === 'href' && value)) {
+  if (name === 'src' || (name === 'href' && value && !(tagName === 'use' && value[0] === '#'))) {
+    // href starts with a # is an id pointer for svg
     return absoluteToDoc(doc, value);
   } else if (name === 'xlink:href' && value && value[0] !== '#') {
     // xlink:href starts with # is an id pointer


### PR DESCRIPTION
Previously when `<svg>`s were snapshotted, `<use>` tag href was serialized to absolute path. But one's that start with '#' should be a local resource and should not be serialized to absolute path and instead left as is.

Previously:
`<use href="https://google.com/#resource-a"></use>`

Which would not resolve the correct local resource.

Now:
`<use href="#resource-a"></use>`

Which correctly resolves the local svg resource. It looks like the `xlink:href` case is already handled (but that attribute is deprecated in new `svg` spec)

See: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use