### PR TITLE
fix issue #933

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -18,6 +18,7 @@ import {
   isElement,
   isShadowRoot,
   maskInputValue,
+  isNativeShadowDom,
 } from './utils';
 
 let _id = 1;
@@ -248,7 +249,10 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || (name === 'href' && value && !(tagName === 'use' && value[0] === '#'))) {
+  if (
+    name === 'src' ||
+    (name === 'href' && value && !(tagName === 'use' && value[0] === '#'))
+  ) {
     // href starts with a # is an id pointer for svg
     return absoluteToDoc(doc, value);
   } else if (name === 'xlink:href' && value && value[0] !== '#') {
@@ -1025,7 +1029,8 @@ export function serializeNodeWithId(
     recordChild = recordChild && !serializedNode.needBlock;
     // this property was not needed in replay side
     delete serializedNode.needBlock;
-    if ((n as HTMLElement).shadowRoot) serializedNode.isShadowHost = true;
+    if ((n as HTMLElement).shadowRoot && isNativeShadowDom())
+      serializedNode.isShadowHost = true;
   }
   if (
     (serializedNode.type === NodeType.Document ||
@@ -1075,14 +1080,14 @@ export function serializeNodeWithId(
       for (const childN of Array.from(n.shadowRoot.childNodes)) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);
         if (serializedChildNode) {
-          serializedChildNode.isShadow = true;
+          isNativeShadowDom() && (serializedChildNode.isShadow = true);
           serializedNode.childNodes.push(serializedChildNode);
         }
       }
     }
   }
 
-  if (n.parentNode && isShadowRoot(n.parentNode)) {
+  if (n.parentNode && isShadowRoot(n.parentNode) && isNativeShadowDom()) {
     serializedNode.isShadow = true;
   }
 

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1029,7 +1029,8 @@ export function serializeNodeWithId(
     recordChild = recordChild && !serializedNode.needBlock;
     // this property was not needed in replay side
     delete serializedNode.needBlock;
-    if ((n as HTMLElement).shadowRoot && isNativeShadowDom())
+    const shadowRoot = (n as HTMLElement).shadowRoot;
+    if (shadowRoot && isNativeShadowDom(shadowRoot))
       serializedNode.isShadowHost = true;
   }
   if (
@@ -1080,14 +1081,19 @@ export function serializeNodeWithId(
       for (const childN of Array.from(n.shadowRoot.childNodes)) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);
         if (serializedChildNode) {
-          isNativeShadowDom() && (serializedChildNode.isShadow = true);
+          isNativeShadowDom(n.shadowRoot) &&
+            (serializedChildNode.isShadow = true);
           serializedNode.childNodes.push(serializedChildNode);
         }
       }
     }
   }
 
-  if (n.parentNode && isShadowRoot(n.parentNode) && isNativeShadowDom()) {
+  if (
+    n.parentNode &&
+    isShadowRoot(n.parentNode) &&
+    isNativeShadowDom(n.parentNode)
+  ) {
     serializedNode.isShadow = true;
   }
 

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -20,8 +20,22 @@ export function isShadowRoot(n: Node): n is ShadowRoot {
  * To fix the issue https://github.com/rrweb-io/rrweb/issues/933.
  * Some websites use polyfilled shadow dom and this function is used to detect this situation.
  */
-export function isNativeShadowDom() {
-  return window.ShadowRoot?.toString().indexOf('[native code]') > -1;
+export function isNativeShadowDom(shadowRoot: ShadowRoot) {
+  return (
+    /**
+     * Some websites use shady dom https://github.com/webcomponents/polyfills/tree/master/packages/shadydom to polyfill the shadow dom and this will cause some issues during the recording.
+     * This statement is to determine whether the current website is polyfilled by shadydom or not.
+     */
+    !(window as Window & typeof globalThis & { ShadyDOM: object }).ShadyDOM &&
+    shadowRoot &&
+    /**
+     * https://github.com/salesforce/lwc/blob/v2.20.3/packages/@lwc/shared/src/keys.ts#L9
+     * All synthetic shadow roots contain the property $shadowResolver$ and this can be used to distinguish them from the native shadowRoot.
+     */
+    !(shadowRoot as ShadowRoot & {
+      $shadowResolver$?: (...args: unknown[]) => unknown;
+    }).$shadowResolver$
+  );
 }
 
 export class Mirror implements IMirror<Node> {

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -16,6 +16,14 @@ export function isShadowRoot(n: Node): n is ShadowRoot {
   return Boolean(host?.shadowRoot === n);
 }
 
+/**
+ * To fix the issue https://github.com/rrweb-io/rrweb/issues/933.
+ * Some websites use polyfilled shadow dom and this function is used to detect this situation.
+ */
+export function isNativeShadowDom() {
+  return window.ShadowRoot?.toString().indexOf('[native code]') > -1;
+}
+
 export class Mirror implements IMirror<Node> {
   private idNodeMap: idNodeMap = new Map();
   private nodeMetaMap: nodeMetaMap = new WeakMap();

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -21,21 +21,7 @@ export function isShadowRoot(n: Node): n is ShadowRoot {
  * Some websites use polyfilled shadow dom and this function is used to detect this situation.
  */
 export function isNativeShadowDom(shadowRoot: ShadowRoot) {
-  return (
-    /**
-     * Some websites use shady dom https://github.com/webcomponents/polyfills/tree/master/packages/shadydom to polyfill the shadow dom and this will cause some issues during the recording.
-     * This statement is to determine whether the current website is polyfilled by shadydom or not.
-     */
-    !(window as Window & typeof globalThis & { ShadyDOM: object }).ShadyDOM &&
-    shadowRoot &&
-    /**
-     * https://github.com/salesforce/lwc/blob/v2.20.3/packages/@lwc/shared/src/keys.ts#L9
-     * All synthetic shadow roots contain the property $shadowResolver$ and this can be used to distinguish them from the native shadowRoot.
-     */
-    !(shadowRoot as ShadowRoot & {
-      $shadowResolver$?: (...args: unknown[]) => unknown;
-    }).$shadowResolver$
-  );
+  return Object.prototype.toString.call(shadowRoot) === '[object ShadowRoot]';
 }
 
 export class Mirror implements IMirror<Node> {

--- a/packages/rrweb-snapshot/typings/utils.d.ts
+++ b/packages/rrweb-snapshot/typings/utils.d.ts
@@ -1,6 +1,7 @@
 import { MaskInputFn, MaskInputOptions, IMirror, serializedNodeWithId } from './types';
 export declare function isElement(n: Node): n is Element;
 export declare function isShadowRoot(n: Node): n is ShadowRoot;
+export declare function isNativeShadowDom(): boolean;
 export declare class Mirror implements IMirror<Node> {
     private idNodeMap;
     private nodeMetaMap;

--- a/packages/rrweb-snapshot/typings/utils.d.ts
+++ b/packages/rrweb-snapshot/typings/utils.d.ts
@@ -1,7 +1,7 @@
 import { MaskInputFn, MaskInputOptions, IMirror, serializedNodeWithId } from './types';
 export declare function isElement(n: Node): n is Element;
 export declare function isShadowRoot(n: Node): n is ShadowRoot;
-export declare function isNativeShadowDom(): boolean;
+export declare function isNativeShadowDom(shadowRoot: ShadowRoot): boolean;
 export declare class Mirror implements IMirror<Node> {
     private idNodeMap;
     private nodeMetaMap;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -583,7 +583,7 @@ export default class MutationBuffer {
               parentId,
               id: nodeId,
               isShadow:
-                isShadowRoot(m.target) && isNativeShadowDom()
+                isShadowRoot(m.target) && isNativeShadowDom(m.target)
                   ? true
                   : undefined,
             });

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -6,6 +6,7 @@ import {
   needMaskingText,
   maskInputValue,
   Mirror,
+  isNativeShadowDom,
 } from 'rrweb-snapshot';
 import type {
   mutationRecord,
@@ -581,7 +582,10 @@ export default class MutationBuffer {
             this.removes.push({
               parentId,
               id: nodeId,
-              isShadow: isShadowRoot(m.target) ? true : undefined,
+              isShadow:
+                isShadowRoot(m.target) && isNativeShadowDom()
+                  ? true
+                  : undefined,
             });
           }
           this.mapRemoves.push(n);

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -7,6 +7,7 @@ import type {
 import { initMutationObserver, initScrollObserver } from './observer';
 import { patch } from '../utils';
 import type { Mirror } from 'rrweb-snapshot';
+import { isNativeShadowDom } from 'rrweb-snapshot';
 
 type BypassOptions = Omit<
   MutationBufferParam,
@@ -53,6 +54,7 @@ export class ShadowDomManager {
   }
 
   public addShadowRoot(shadowRoot: ShadowRoot, doc: Document) {
+    if (!isNativeShadowDom()) return;
     initMutationObserver(
       {
         ...this.bypassOptions,

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -54,7 +54,7 @@ export class ShadowDomManager {
   }
 
   public addShadowRoot(shadowRoot: ShadowRoot, doc: Document) {
-    if (!isNativeShadowDom()) return;
+    if (!isNativeShadowDom(shadowRoot)) return;
     initMutationObserver(
       {
         ...this.bypassOptions,

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -10764,6 +10764,252 @@ exports[`record integration tests should record shadow DOM 1`] = `
 ]"
 `;
 
+exports[`record integration tests should record shadow doms polyfilled by shadydom 1`] = `
+"[
+  {
+    \\"type\\": 0,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 1,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {
+              \\"lang\\": \\"en\\"
+            },
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 7
+                      }
+                    ],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\",
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {
+                      \\"src\\": \\"https://cdn.jsdelivr.net/npm/@webcomponents/shadydom@1.9.0/shadydom.min.js\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\",
+                    \\"id\\": 10
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"charset\\": \\"UTF-8\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 11
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 12
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 14
+                      }
+                    ],
+                    \\"id\\": 13
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 15
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 16
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target1\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"div\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [],
+                        \\"id\\": 20
+                      }
+                    ],
+                    \\"id\\": 19
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 21
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target2\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"p\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [],
+                        \\"id\\": 23
+                      }
+                    ],
+                    \\"id\\": 22
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 24
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target3\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 25
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"id\\": 26
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 28
+                      }
+                    ],
+                    \\"id\\": 27
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
+                    \\"id\\": 29
+                  }
+                ],
+                \\"id\\": 17
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 25,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"span\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"id\\": 30
+          }
+        }
+      ]
+    }
+  }
+]"
+`;
+
 exports[`record integration tests should record webgl canvas mutations 1`] = `
 "[
   {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -10855,26 +10855,8 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
                   },
                   {
                     \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 12
-                  },
-                  {
-                    \\"type\\": 2,
-                    \\"tagName\\": \\"script\\",
-                    \\"attributes\\": {},
-                    \\"childNodes\\": [
-                      {
-                        \\"type\\": 3,
-                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 14
-                      }
-                    ],
-                    \\"id\\": 13
-                  },
-                  {
-                    \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\",
-                    \\"id\\": 15
+                    \\"id\\": 12
                   }
                 ],
                 \\"id\\": 4
@@ -10882,7 +10864,7 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
               {
                 \\"type\\": 3,
                 \\"textContent\\": \\"\\\\n  \\",
-                \\"id\\": 16
+                \\"id\\": 13
               },
               {
                 \\"type\\": 2,
@@ -10892,7 +10874,7 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 18
+                    \\"id\\": 15
                   },
                   {
                     \\"type\\": 2,
@@ -10904,6 +10886,28 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"div\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [],
+                        \\"id\\": 17
+                      }
+                    ],
+                    \\"id\\": 16
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target2\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"p\\",
                         \\"attributes\\": {},
                         \\"childNodes\\": [],
                         \\"id\\": 20
@@ -10920,32 +10924,28 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
                     \\"type\\": 2,
                     \\"tagName\\": \\"div\\",
                     \\"attributes\\": {
-                      \\"id\\": \\"target2\\"
+                      \\"id\\": \\"target3\\"
                     },
-                    \\"childNodes\\": [
-                      {
-                        \\"type\\": 2,
-                        \\"tagName\\": \\"p\\",
-                        \\"attributes\\": {},
-                        \\"childNodes\\": [],
-                        \\"id\\": 23
-                      }
-                    ],
+                    \\"childNodes\\": [],
                     \\"id\\": 22
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 24
+                    \\"id\\": 23
                   },
                   {
                     \\"type\\": 2,
-                    \\"tagName\\": \\"div\\",
-                    \\"attributes\\": {
-                      \\"id\\": \\"target3\\"
-                    },
-                    \\"childNodes\\": [],
-                    \\"id\\": 25
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 25
+                      }
+                    ],
+                    \\"id\\": 24
                   },
                   {
                     \\"type\\": 3,
@@ -10971,7 +10971,7 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
                     \\"id\\": 29
                   }
                 ],
-                \\"id\\": 17
+                \\"id\\": 14
               }
             ],
             \\"id\\": 3
@@ -10994,7 +10994,7 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
       \\"removes\\": [],
       \\"adds\\": [
         {
-          \\"parentId\\": 25,
+          \\"parentId\\": 22,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 2,
@@ -11002,6 +11002,291 @@ exports[`record integration tests should record shadow doms polyfilled by shadyd
             \\"attributes\\": {},
             \\"childNodes\\": [],
             \\"id\\": 30
+          }
+        }
+      ]
+    }
+  }
+]"
+`;
+
+exports[`record integration tests should record shadow doms polyfilled by synthetic-shadow 1`] = `
+"[
+  {
+    \\"type\\": 0,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 1,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {
+              \\"lang\\": \\"en\\"
+            },
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 7
+                      }
+                    ],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\",
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {
+                      \\"src\\": \\"https://cdn.jsdelivr.net/npm/@lwc/synthetic-shadow@2.20.3/dist/synthetic-shadow.js\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n      \\\\n    \\",
+                    \\"id\\": 10
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"charset\\": \\"UTF-8\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 11
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 12
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 13
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 15
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target1\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"div\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [],
+                        \\"id\\": 17,
+                        \\"isShadow\\": true
+                      }
+                    ],
+                    \\"id\\": 16,
+                    \\"isShadowHost\\": true
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target2\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"p\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [],
+                        \\"id\\": 20
+                      }
+                    ],
+                    \\"id\\": 19
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 21
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"target3\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 22
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 23
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 25
+                      }
+                    ],
+                    \\"id\\": 24
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"id\\": 26
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 28
+                      }
+                    ],
+                    \\"id\\": 27
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
+                    \\"id\\": 29
+                  }
+                ],
+                \\"id\\": 14
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 22,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"span\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"id\\": 30
+          }
+        },
+        {
+          \\"parentId\\": 14,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"div\\",
+            \\"attributes\\": {
+              \\"id\\": \\"target4\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 31,
+            \\"isShadowHost\\": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 31,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"ul\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"id\\": 32,
+            \\"isShadow\\": true
           }
         }
       ]

--- a/packages/rrweb/test/html/polyfilled-shadowdom-mutation.html
+++ b/packages/rrweb/test/html/polyfilled-shadowdom-mutation.html
@@ -2,25 +2,23 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <script>
-      window.onload = function () {
-        const target1 = document.querySelector('#target1');
-        target1.attachShadow({
-          mode: 'open',
-        });
-        target1.shadowRoot.appendChild(document.createElement('div'));
-        const target2 = document.querySelector('#target2');
-        target2.attachShadow({
-          mode: 'open',
-          '$$lwc-synthetic-mode': true,
-        });
-        target2.shadowRoot.appendChild(document.createElement('p'));
-      };
-    </script>
   </head>
   <body>
     <div id="target1"></div>
     <div id="target2"></div>
     <div id="target3"></div>
+    <script>
+      const target1 = document.querySelector('#target1');
+      target1.attachShadow({
+        mode: 'open',
+      });
+      target1.shadowRoot.appendChild(document.createElement('div'));
+      const target2 = document.querySelector('#target2');
+      target2.attachShadow({
+        mode: 'open',
+        '$$lwc-synthetic-mode': true,
+      });
+      target2.shadowRoot.appendChild(document.createElement('p'));
+    </script>
   </body>
 </html>

--- a/packages/rrweb/test/html/polyfilled-shadowdom-mutation.html
+++ b/packages/rrweb/test/html/polyfilled-shadowdom-mutation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script>
+      window.onload = function () {
+        const target1 = document.querySelector('#target1');
+        target1.attachShadow({
+          mode: 'open',
+        });
+        target1.shadowRoot.appendChild(document.createElement('div'));
+        const target2 = document.querySelector('#target2');
+        target2.attachShadow({
+          mode: 'open',
+          '$$lwc-synthetic-mode': true,
+        });
+        target2.shadowRoot.appendChild(document.createElement('p'));
+      };
+    </script>
+  </head>
+  <body>
+    <div id="target1"></div>
+    <div id="target2"></div>
+    <div id="target3"></div>
+  </body>
+</html>

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -648,6 +648,7 @@ describe('record integration tests', function (this: ISuite) {
       } as ShadowRootInit);
       target3?.shadowRoot?.appendChild(document.createElement('span'));
       const target4 = document.createElement('div');
+      target4.id = 'target4';
       // create a native shadow dom
       document.body.appendChild(target4);
       target4.attachShadow({


### PR DESCRIPTION
This PR is trying to fix shadow dom recording problems #933 caused by [shadydom](https://github.com/webcomponents/polyfills/tree/master/packages/shadydom) and [@lwc/synthetic-shadow](https://github.com/salesforce/lwc/tree/master/packages/%40lwc/synthetic-shadow). These two packages are all shadow dom polyfills but don't act exactly like native shadow dom, e.g. they don't provide style isolation.
The main idea of this PR is that on the recording side, we record poly-filled shadow doms as if they are native shadow doms but on the replayer side, we rebuild them as normal elements. That is we don't add `isShadowHost` and `isShadow` properties to them in the recorded results.