### PR TITLE
fix: eslint action error in a PR from a fork repo

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,13 +24,23 @@ jobs:
         run: yarn lint:report
         # Continue to the next step even if this fails
         continue-on-error: true
+      - name: Upload ESLint report
+        uses: actions/upload-artifact@v3
+        with:
+          name: eslint_report.json
+          path: eslint_report.json
+
+  Annotation:
+    if: github.repository == 'rrweb-io/rrweb'
+    needs: eslint_check_upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: eslint_report.json
       - name: Annotate Code Linting Results
         uses: ataylorme/eslint-annotate-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'
-      - name: Upload ESLint report
-        uses: actions/upload-artifact@v2
-        with:
-          name: eslint_report.json
-          path: eslint_report.json

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -31,7 +31,8 @@ jobs:
           path: eslint_report.json
 
   Annotation:
-    if: github.repository == 'rrweb-io/rrweb'
+    # Skip the annotation action in PRs from the forked repositories
+    if: github.event.pull_request.head.repo.full_name == 'rrweb-io/rrweb'
     needs: eslint_check_upload
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When using a read-only token (e.g. in a PR from a fork) the action fails with the error `Resource not accessible by integration`. related issue: https://github.com/ataylorme/eslint-annotate-action/issues/28
In this PR, I configured the annotation action to run only under our main repo so that this error could be avoided.