### PR TITLE
fix: can't record shadow root's children except the last one

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -384,7 +384,7 @@ export default class MutationBuffer {
             }
             // nextId !== -1 && parentId === -1 This branch can happen if the node is the child of shadow root
             else {
-              const nodeInShadowDom = (_node.value as Node) as HTMLElement;
+              const nodeInShadowDom = _node.value;
               // Get the host of the shadow dom and treat it as parent node.
               const shadowHost: Element | null = nodeInShadowDom.getRootNode
                 ? (nodeInShadowDom.getRootNode() as ShadowRoot)?.host

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -370,14 +370,30 @@ export default class MutationBuffer {
       }
       if (!node) {
         for (let index = addList.length - 1; index >= 0; index--) {
-          const _node = addList.get(index)!;
+          const _node = addList.get(index);
           // ensure _node is defined before attempting to find value
           if (_node) {
             const parentId = this.mirror.getId(_node.value.parentNode);
             const nextId = getNextId(_node.value);
-            if (parentId !== -1 && nextId !== -1) {
+
+            if (nextId === -1) continue;
+            // nextId !== -1 && parentId !== -1
+            else if (parentId !== -1) {
               node = _node;
               break;
+            }
+            // nextId !== -1 && parentId === -1 This branch can happen if the node is the child of shadow root
+            else {
+              const nodeInShadowDom = (_node.value as Node) as HTMLElement;
+              // Get the host of the shadow dom and treat it as parent node.
+              const shadowHost: Element | null = nodeInShadowDom.getRootNode
+                ? (nodeInShadowDom.getRootNode() as ShadowRoot)?.host
+                : null;
+              const parentId = this.mirror.getId(shadowHost);
+              if (parentId !== -1) {
+                node = _node;
+                break;
+              }
             }
           }
         }

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -12053,6 +12053,18 @@ exports[`record integration tests should record shadow DOM 1`] = `
             \\"id\\": 43,
             \\"isShadow\\": true
           }
+        },
+        {
+          \\"parentId\\": 22,
+          \\"nextId\\": 43,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"span\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"id\\": 44,
+            \\"isShadow\\": true
+          }
         }
       ]
     }
@@ -12073,7 +12085,7 @@ exports[`record integration tests should record shadow DOM 1`] = `
             \\"tagName\\": \\"p\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
-            \\"id\\": 44
+            \\"id\\": 45
           }
         }
       ]
@@ -12104,12 +12116,12 @@ exports[`record integration tests should record shadow DOM 1`] = `
       \\"removes\\": [],
       \\"adds\\": [
         {
-          \\"parentId\\": 44,
+          \\"parentId\\": 45,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"hi\\",
-            \\"id\\": 45
+            \\"id\\": 46
           }
         }
       ]
@@ -12123,18 +12135,18 @@ exports[`record integration tests should record shadow DOM 1`] = `
       \\"attributes\\": [],
       \\"removes\\": [
         {
-          \\"parentId\\": 44,
-          \\"id\\": 45
+          \\"parentId\\": 45,
+          \\"id\\": 46
         }
       ],
       \\"adds\\": [
         {
-          \\"parentId\\": 44,
+          \\"parentId\\": 45,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"123\\",
-            \\"id\\": 46
+            \\"id\\": 47
           }
         }
       ]
@@ -12149,24 +12161,24 @@ exports[`record integration tests should record shadow DOM 1`] = `
       \\"removes\\": [],
       \\"adds\\": [
         {
-          \\"parentId\\": 44,
+          \\"parentId\\": 45,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 2,
             \\"tagName\\": \\"span\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
-            \\"id\\": 47,
+            \\"id\\": 48,
             \\"isShadow\\": true
           }
         },
         {
-          \\"parentId\\": 47,
+          \\"parentId\\": 48,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"nested shadow dom\\",
-            \\"id\\": 48
+            \\"id\\": 49
           }
         }
       ]

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -561,6 +561,7 @@ describe('record integration tests', function (this: ISuite) {
 
       const el = document.querySelector('.my-element') as HTMLDivElement;
       const shadowRoot = el.shadowRoot as ShadowRoot;
+      shadowRoot.appendChild(document.createElement('span'));
       shadowRoot.appendChild(document.createElement('p'));
       sleep(1)
         .then(() => {
@@ -667,7 +668,7 @@ describe('record integration tests', function (this: ISuite) {
     const snapshots = await page.evaluate('window.snapshots');
     assertSnapshot(snapshots);
   });
-  
+
   // https://github.com/webcomponents/polyfills/tree/master/packages/shadydom
   it('should record shadow doms polyfilled by shadydom', async () => {
     const page: puppeteer.Page = await browser.newPage();

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -81,7 +81,6 @@ export const startServer = (defaultPort: number = 3030) =>
         resolve(s);
       })
       .on('error', (e) => {
-        console.log('port in use, trying next one');
         s.listen().on('listening', () => {
           resolve(s);
         });
@@ -152,14 +151,6 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
                 coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
               }
             }
-
-            // strip blob:urls as they are different every time
-            console.log(
-              a.attributes.src,
-              'src' in a.attributes &&
-                a.attributes.src &&
-                typeof a.attributes.src === 'string',
-            );
           });
           s.data.adds.forEach((add) => {
             if (add.node.type === NodeType.Element) {


### PR DESCRIPTION
PR #834 added the ability to record incremental shadow dom mutations. But I found that it has a bug: If a shadow root has more than one child, the recorder can only record the last child and other children are ignored.

In the test case, I added one more child to the shadow root, but generated snapshot of the old version rrweb didn't change at all, which means the recorder did not record that child. 

The reason is that all children except the last one of a shadow root are all added to the DoubleLinkedList in the `pushAdd` function because their siblings haven't been added yet. But while resolving these nodes in the next stage, their parentNode is the shadow root that is not in the Mirror so they are all ignored to break out the while loop. This PR adds a check for this situation.