### PR TITLE
add custom event into the counting of checkout

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -160,9 +160,12 @@ function record<T = eventWithTime>(
     if (e.type === EventType.FullSnapshot) {
       lastFullSnapshotEvent = e;
       incrementalSnapshotCount = 0;
-    } else if (e.type === EventType.IncrementalSnapshot) {
+    } else if (
+      [EventType.IncrementalSnapshot, EventType.Custom].includes(e.type)
+    ) {
       // attach iframe should be considered as full snapshot
       if (
+        e.type === EventType.IncrementalSnapshot &&
         e.data.source === IncrementalSource.Mutation &&
         e.data.isAttachIframe
       ) {


### PR DESCRIPTION
related to #958, #763

I've marked this PR as a draft because I think there are several things we can discuss.

## The benefit of counting all events into the checkout calculating

This let the behavior of checkout become more transparent and can use things like custom event and plugin to do fancy features.

But there is also a sub-question of whether we should count all the meta, load, custom, plugin events, or just part of it. For example, the current PR only count custom event because I think the custom events can be controlled by the recorder user.

## The downside of this change

1. It will break some current behavior.
2. If there is a plugin that can produce a lot of events, it may mass up things.

But we are on the schedule for v2.0, so I think it's good timing if we want to do some changes.