### PR TITLE
fix: reset fns when when stopping record

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -518,6 +518,9 @@ function record<T = eventWithTime>(
     }
     return () => {
       handlers.forEach((h) => h());
+      // reset init fns when stopping record
+      (wrappedEmit as unknown) = undefined;
+      (takeFullSnapshot as unknown) = undefined;
     };
   } catch (error) {
     // TODO: handle internal error


### PR DESCRIPTION
reset `wrappedEmit` and `takeFullSnapshot` when stopping record

https://github.com/rrweb-io/rrweb/blob/5f59f9171e481c78d08a1008186cff31a40ee199/packages/rrweb/src/record/index.ts#L528

https://github.com/rrweb-io/rrweb/blob/5f59f9171e481c78d08a1008186cff31a40ee199/packages/rrweb/src/record/index.ts#L547
