### PR TITLE
fix: record canvas by fps when blockClass is RegExp

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -141,7 +141,7 @@ export class CanvasManager {
     const getCanvas = (): HTMLCanvasElement[] => {
       const matchedCanvas: HTMLCanvasElement[] = [];
       win.document.querySelectorAll('canvas').forEach(canvas => {
-        if (!isBlocked(canvas, blockClass, false)) {
+        if (!isBlocked(canvas, blockClass, true)) {
           matchedCanvas.push(canvas);
         }
       })

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -9,6 +9,7 @@ import type {
   listenerHandler,
   CanvasArg,
 } from '../../../types';
+import { isBlocked } from '../../../utils';
 import { CanvasContext } from '../../../types';
 import initCanvas2DMutationObserver from './2d';
 import initCanvasContextObserver from './canvas';
@@ -137,6 +138,16 @@ export class CanvasManager {
     let lastSnapshotTime = 0;
     let rafId: number;
 
+    const getCanvas = (): HTMLCanvasElement[] => {
+      const matchedCanvas: HTMLCanvasElement[] = [];
+      win.document.querySelectorAll('canvas').forEach(canvas => {
+        if (!isBlocked(canvas, blockClass, false)) {
+          matchedCanvas.push(canvas);
+        }
+      })
+      return matchedCanvas;
+    };
+
     const takeCanvasSnapshots = (timestamp: DOMHighResTimeStamp) => {
       if (
         lastSnapshotTime &&
@@ -147,8 +158,7 @@ export class CanvasManager {
       }
       lastSnapshotTime = timestamp;
 
-      win.document
-        .querySelectorAll(`canvas:not(.${blockClass as string} *)`)
+      getCanvas()
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         .forEach(async (canvas: HTMLCanvasElement) => {
           const id = this.mirror.getId(canvas);


### PR DESCRIPTION
解决当 blockClass 是 RegExp 时，用 FPSObserver 不能录制 canvas 的 bug