### PR TITLE
fix: Iframe replay fails after the second full snapshot #983

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -478,13 +478,11 @@ function serializeNode(
           type: NodeType.Document,
           childNodes: [],
           compatMode: (n as Document).compatMode, // probably "BackCompat"
-          rootId,
         };
       } else {
         return {
           type: NodeType.Document,
           childNodes: [],
-          rootId,
         };
       }
     case n.DOCUMENT_TYPE_NODE:


### PR DESCRIPTION
the frame document node root id is undefined after first full snapshot, is the same as id after second full snapshot, then replay fail
