### PR TITLE
Fix inline link elements bug

### DIFF
--- a/packages/rrdom/src/index.ts
+++ b/packages/rrdom/src/index.ts
@@ -389,7 +389,12 @@ export class Mirror implements IMirror<RRNode> {
   }
 
   replace(id: number, n: RRNode) {
-    this.idNodeMap.set(id, n);
+    const oldNode = this.getNode(id);
+    if (oldNode) {
+      const meta = this.nodeMetaMap.get(oldNode);
+      if (meta) this.nodeMetaMap.set(n, meta);
+      this.idNodeMap.set(id, n);
+    }
   }
 
   reset() {

--- a/packages/rrdom/src/index.ts
+++ b/packages/rrdom/src/index.ts
@@ -393,8 +393,8 @@ export class Mirror implements IMirror<RRNode> {
     if (oldNode) {
       const meta = this.nodeMetaMap.get(oldNode);
       if (meta) this.nodeMetaMap.set(n, meta);
-      this.idNodeMap.set(id, n);
     }
+    this.idNodeMap.set(id, n);
   }
 
   reset() {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1165,7 +1165,6 @@ export function serializeNodeWithId(
       },
       stylesheetLoadTimeout,
     );
-    if (isStylesheetLoaded(n as HTMLLinkElement) === false) return null; // add stylesheet in later mutation
   }
 
   return serializedNode;

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -329,7 +329,7 @@ function record<T = eventWithTime>(
         shadowDomManager.observeAttachShadow(iframe);
       },
       onStylesheetLoad: (linkEl, childSn) => {
-        stylesheetManager.attachLinkElement(linkEl, childSn, mirror);
+        stylesheetManager.attachLinkElement(linkEl, childSn);
       },
       keepIframeSrcFn,
     });

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -324,7 +324,7 @@ export default class MutationBuffer {
           this.shadowDomManager.observeAttachShadow(iframe);
         },
         onStylesheetLoad: (link, childSn) => {
-          this.stylesheetManager.attachLinkElement(link, childSn, this.mirror);
+          this.stylesheetManager.attachLinkElement(link, childSn);
         },
       });
       if (sn) {

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -1,8 +1,9 @@
-import type { Mirror, serializedNodeWithId } from 'rrweb-snapshot';
+import type { elementNode, serializedNodeWithId } from 'rrweb-snapshot';
 import { getCssRuleString } from 'rrweb-snapshot';
 import type {
   adoptedStyleSheetCallback,
   adoptedStyleSheetParam,
+  attributeMutation,
   mutationCallBack,
 } from '../types';
 import { StyleSheetMirror } from '../utils';
@@ -24,20 +25,20 @@ export class StylesheetManager {
   public attachLinkElement(
     linkEl: HTMLLinkElement,
     childSn: serializedNodeWithId,
-    mirror: Mirror,
   ) {
-    this.mutationCb({
-      adds: [
-        {
-          parentId: mirror.getId(linkEl),
-          nextId: null,
-          node: childSn,
-        },
-      ],
-      removes: [],
-      texts: [],
-      attributes: [],
-    });
+    if ('_cssText' in (childSn as elementNode).attributes)
+      this.mutationCb({
+        adds: [],
+        removes: [],
+        texts: [],
+        attributes: [
+          {
+            id: childSn.id,
+            attributes: (childSn as elementNode)
+              .attributes as attributeMutation['attributes'],
+          },
+        ],
+      });
 
     this.trackLinkElement(linkEl);
   }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1661,12 +1661,6 @@ export class Replayer {
                     skipChild: true,
                     hackCss: true,
                     cache: this.cache,
-                    afterAppend: (node: Node | RRNode, id: number) => {
-                      for (const plugin of this.config.plugins || []) {
-                        if (plugin.onBuild)
-                          plugin.onBuild(node, { id, replayer: this });
-                      }
-                    },
                   });
                   const siblingNode = target.nextSibling;
                   const parentNode = target.parentNode;

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1654,7 +1654,10 @@ export class Replayer {
                   const newSn = mirror.getMeta(
                     target as Node & RRNode,
                   ) as serializedElementNodeWithId;
-                  newSn.attributes = mutation.attributes as attributes;
+                  Object.assign(
+                    newSn.attributes,
+                    mutation.attributes as attributes,
+                  );
                   const newNode = buildNodeWithSN(newSn, {
                     doc: target.ownerDocument as Document, // can be Document or RRDocument
                     mirror: mirror as Mirror,

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -173,9 +173,12 @@ exports[`record captures CORS stylesheets that are still loading 1`] = `
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
       \\"adds\\": [
         {
-          \\"parentId\\": 9,
+          \\"parentId\\": 4,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 2,
@@ -188,10 +191,7 @@ exports[`record captures CORS stylesheets that are still loading 1`] = `
             \\"id\\": 9
           }
         }
-      ],
-      \\"removes\\": [],
-      \\"texts\\": [],
-      \\"attributes\\": []
+      ]
     }
   }
 ]"
@@ -2007,7 +2007,19 @@ exports[`record captures stylesheets in iframes that are still loading 1`] = `
                     \\"type\\": 2,
                     \\"tagName\\": \\"head\\",
                     \\"attributes\\": {},
-                    \\"childNodes\\": [],
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"link\\",
+                        \\"attributes\\": {
+                          \\"rel\\": \\"stylesheet\\",
+                          \\"href\\": \\"blob:null\\"
+                        },
+                        \\"childNodes\\": [],
+                        \\"rootId\\": 10,
+                        \\"id\\": 13
+                      }
+                    ],
                     \\"rootId\\": 10,
                     \\"id\\": 12
                   },
@@ -2039,25 +2051,17 @@ exports[`record captures stylesheets in iframes that are still loading 1`] = `
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 0,
-      \\"adds\\": [
-        {
-          \\"parentId\\": 13,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"link\\",
-            \\"attributes\\": {
-              \\"_cssText\\": \\"body { color: pink; }\\"
-            },
-            \\"childNodes\\": [],
-            \\"rootId\\": 10,
-            \\"id\\": 13
-          }
-        }
-      ],
+      \\"adds\\": [],
       \\"removes\\": [],
       \\"texts\\": [],
-      \\"attributes\\": []
+      \\"attributes\\": [
+        {
+          \\"id\\": 13,
+          \\"attributes\\": {
+            \\"_cssText\\": \\"body { color: pink; }\\"
+          }
+        }
+      ]
     }
   }
 ]"
@@ -2286,24 +2290,42 @@ exports[`record captures stylesheets that are still loading 1`] = `
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
       \\"adds\\": [
         {
-          \\"parentId\\": 9,
+          \\"parentId\\": 4,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 2,
             \\"tagName\\": \\"link\\",
             \\"attributes\\": {
-              \\"_cssText\\": \\"body { color: pink; }\\"
+              \\"rel\\": \\"stylesheet\\",
+              \\"href\\": \\"blob:null\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 9
           }
         }
-      ],
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"adds\\": [],
       \\"removes\\": [],
       \\"texts\\": [],
-      \\"attributes\\": []
+      \\"attributes\\": [
+        {
+          \\"id\\": 9,
+          \\"attributes\\": {
+            \\"_cssText\\": \\"body { color: pink; }\\"
+          }
+        }
+      ]
     }
   }
 ]"

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -626,8 +626,11 @@ describe('record', function (this: ISuite) {
 
     // `blob:` URLs are not available immediately, so we need to wait for the browser to load them
     await waitForRAF(ctx.page);
-
-    assertSnapshot(ctx.events);
+    // 'blob' URL is different in every execution so we need to remove it from the snapshot.
+    const filteredEvents = JSON.parse(
+      JSON.stringify(ctx.events).replace(/blob\:[\w\d-/]+"/, 'blob:null"'),
+    );
+    assertSnapshot(filteredEvents);
   });
 
   it('captures stylesheets in iframes that are still loading', async () => {
@@ -659,8 +662,10 @@ describe('record', function (this: ISuite) {
 
     // `blob:` URLs are not available immediately, so we need to wait for the browser to load them
     await waitForRAF(ctx.page);
-
-    assertSnapshot(ctx.events);
+    const filteredEvents = JSON.parse(
+      JSON.stringify(ctx.events).replace(/blob\:[\w\d-/]+"/, 'blob:null"'),
+    );
+    assertSnapshot(filteredEvents);
   });
 
   it('captures CORS stylesheets that are still loading', async () => {


### PR DESCRIPTION
In PR #909, an async mechanism for inlining link elements is introduced but it still has a bug and some negative impacts on the replayer side.

### The Bug
In the stylesheet-manager.ts, when the link element loaded the styles, the manager emits an incremental mutation event to inline styles. But the mutation's parentId is wrong. https://github.com/rrweb-io/rrweb/blob/abc035fd00972c3ffa1a9cf379b46f53cb74d394/packages/rrweb/src/record/stylesheet-manager.ts#L34
As a result, the event looks like this: 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/27533910/189511629-cbb0f229-2167-41bf-b949-2b756bcab3d4.png"> https://github.com/rrweb-io/rrweb/compare/master...fix-inline-link-elements#diff-988864050cbe6d85b4cb140a06ffce65819d8967e071b175f1d27b8a864b5383L176-L189
The parentNode of the link element is itself and it can't be appended to the dom actually.

### Negative Impacts
This mechanism makes elements absent in the normal snapshot stage and causes performance issues and many warnings in the console.
Here's a diagram to explain this problem.

![explanation](https://user-images.githubusercontent.com/27533910/189512099-78120d7c-259a-4bea-9475-2e5672a99b1f.svg)

<img width="540" alt="image" src="https://user-images.githubusercontent.com/27533910/189512834-08369d55-876b-4e71-a010-7f46a44bdd9d.png">


### Changes

I built this PR based on #989 so that it contains all changes of that PR. **This PR has to get merged after #989**.
I made some changes to the current mechanism. In the snapshot stage, the unloaded Link elements will still get serialized without inline styles. After they are loaded. an incremental mutation of attributes is appended which includes an attribute `_cssText`. Its value is the inlined CSS styles. 
```ts
{
  source: IncrementalSource.Mutation,
  adds: [],
  removes: [],
  texts: [],
  attributes: [
    {
      id: 9,
      attributes: {
        _cssText: "body { color: pink; }",
      },
    },
  ],
}
```
This way, the unloaded Link elements can be inlined without causing the above-mentioned side effects.
On the replaying side, when the replayer encounters the '_cssText' attribute change and its target is the Link element, the replayer can replace the old un-inlined one with the inlined loaded Link element.
This method can make it easy to implement the TODO feature as well. https://github.com/rrweb-io/rrweb/blob/abc035fd00972c3ffa1a9cf379b46f53cb74d394/packages/rrweb/src/record/stylesheet-manager.ts#L19-L24 

This PR can also fix #981.
