### PR TITLE
Ensure positions has length before referencing

### DIFF
--- a/packages/rrweb/src/replay/timer.ts
+++ b/packages/rrweb/src/replay/timer.ts
@@ -101,7 +101,9 @@ export function addDelay(event: eventWithTime, baselineTime: number): number {
   // so we need to find the real timestamp by traverse the time offsets.
   if (
     event.type === EventType.IncrementalSnapshot &&
-    event.data.source === IncrementalSource.MouseMove
+    event.data.source === IncrementalSource.MouseMove &&
+    event.data.positions &&
+    event.data.positions.length
   ) {
     const firstOffset = event.data.positions[0].timeOffset;
     // timeOffset is a negative offset to event.timestamp


### PR DESCRIPTION
Found some replays with mouse move events that had no position data. This caused rrweb replay to throw an exception. This fix handles this scenario.