### PR TITLE
Fix that `addAction` wouldn't have any effect without a stop and start

### DIFF
--- a/packages/rrweb/src/replay/machine.ts
+++ b/packages/rrweb/src/replay/machine.ts
@@ -188,7 +188,6 @@ export function createPlayerService(
           }
 
           const syncEvents = new Array<eventWithTime>();
-          const actions = new Array<actionWithDelay>();
           for (const event of neededEvents) {
             if (
               lastPlayedTimestamp &&
@@ -202,7 +201,7 @@ export function createPlayerService(
               syncEvents.push(event);
             } else {
               const castFn = getCastFn(event, false);
-              actions.push({
+              timer.addAction({
                 doAction: () => {
                   castFn();
                 },
@@ -212,7 +211,6 @@ export function createPlayerService(
           }
           applyEventsSynchronously(syncEvents);
           emitter.emit(ReplayerEvents.Flush);
-          timer.addActions(actions);
           timer.start();
         },
         pause(ctx) {

--- a/packages/rrweb/src/replay/timer.ts
+++ b/packages/rrweb/src/replay/timer.ts
@@ -41,22 +41,21 @@ export class Timer {
   public start() {
     this.timeOffset = 0;
     let lastTimestamp = performance.now();
-    const { actions } = this;
     const check = () => {
       const time = performance.now();
       this.timeOffset += (time - lastTimestamp) * this.speed;
       lastTimestamp = time;
-      while (actions.length) {
-        const action = actions[0];
+      while (this.actions.length) {
+        const action = this.actions[0];
 
         if (this.timeOffset >= action.delay) {
-          actions.shift();
+          this.actions.shift();
           action.doAction();
         } else {
           break;
         }
       }
-      if (actions.length > 0 || this.liveMode) {
+      if (this.actions.length > 0 || this.liveMode) {
         this.raf = requestAnimationFrame(check);
       }
     };

--- a/packages/rrweb/src/replay/timer.ts
+++ b/packages/rrweb/src/replay/timer.ts
@@ -25,17 +25,17 @@ export class Timer {
     this.liveMode = config.liveMode;
   }
   /**
-   * Add an action after the timer starts.
+   * Add an action, possibly after the timer starts.
    */
   public addAction(action: actionWithDelay) {
+    if (!this.actions.length || this.actions[this.actions.length - 1].delay <= action.delay) {
+      // 'fast track'
+      this.actions.push(action);
+      return;
+    }
+    // binary search - events can arrive out of order in a realtime context
     const index = this.findActionIndex(action);
     this.actions.splice(index, 0, action);
-  }
-  /**
-   * Add all actions before the timer starts
-   */
-  public addActions(actions: actionWithDelay[]) {
-    this.actions = this.actions.concat(actions);
   }
 
   public start() {

--- a/packages/rrweb/src/replay/timer.ts
+++ b/packages/rrweb/src/replay/timer.ts
@@ -28,7 +28,10 @@ export class Timer {
    * Add an action, possibly after the timer starts.
    */
   public addAction(action: actionWithDelay) {
-    if (!this.actions.length || this.actions[this.actions.length - 1].delay <= action.delay) {
+    if (
+      !this.actions.length ||
+      this.actions[this.actions.length - 1].delay <= action.delay
+    ) {
       // 'fast track'
       this.actions.push(action);
       return;


### PR DESCRIPTION
`addActions` (not `addAction`) had a bug where it would replace `this.actions` rather than mutating it, causing the `actions` array in the `raf` loop to fail to get new actions (because it still referred to the previous incarnation of `this.actions`)

Noticed during live mode where I don't think `addActions` is actually used, so there may be another bug lurking here.