### PR TITLE
fix duplicate shadow doms in the recorder

### DIFF
--- a/packages/rrweb/scripts/stream.js
+++ b/packages/rrweb/scripts/stream.js
@@ -227,6 +227,9 @@ void (async () => {
         'window.__IS_RECORDING__',
       );
       if (!isRecording) {
+        // When the page navigates, I notice this event is emitted twice so that there are two recording processes running in a single page.
+        // Set recording flag True ASAP to prevent recording twice.
+        await recordedPage.evaluate('window.__IS_RECORDING__ = true');
         await startRecording(recordedPage, serverURL);
       }
     });

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -17,6 +17,7 @@ type BypassOptions = Omit<
 };
 
 export class ShadowDomManager {
+  private shadowDoms = new WeakSet<ShadowRoot>();
   private mutationCb: mutationCallBack;
   private scrollCb: scrollCallback;
   private bypassOptions: BypassOptions;
@@ -55,6 +56,8 @@ export class ShadowDomManager {
 
   public addShadowRoot(shadowRoot: ShadowRoot, doc: Document) {
     if (!isNativeShadowDom(shadowRoot)) return;
+    if (this.shadowDoms.has(shadowRoot)) return;
+    this.shadowDoms.add(shadowRoot);
     initMutationObserver(
       {
         ...this.bypassOptions,
@@ -106,5 +109,6 @@ export class ShadowDomManager {
 
   public reset() {
     this.restorePatches.forEach((restorePatch) => restorePatch());
+    this.shadowDoms = new WeakSet();
   }
 }


### PR DESCRIPTION
### bug description

In the recorder, some elements can be mutated and serialized multiple times. If they have attached shadow doms, these shadow doms can be also observed multiple times in the `shadow-dom-manager`. Then children of shadow doms would be created multiple times causing duplicate elements in the replayer.
For example:
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/27533910/190594139-63333c3f-ec9c-425c-ac45-e8ccbf2d52e3.png">
The original page is on the left-hand side and the problematic page is on the RHS.

I also noticed a bug in the live-stream script. When navigating a page, the recorder would be executed twice and also cause duplicate shadow doms.

### Solution

Add a set in the `shadow-dom-manager` and check each shadow root before observing them.