### PR TITLE
Add `play` to live-mode.md

### DIFF
--- a/docs/recipes/live-mode.md
+++ b/docs/recipes/live-mode.md
@@ -5,8 +5,7 @@ If you want to replay the events in a real-time way, you can use the live mode A
 When you are using rrweb's Replayer to do a real-time replay, you need to configure `liveMode: true` and call the `startLive` API to enable the live mode.
 
 ```js
-const ANY_OLD_EVENTS = [];
-const replayer = new rrweb.Replayer(ANY_OLD_EVENTS, {
+const replayer = new rrweb.Replayer([], {
   liveMode: true,
 });
 replayer.startLive();
@@ -20,7 +19,17 @@ function onReceive(event) {
 }
 ```
 
-When calling the `startLive` API, there is an optional parameter to set the baseline time. By default, this is `Date.now()` so that events are applied as soon as they come in, however this may cause your replay to look laggy. Because data transportation needs time(such as the delay of the network). And some events have been throttled(such as mouse movements) which has a delay by default.
+If you have an ongoing recording that already has events, and wish to continue play from the current/most recent position, it's also possible to use the `play` function, supplied with an offset which corresponds to the current time:
+
+```js
+const replayer = new rrweb.Replayer(EXISTING_EVENTS, {
+  liveMode: true,
+});
+replayer.play(Date.now() - EXISTING_EVENTS[0].timestamp);
+```
+
+
+When calling the `startLive` API, there is an optional parameter to set the baseline time. By default, this is `Date.now()` so that events are applied as soon as they come in, however this may cause your replay to appear laggy. Because data transportation needs time (such as the delay of the network), And some events have been throttled(such as mouse movements) which has a delay by default.
 
 Here is how you introduce a buffer:
 
@@ -30,3 +39,5 @@ replayer.startLive(Date.now() - BUFFER_MS);
 ```
 
 This will let the replay always delay 1 second than the source. If the time of data transportation is not longer than 1 second, the user will not feel laggy.
+
+The same can be done for `play` as follows: `replayer.play((Date.now() - EXISTING_EVENTS[0].timestamp) - BUFFER_MS)`


### PR DESCRIPTION
`play`  is superior in the case that there are existing events as it will utilize `discardPriorSnapshots` to skip unnecessary things.