### PR TITLE
Standardize browserslist and remove lint exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@monorepo-utils/workspaces-to-typescript-project-references": "^2.8.2",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
+    "browserslist": "^4.21.4",
     "concurrently": "^7.1.0",
     "eslint": "^8.19.0",
     "eslint-plugin-compat": "^4.0.2",
@@ -42,5 +43,9 @@
     "live-stream": "cd packages/rrweb && yarn live-stream",
     "lint": "yarn run concurrently --success=all -r -m=1 'yarn run markdownlint docs' 'yarn eslint packages/*/src --ext .ts,.tsx,.js,.jsx,.svelte'",
     "lint:report": "yarn eslint --output-file eslint_report.json --format json packages/*/src --ext .ts,.tsx,.js,.jsx"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "not op_mini all"
+  ]
 }

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -47,8 +47,5 @@
   },
   "dependencies": {
     "rrweb-snapshot": "^2.0.0-alpha.2"
-  },
-  "browserslist": [
-    "supports es6-class"
-  ]
+  }
 }

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -57,8 +57,5 @@
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
-  "homepage": "https://github.com/rrweb-io/rrweb#readme",
-  "browserslist": [
-    "supports promises and supports fullscreen"
-  ]
+  "homepage": "https://github.com/rrweb-io/rrweb#readme"
 }

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -57,9 +57,5 @@
     "ts-node": "^7.0.1",
     "tslib": "^1.9.3",
     "typescript": "^4.7.3"
-  },
-  "browserslist": [
-    "cover 98%",
-    "not ie >= 0 and not ie_mob >= 0"
-  ]
+  }
 }

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -87,8 +87,5 @@
     "mitt": "^3.0.0",
     "rrdom": "^0.1.5",
     "rrweb-snapshot": "^2.0.0-alpha.2"
-  },
-  "browserslist": [
-    "supports mutationobserver and supports es6-class and supports promises"
-  ]
+  }
 }

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -348,18 +348,14 @@ function record<T = eventWithTime>(
               window.pageXOffset !== undefined
                 ? window.pageXOffset
                 : document?.documentElement.scrollLeft ||
-                  // eslint-disable-next-line compat/compat
                   document?.body?.parentElement?.scrollLeft ||
-                  // eslint-disable-next-line compat/compat
                   document?.body?.scrollLeft ||
                   0,
             top:
               window.pageYOffset !== undefined
                 ? window.pageYOffset
                 : document?.documentElement.scrollTop ||
-                  // eslint-disable-next-line compat/compat
                   document?.body?.parentElement?.scrollTop ||
-                  // eslint-disable-next-line compat/compat
                   document?.body?.scrollTop ||
                   0,
           },

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -170,7 +170,6 @@ export class Replayer {
     const defaultConfig: playerConfig = {
       speed: 1,
       maxSpeed: 360,
-      // eslint-disable-next-line compat/compat
       root: document.body,
       loadTimeout: 0,
       skipInactive: false,
@@ -1284,7 +1283,6 @@ export class Replayer {
       }
       case IncrementalSource.Font: {
         try {
-          // eslint-disable-next-line compat/compat
           const fontFace = new FontFace(
             d.family,
             d.buffer

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -171,7 +171,6 @@ export function getWindowHeight(): number {
   return (
     window.innerHeight ||
     (document.documentElement && document.documentElement.clientHeight) ||
-    // eslint-disable-next-line compat/compat
     (document.body && document.body.clientHeight)
   );
 }
@@ -180,7 +179,6 @@ export function getWindowWidth(): number {
   return (
     window.innerWidth ||
     (document.documentElement && document.documentElement.clientWidth) ||
-    // eslint-disable-next-line compat/compat
     (document.body && document.body.clientWidth)
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3069,7 +3069,7 @@ browserslist@^4.16.6:
     node-releases "^1.1.77"
     picocolors "^0.2.1"
 
-browserslist@^4.16.8:
+browserslist@^4.16.8, browserslist@^4.21.4:
   version "4.21.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
   integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==


### PR DESCRIPTION
This PR sets all packages to a common browserslist standard. It uses `defaults` which is recommended by the browserslist project: https://github.com/browserslist/browserslist#best-practices

On thing this PR does which is against the browserslist best practices, is remove Opera Mini.
Because of how Opera Mini works most of the javascript is executed on Opera's servers and just the html is sent to the users device. This means we have an extremely restrictive environment and one I don't think we'll be able to record with rrweb anyway. So for this reason I think we should remove it from browserslist.

This pr also removes any `eslint disable` exceptions in favor of feature checking.
Unfortuneatly we can't use early returns as that isn't supported yet: https://github.com/amilajack/eslint-plugin-compat/issues/523