### PR TITLE
Add maxScale to rrwebPlayer types

### DIFF
--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -5,13 +5,50 @@ import { SvelteComponent } from 'svelte';
 export type RRwebPlayerOptions = {
   target: HTMLElement;
   props: {
+    /**
+     * The events to replay.
+     * @default `[]`
+     */
     events: eventWithTime[];
+    /**
+     * The width of the replayer
+     * @defaultValue `1024`
+     */
     width?: number;
+    /**
+     * The height of the replayer
+     * @defaultValue `576`
+     */
     height?: number;
+    /**
+     * The maximum scale of the replayer (1 = 100%). Set to 0 for unlimited
+     * @defaultValue `1`
+     */
+    maxScale?: number;
+    /**
+     * Whether to autoplay
+     * @defaultValue `true`
+     */
     autoPlay?: boolean;
+    /**
+     * The default speed to play at
+     * @defaultValue `1`
+     */
     speed?: number;
+    /**
+     * Speed options in UI
+     * @defaultValue `[1, 2, 4, 8]`
+     */
     speedOption?: number[];
+    /**
+     * Whether to show the controller UI
+     * @defaultValue `true`
+     */
     showController?: boolean;
+    /**
+     * Customize the custom events style with a key-value map
+     * @defaultValue `{}`
+     */
     tags?: Record<string, string>;
   } & Partial<playerConfig>;
 };


### PR DESCRIPTION
Turns out in PR 

Add maxScale to rrwebPlayer types.
And add some inline documentation for other options.

Turns out in https://github.com/rrweb-io/rrweb/pull/1006 I didn't add the types for max scale. Looks like I thought these would be auto-generated like the other packages but I was wrong.