### PR TITLE
Separate out window monkeypatching into an optional rrweb-init.js 

### DIFF
--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -12,6 +12,12 @@ function toRecordPath(path) {
     .replace('rrweb', 'rrweb-record');
 }
 
+function toRecordInitPath(path) {
+  return path
+    .replace(/^([\w]+)\//, '$1/record/')
+    .replace('rrweb', 'rrweb-init');
+}
+
 function toRecordPackPath(path) {
   return path
     .replace(/^([\w]+)\//, '$1/record/')
@@ -52,6 +58,12 @@ const baseConfigs = [
     name: 'rrweb',
     pathFn: toAllPath,
     esm: true,
+  },
+  // record only, early initialization
+  {
+    input: './src/entries/record-init.ts',
+    name: 'rrwebInit',
+    pathFn: toRecordInitPath,
   },
   // record only
   {

--- a/packages/rrweb/src/entries/record-init.ts
+++ b/packages/rrweb/src/entries/record-init.ts
@@ -1,0 +1,7 @@
+import { earlyPatch } from '../record/observers/canvas/canvas-manager';
+
+function rrwebInit() {
+  earlyPatch();
+  // anticipate other window patching to go here
+}
+export default rrwebInit;

--- a/packages/rrweb/src/record/observers/canvas/webgl.ts
+++ b/packages/rrweb/src/record/observers/canvas/webgl.ts
@@ -1,4 +1,3 @@
-import type { Mirror } from 'rrweb-snapshot';
 import {
   blockClass,
   CanvasContext,
@@ -16,7 +15,6 @@ function patchGLPrototype(
   cb: canvasManagerMutationCallback,
   blockClass: blockClass,
   blockSelector: string | null,
-  mirror: Mirror,
   win: IWindow,
 ): listenerHandler[] {
   const handlers: listenerHandler[] = [];
@@ -78,7 +76,6 @@ export default function initCanvasWebGLMutationObserver(
   win: IWindow,
   blockClass: blockClass,
   blockSelector: string | null,
-  mirror: Mirror,
 ): listenerHandler {
   const handlers: listenerHandler[] = [];
 
@@ -89,7 +86,6 @@ export default function initCanvasWebGLMutationObserver(
       cb,
       blockClass,
       blockSelector,
-      mirror,
       win,
     ),
   );
@@ -102,7 +98,6 @@ export default function initCanvasWebGLMutationObserver(
         cb,
         blockClass,
         blockSelector,
-        mirror,
         win,
       ),
     );

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -581,7 +581,11 @@ export type canvasMutationWithType = {
 
 export type canvasMutationCallback = (p: canvasMutationParam) => void;
 
-export type canvasMutationCallbackWithSuccess = (canvas: HTMLCanvasElement, type: CanvasContext, commands: canvasMutationCommand[]) => boolean;
+export type canvasMutationCallbackWithSuccess = (
+  canvas: HTMLCanvasElement,
+  type: CanvasContext,
+  commands: canvasMutationCommand[],
+) => boolean;
 
 export type canvasManagerMutationCallback = (
   target: HTMLCanvasElement,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -581,6 +581,8 @@ export type canvasMutationWithType = {
 
 export type canvasMutationCallback = (p: canvasMutationParam) => void;
 
+export type canvasMutationCallbackWithSuccess = (canvas: HTMLCanvasElement, type: CanvasContext, commands: canvasMutationCommand[]) => boolean;
+
 export type canvasManagerMutationCallback = (
   target: HTMLCanvasElement,
   p: canvasMutationWithType,


### PR DESCRIPTION
rrweb-init.js file is intended to be used much earlier in the page loading lifecycle (e.g. early injection from a browser extension) and which communicates with the main rrweb code via window.postMessage