### PR TITLE
fix: recording bug in youtube and bitbucket

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -266,15 +266,20 @@ export default class MutationBuffer {
       return nextId;
     };
     const pushAdd = (n: Node) => {
-      const shadowHost: Element | null = n.getRootNode
-        ? (n.getRootNode() as ShadowRoot)?.host
-        : null;
+      let shadowHost: Element | null = null;
+      if (
+        n.getRootNode?.()?.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
+        (n.getRootNode() as ShadowRoot).host
+      )
+        shadowHost = (n.getRootNode() as ShadowRoot).host;
       // If n is in a nested shadow dom.
       let rootShadowHost = shadowHost;
-      while ((rootShadowHost?.getRootNode?.() as ShadowRoot | undefined)?.host)
-        rootShadowHost =
-          (rootShadowHost?.getRootNode?.() as ShadowRoot | undefined)?.host ||
-          null;
+      while (
+        rootShadowHost?.getRootNode?.()?.nodeType ===
+          Node.DOCUMENT_FRAGMENT_NODE &&
+        (rootShadowHost.getRootNode() as ShadowRoot).host
+      )
+        rootShadowHost = (rootShadowHost.getRootNode() as ShadowRoot).host;
       // ensure contains is passed a Node, or it will throw an error
       const notInDoc =
         !this.doc.contains(n) &&


### PR DESCRIPTION
When getting shadow host elements, if the root element is an anchor element <a>, it also has a `host` property as a string. This unexpected value can crash the recorder.

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/27533910/195238574-7f713494-b259-48d7-8f69-203ee1b6ec4d.png">


This PR also fixes #941