### PR TITLE
Use a custom Window object (aka: allow injection of rrweb from an iframe)

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -160,6 +160,7 @@ The parameter of `rrweb.record` accepts the following options.
 | inlineImages         | false              | whether to record the image content                                                                                                                                                           |
 | collectFonts         | false              | whether to collect fonts in the website                                                                                                                                                       |
 | userTriggeredOnInput | false              | whether to add `userTriggered` on input events that indicates if this event was triggered directly by the user or not. [What is `userTriggered`?](https://github.com/rrweb-io/rrweb/pull/495) |
+| window               | window             | Window object to record. When rrweb is loaded from an iframe, inject here the parent `window` Element.                                                                                        |
 | plugins              | []                 | load plugins to provide extended record functions. [What is plugins?](./docs/recipes/plugin.md)                                                                                               |
 
 #### Privacy

--- a/guide.zh_CN.md
+++ b/guide.zh_CN.md
@@ -156,7 +156,7 @@ setInterval(save, 10 * 1000);
 | inlineImages         | false              | 是否将图片内容记内联录制                                                                                                                                                              |
 | collectFonts         | false              | 是否记录页面中的字体文件                                                                                                                                                              |
 | userTriggeredOnInput | false              | [什么是 `userTriggered`](https://github.com/rrweb-io/rrweb/pull/495)                                                                                                                  |
-| window               | window             |                                                                                                                                                                                |
+| window               | window             |                                                                                                                                                                                       |
 | plugins              | []                 | 加载插件以获得额外的录制功能. [什么是插件？](./docs/recipes/plugin.zh_CN.md)                                                                                                          |
 
 #### 隐私

--- a/guide.zh_CN.md
+++ b/guide.zh_CN.md
@@ -156,6 +156,7 @@ setInterval(save, 10 * 1000);
 | inlineImages         | false              | 是否将图片内容记内联录制                                                                                                                                                              |
 | collectFonts         | false              | 是否记录页面中的字体文件                                                                                                                                                              |
 | userTriggeredOnInput | false              | [什么是 `userTriggered`](https://github.com/rrweb-io/rrweb/pull/495)                                                                                                                  |
+| window               | window             |                                                                                                                                                                                |
 | plugins              | []                 | 加载插件以获得额外的录制功能. [什么是插件？](./docs/recipes/plugin.zh_CN.md)                                                                                                          |
 
 #### 隐私

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -71,6 +71,7 @@ function record<T = eventWithTime>(
     userTriggeredOnInput = false,
     collectFonts = false,
     inlineImages = false,
+    window: win = window,
     plugins,
     keepIframeSrcFn = () => false,
     ignoreCSSAttributes = new Set([]),
@@ -91,46 +92,46 @@ function record<T = eventWithTime>(
   const maskInputOptions: MaskInputOptions =
     maskAllInputs === true
       ? {
-          color: true,
-          date: true,
-          'datetime-local': true,
-          email: true,
-          month: true,
-          number: true,
-          range: true,
-          search: true,
-          tel: true,
-          text: true,
-          time: true,
-          url: true,
-          week: true,
-          textarea: true,
-          select: true,
-          password: true,
-        }
+        color: true,
+        date: true,
+        'datetime-local': true,
+        email: true,
+        month: true,
+        number: true,
+        range: true,
+        search: true,
+        tel: true,
+        text: true,
+        time: true,
+        url: true,
+        week: true,
+        textarea: true,
+        select: true,
+        password: true,
+      }
       : _maskInputOptions !== undefined
-      ? _maskInputOptions
-      : { password: true };
+        ? _maskInputOptions
+        : { password: true };
 
   const slimDOMOptions: SlimDOMOptions =
     _slimDOMOptions === true || _slimDOMOptions === 'all'
       ? {
-          script: true,
-          comment: true,
-          headFavicon: true,
-          headWhitespace: true,
-          headMetaSocial: true,
-          headMetaRobots: true,
-          headMetaHttpEquiv: true,
-          headMetaVerification: true,
-          // the following are off for slimDOMOptions === true,
-          // as they destroy some (hidden) info:
-          headMetaAuthorship: _slimDOMOptions === 'all',
-          headMetaDescKeywords: _slimDOMOptions === 'all',
-        }
+        script: true,
+        comment: true,
+        headFavicon: true,
+        headWhitespace: true,
+        headMetaSocial: true,
+        headMetaRobots: true,
+        headMetaHttpEquiv: true,
+        headMetaVerification: true,
+        // the following are off for slimDOMOptions === true,
+        // as they destroy some (hidden) info:
+        headMetaAuthorship: _slimDOMOptions === 'all',
+        headMetaDescKeywords: _slimDOMOptions === 'all',
+      }
       : _slimDOMOptions
-      ? _slimDOMOptions
-      : {};
+        ? _slimDOMOptions
+        : {};
 
   polyfill();
 
@@ -250,7 +251,7 @@ function record<T = eventWithTime>(
   canvasManager = new CanvasManager({
     recordCanvas,
     mutationCb: wrappedCanvasMutationEmit,
-    win: window,
+    win: win,
     blockClass,
     blockSelector,
     mirror,
@@ -259,6 +260,7 @@ function record<T = eventWithTime>(
   });
 
   const shadowDomManager = new ShadowDomManager({
+    win,
     mutationCb: wrappedMutationEmit,
     scrollCb: wrappedScrollEmit,
     bypassOptions: {
@@ -288,9 +290,9 @@ function record<T = eventWithTime>(
       wrapEvent({
         type: EventType.Meta,
         data: {
-          href: window.location.href,
-          width: getWindowWidth(),
-          height: getWindowHeight(),
+          href: win.location.href,
+          width: getWindowWidth(win),
+          height: getWindowHeight(win),
         },
       }),
       isCheckout,
@@ -300,7 +302,7 @@ function record<T = eventWithTime>(
     stylesheetManager.reset();
 
     mutationBuffers.forEach((buf) => buf.lock()); // don't allow any mirror modifications during snapshotting
-    const node = snapshot(document, {
+    const node = snapshot(win.document, {
       mirror,
       blockClass,
       blockSelector,
@@ -321,7 +323,7 @@ function record<T = eventWithTime>(
           stylesheetManager.trackLinkElement(n as HTMLLinkElement);
         }
         if (hasShadowRoot(n)) {
-          shadowDomManager.addShadowRoot(n.shadowRoot, document);
+          shadowDomManager.addShadowRoot(n.shadowRoot, win.document);
         }
       },
       onIframeLoad: (iframe, childSn) => {
@@ -345,19 +347,19 @@ function record<T = eventWithTime>(
           node,
           initialOffset: {
             left:
-              window.pageXOffset !== undefined
-                ? window.pageXOffset
-                : document?.documentElement.scrollLeft ||
-                  document?.body?.parentElement?.scrollLeft ||
-                  document?.body?.scrollLeft ||
-                  0,
+              win.pageXOffset !== undefined
+                ? win.pageXOffset
+                : win.document?.documentElement.scrollLeft ||
+                win.document?.body?.parentElement?.scrollLeft ||
+                win.document?.body?.scrollLeft ||
+                0,
             top:
-              window.pageYOffset !== undefined
-                ? window.pageYOffset
-                : document?.documentElement.scrollTop ||
-                  document?.body?.parentElement?.scrollTop ||
-                  document?.body?.scrollTop ||
-                  0,
+              win.pageYOffset !== undefined
+                ? win.pageYOffset
+                : win.document?.documentElement.scrollTop ||
+                win.document?.body?.parentElement?.scrollTop ||
+                win.document?.body?.scrollTop ||
+                0,
           },
         },
       }),
@@ -365,10 +367,10 @@ function record<T = eventWithTime>(
     mutationBuffers.forEach((buf) => buf.unlock()); // generate & emit any mutations that happened during snapshotting, as can now apply against the newly built mirror
 
     // Some old browsers don't support adoptedStyleSheets.
-    if (document.adoptedStyleSheets && document.adoptedStyleSheets.length > 0)
+    if (win.document.adoptedStyleSheets && win.document.adoptedStyleSheets.length > 0)
       stylesheetManager.adoptStyleSheets(
-        document.adoptedStyleSheets,
-        mirror.getId(document),
+        win.document.adoptedStyleSheets,
+        mirror.getId(win.document),
       );
   };
 
@@ -493,6 +495,7 @@ function record<T = eventWithTime>(
           inlineImages,
           userTriggeredOnInput,
           collectFonts,
+          window: win,
           doc,
           maskInputFn,
           maskTextFn,
@@ -534,11 +537,11 @@ function record<T = eventWithTime>(
 
     const init = () => {
       takeFullSnapshot();
-      handlers.push(observe(document));
+      handlers.push(observe(win.document));
     };
     if (
-      document.readyState === 'interactive' ||
-      document.readyState === 'complete'
+      win.document.readyState === 'interactive' ||
+      win.document.readyState === 'complete'
     ) {
       init();
     } else {
@@ -554,7 +557,7 @@ function record<T = eventWithTime>(
             );
             init();
           },
-          window,
+          win,
         ),
       );
     }

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -94,46 +94,46 @@ function record<T = eventWithTime>(
   const maskInputOptions: MaskInputOptions =
     maskAllInputs === true
       ? {
-        color: true,
-        date: true,
-        'datetime-local': true,
-        email: true,
-        month: true,
-        number: true,
-        range: true,
-        search: true,
-        tel: true,
-        text: true,
-        time: true,
-        url: true,
-        week: true,
-        textarea: true,
-        select: true,
-        password: true,
-      }
+          color: true,
+          date: true,
+          'datetime-local': true,
+          email: true,
+          month: true,
+          number: true,
+          range: true,
+          search: true,
+          tel: true,
+          text: true,
+          time: true,
+          url: true,
+          week: true,
+          textarea: true,
+          select: true,
+          password: true,
+        }
       : _maskInputOptions !== undefined
-        ? _maskInputOptions
-        : { password: true };
+      ? _maskInputOptions
+      : { password: true };
 
   const slimDOMOptions: SlimDOMOptions =
     _slimDOMOptions === true || _slimDOMOptions === 'all'
       ? {
-        script: true,
-        comment: true,
-        headFavicon: true,
-        headWhitespace: true,
-        headMetaSocial: true,
-        headMetaRobots: true,
-        headMetaHttpEquiv: true,
-        headMetaVerification: true,
-        // the following are off for slimDOMOptions === true,
-        // as they destroy some (hidden) info:
-        headMetaAuthorship: _slimDOMOptions === 'all',
-        headMetaDescKeywords: _slimDOMOptions === 'all',
-      }
+          script: true,
+          comment: true,
+          headFavicon: true,
+          headWhitespace: true,
+          headMetaSocial: true,
+          headMetaRobots: true,
+          headMetaHttpEquiv: true,
+          headMetaVerification: true,
+          // the following are off for slimDOMOptions === true,
+          // as they destroy some (hidden) info:
+          headMetaAuthorship: _slimDOMOptions === 'all',
+          headMetaDescKeywords: _slimDOMOptions === 'all',
+        }
       : _slimDOMOptions
-        ? _slimDOMOptions
-        : {};
+      ? _slimDOMOptions
+      : {};
 
   polyfill();
 
@@ -353,16 +353,16 @@ function record<T = eventWithTime>(
               win.pageXOffset !== undefined
                 ? win.pageXOffset
                 : win.document?.documentElement.scrollLeft ||
-                win.document?.body?.parentElement?.scrollLeft ||
-                win.document?.body?.scrollLeft ||
-                0,
+                  win.document?.body?.parentElement?.scrollLeft ||
+                  win.document?.body?.scrollLeft ||
+                  0,
             top:
               win.pageYOffset !== undefined
                 ? win.pageYOffset
                 : win.document?.documentElement.scrollTop ||
-                win.document?.body?.parentElement?.scrollTop ||
-                win.document?.body?.scrollTop ||
-                0,
+                  win.document?.body?.parentElement?.scrollTop ||
+                  win.document?.body?.scrollTop ||
+                  0,
           },
         },
       }),
@@ -370,7 +370,10 @@ function record<T = eventWithTime>(
     mutationBuffers.forEach((buf) => buf.unlock()); // generate & emit any mutations that happened during snapshotting, as can now apply against the newly built mirror
 
     // Some old browsers don't support adoptedStyleSheets.
-    if (win.document.adoptedStyleSheets && win.document.adoptedStyleSheets.length > 0)
+    if (
+      win.document.adoptedStyleSheets &&
+      win.document.adoptedStyleSheets.length > 0
+    )
       stylesheetManager.adoptStyleSheets(
         win.document.adoptedStyleSheets,
         mirror.getId(win.document),

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -25,6 +25,7 @@ import {
   scrollCallback,
   canvasMutationParam,
   adoptedStyleSheetParam,
+  IWindow,
 } from '../types';
 import { IframeManager } from './iframe-manager';
 import { ShadowDomManager } from './shadow-dom-manager';
@@ -71,11 +72,12 @@ function record<T = eventWithTime>(
     userTriggeredOnInput = false,
     collectFonts = false,
     inlineImages = false,
-    window: win = window,
+    window: _win = window,
     plugins,
     keepIframeSrcFn = () => false,
     ignoreCSSAttributes = new Set([]),
   } = options;
+  const win = (_win as unknown) as IWindow;
 
   // runtime checks for user options
   if (!emit) {
@@ -251,7 +253,7 @@ function record<T = eventWithTime>(
   canvasManager = new CanvasManager({
     recordCanvas,
     mutationCb: wrappedCanvasMutationEmit,
-    win: win,
+    win,
     blockClass,
     blockSelector,
     mirror,
@@ -281,6 +283,7 @@ function record<T = eventWithTime>(
       stylesheetManager,
       canvasManager,
       keepIframeSrcFn,
+      window: win,
     },
     mirror,
   });

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -170,6 +170,7 @@ export default class MutationBuffer {
   private inlineImages: observerParam['inlineImages'];
   private slimDOMOptions: observerParam['slimDOMOptions'];
   private dataURLOptions: observerParam['dataURLOptions'];
+  private window: observerParam['window'];
   private doc: observerParam['doc'];
   private mirror: observerParam['mirror'];
   private iframeManager: observerParam['iframeManager'];
@@ -193,6 +194,7 @@ export default class MutationBuffer {
       'inlineImages',
       'slimDOMOptions',
       'dataURLOptions',
+      'window',
       'doc',
       'mirror',
       'iframeManager',
@@ -321,7 +323,7 @@ export default class MutationBuffer {
             );
           }
           if (hasShadowRoot(n)) {
-            this.shadowDomManager.addShadowRoot(n.shadowRoot, document);
+            this.shadowDomManager.addShadowRoot(n.shadowRoot, this.window.document);
           }
         },
         onIframeLoad: (iframe, childSn) => {

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -323,7 +323,10 @@ export default class MutationBuffer {
             );
           }
           if (hasShadowRoot(n)) {
-            this.shadowDomManager.addShadowRoot(n.shadowRoot, this.window.document);
+            this.shadowDomManager.addShadowRoot(
+              n.shadowRoot,
+              this.window.document,
+            );
           }
         },
         onIframeLoad: (iframe, childSn) => {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -103,7 +103,7 @@ export function initMutationObserver(
   if (
     angularZoneSymbol &&
     ((options.window as unknown) as Record<string, typeof MutationObserver>)[
-    angularZoneSymbol
+      angularZoneSymbol
     ]
   ) {
     mutationObserverCtor = ((options.window as unknown) as Record<
@@ -187,8 +187,8 @@ function initMoveObserver({
         typeof DragEvent !== 'undefined' && evt instanceof DragEvent
           ? IncrementalSource.Drag
           : evt instanceof MouseEvent
-            ? IncrementalSource.MouseMove
-            : IncrementalSource.TouchMove,
+          ? IncrementalSource.MouseMove
+          : IncrementalSource.TouchMove,
       );
     },
     threshold,
@@ -221,7 +221,7 @@ function initMouseInteractionObserver({
   }
   const disableMap: Record<string, boolean | undefined> =
     sampling.mouseInteraction === true ||
-      sampling.mouseInteraction === undefined
+    sampling.mouseInteraction === undefined
       ? {}
       : sampling.mouseInteraction;
 
@@ -369,7 +369,7 @@ function initInputObserver({
       isChecked = (target as HTMLInputElement).checked;
     } else if (
       maskInputOptions[
-      (target as Element).tagName.toLowerCase() as keyof MaskInputOptions
+        (target as Element).tagName.toLowerCase() as keyof MaskInputOptions
       ] ||
       maskInputOptions[type as keyof MaskInputOptions]
     ) {
@@ -1131,8 +1131,8 @@ export function initObservers(
   const fontObserver = o.collectFonts
     ? initFontObserver(o)
     : () => {
-      //
-    };
+        //
+      };
   const selectionObserver = initSelectionObserver(o);
 
   // plugins

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -22,7 +22,7 @@ type BypassOptions = Omit<
 };
 
 export class ShadowDomManager {
-  private win: IWindow
+  private win: IWindow;
   private shadowDoms = new WeakSet<ShadowRoot>();
   private mutationCb: mutationCallBack;
   private scrollCb: scrollCallback;
@@ -31,7 +31,7 @@ export class ShadowDomManager {
   private restorePatches: (() => void)[] = [];
 
   constructor(options: {
-    win: IWindow,
+    win: IWindow;
     mutationCb: mutationCallBack;
     scrollCb: scrollCallback;
     bypassOptions: BypassOptions;

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -3,6 +3,7 @@ import type {
   scrollCallback,
   MutationBufferParam,
   SamplingStrategy,
+  IWindow,
 } from '../types';
 import {
   initMutationObserver,
@@ -21,6 +22,7 @@ type BypassOptions = Omit<
 };
 
 export class ShadowDomManager {
+  private win: IWindow
   private shadowDoms = new WeakSet<ShadowRoot>();
   private mutationCb: mutationCallBack;
   private scrollCb: scrollCallback;
@@ -29,11 +31,13 @@ export class ShadowDomManager {
   private restorePatches: (() => void)[] = [];
 
   constructor(options: {
+    win: IWindow,
     mutationCb: mutationCallBack;
     scrollCb: scrollCallback;
     bypassOptions: BypassOptions;
     mirror: Mirror;
   }) {
+    this.win = options.win;
     this.mutationCb = options.mutationCb;
     this.scrollCb = options.scrollCb;
     this.bypassOptions = options.bypassOptions;
@@ -65,6 +69,7 @@ export class ShadowDomManager {
     initMutationObserver(
       {
         ...this.bypassOptions,
+        window: this.win,
         doc,
         mutationCb: this.mutationCb,
         mirror: this.mirror,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -102,9 +102,9 @@ export type mutationData = {
 
 export type mousemoveData = {
   source:
-    | IncrementalSource.MouseMove
-    | IncrementalSource.TouchMove
-    | IncrementalSource.Drag;
+  | IncrementalSource.MouseMove
+  | IncrementalSource.TouchMove
+  | IncrementalSource.Drag;
   positions: mousePosition[];
 };
 
@@ -263,6 +263,7 @@ export type recordOptions<T> = {
   userTriggeredOnInput?: boolean;
   collectFonts?: boolean;
   inlineImages?: boolean;
+  window?: IWindow;
   plugins?: RecordPlugin[];
   // departed, please use sampling options
   mousemoveWait?: number;
@@ -299,6 +300,7 @@ export type observerParam = {
   collectFonts: boolean;
   slimDOMOptions: SlimDOMOptions;
   dataURLOptions: DataURLOptions;
+  window: IWindow,
   doc: Document;
   mirror: Mirror;
   iframeManager: IframeManager;
@@ -333,6 +335,7 @@ export type MutationBufferParam = Pick<
   | 'inlineImages'
   | 'slimDOMOptions'
   | 'dataURLOptions'
+  | 'window'
   | 'doc'
   | 'mirror'
   | 'iframeManager'
@@ -462,26 +465,26 @@ export enum CanvasContext {
 
 export type SerializedCanvasArg =
   | {
-      rr_type: 'ArrayBuffer';
-      base64: string; // base64
-    }
+    rr_type: 'ArrayBuffer';
+    base64: string; // base64
+  }
   | {
-      rr_type: 'Blob';
-      data: Array<CanvasArg>;
-      type?: string;
-    }
+    rr_type: 'Blob';
+    data: Array<CanvasArg>;
+    type?: string;
+  }
   | {
-      rr_type: string;
-      src: string; // url of image
-    }
+    rr_type: string;
+    src: string; // url of image
+  }
   | {
-      rr_type: string;
-      args: Array<CanvasArg>;
-    }
+    rr_type: string;
+    args: Array<CanvasArg>;
+  }
   | {
-      rr_type: string;
-      index: number;
-    };
+    rr_type: string;
+    index: number;
+  };
 
 export type CanvasArg =
   | SerializedCanvasArg
@@ -566,14 +569,14 @@ export type canvasMutationCommand = {
 
 export type canvasMutationParam =
   | {
-      id: number;
-      type: CanvasContext;
-      commands: canvasMutationCommand[];
-    }
+    id: number;
+    type: CanvasContext;
+    commands: canvasMutationCommand[];
+  }
   | ({
-      id: number;
-      type: CanvasContext;
-    } & canvasMutationCommand);
+    id: number;
+    type: CanvasContext;
+  } & canvasMutationCommand);
 
 export type canvasMutationWithType = {
   type: CanvasContext;
@@ -596,15 +599,15 @@ export type ImageBitmapDataURLWorkerParams = {
 
 export type ImageBitmapDataURLWorkerResponse =
   | {
-      id: number;
-    }
+    id: number;
+  }
   | {
-      id: number;
-      type: string;
-      base64: string;
-      width: number;
-      height: number;
-    };
+    id: number;
+    type: string;
+    base64: string;
+    width: number;
+    height: number;
+  };
 
 export type fontParam = {
   family: string;
@@ -722,13 +725,13 @@ export type playerConfig = {
   UNSAFE_replayCanvas: boolean;
   pauseAnimation?: boolean;
   mouseTail:
-    | boolean
-    | {
-        duration?: number;
-        lineCap?: string;
-        lineWidth?: number;
-        strokeStyle?: string;
-      };
+  | boolean
+  | {
+    duration?: number;
+    lineCap?: string;
+    lineWidth?: number;
+    strokeStyle?: string;
+  };
   unpackFn?: UnpackFn;
   useVirtualDom: boolean;
   plugins?: ReplayPlugin[];

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -263,7 +263,7 @@ export type recordOptions<T> = {
   userTriggeredOnInput?: boolean;
   collectFonts?: boolean;
   inlineImages?: boolean;
-  window?: IWindow;
+  window?: Window;
   plugins?: RecordPlugin[];
   // departed, please use sampling options
   mousemoveWait?: number;

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -102,9 +102,9 @@ export type mutationData = {
 
 export type mousemoveData = {
   source:
-  | IncrementalSource.MouseMove
-  | IncrementalSource.TouchMove
-  | IncrementalSource.Drag;
+    | IncrementalSource.MouseMove
+    | IncrementalSource.TouchMove
+    | IncrementalSource.Drag;
   positions: mousePosition[];
 };
 
@@ -300,7 +300,7 @@ export type observerParam = {
   collectFonts: boolean;
   slimDOMOptions: SlimDOMOptions;
   dataURLOptions: DataURLOptions;
-  window: IWindow,
+  window: IWindow;
   doc: Document;
   mirror: Mirror;
   iframeManager: IframeManager;
@@ -465,26 +465,26 @@ export enum CanvasContext {
 
 export type SerializedCanvasArg =
   | {
-    rr_type: 'ArrayBuffer';
-    base64: string; // base64
-  }
+      rr_type: 'ArrayBuffer';
+      base64: string; // base64
+    }
   | {
-    rr_type: 'Blob';
-    data: Array<CanvasArg>;
-    type?: string;
-  }
+      rr_type: 'Blob';
+      data: Array<CanvasArg>;
+      type?: string;
+    }
   | {
-    rr_type: string;
-    src: string; // url of image
-  }
+      rr_type: string;
+      src: string; // url of image
+    }
   | {
-    rr_type: string;
-    args: Array<CanvasArg>;
-  }
+      rr_type: string;
+      args: Array<CanvasArg>;
+    }
   | {
-    rr_type: string;
-    index: number;
-  };
+      rr_type: string;
+      index: number;
+    };
 
 export type CanvasArg =
   | SerializedCanvasArg
@@ -569,14 +569,14 @@ export type canvasMutationCommand = {
 
 export type canvasMutationParam =
   | {
-    id: number;
-    type: CanvasContext;
-    commands: canvasMutationCommand[];
-  }
+      id: number;
+      type: CanvasContext;
+      commands: canvasMutationCommand[];
+    }
   | ({
-    id: number;
-    type: CanvasContext;
-  } & canvasMutationCommand);
+      id: number;
+      type: CanvasContext;
+    } & canvasMutationCommand);
 
 export type canvasMutationWithType = {
   type: CanvasContext;
@@ -599,15 +599,15 @@ export type ImageBitmapDataURLWorkerParams = {
 
 export type ImageBitmapDataURLWorkerResponse =
   | {
-    id: number;
-  }
+      id: number;
+    }
   | {
-    id: number;
-    type: string;
-    base64: string;
-    width: number;
-    height: number;
-  };
+      id: number;
+      type: string;
+      base64: string;
+      width: number;
+      height: number;
+    };
 
 export type fontParam = {
   family: string;
@@ -725,13 +725,13 @@ export type playerConfig = {
   UNSAFE_replayCanvas: boolean;
   pauseAnimation?: boolean;
   mouseTail:
-  | boolean
-  | {
-    duration?: number;
-    lineCap?: string;
-    lineWidth?: number;
-    strokeStyle?: string;
-  };
+    | boolean
+    | {
+        duration?: number;
+        lineCap?: string;
+        lineWidth?: number;
+        strokeStyle?: string;
+      };
   unpackFn?: UnpackFn;
   useVirtualDom: boolean;
   plugins?: ReplayPlugin[];

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -110,16 +110,16 @@ export function hookSetter<T>(
     isRevoked
       ? d
       : {
-        set(value) {
-          // put hooked setter into event loop to avoid of set latency
-          setTimeout(() => {
-            d.set!.call(this, value);
-          }, 0);
-          if (original && original.set) {
-            original.set.call(this, value);
-          }
+          set(value) {
+            // put hooked setter into event loop to avoid of set latency
+            setTimeout(() => {
+              d.set!.call(this, value);
+            }, 0);
+            if (original && original.set) {
+              original.set.call(this, value);
+            }
+          },
         },
-      },
   );
   return () => hookSetter(target, key, original || {}, true);
 }
@@ -170,7 +170,8 @@ export function patch(
 export function getWindowHeight(win: Window): number {
   return (
     win.innerHeight ||
-    (win.document.documentElement && win.document.documentElement.clientHeight) ||
+    (win.document.documentElement &&
+      win.document.documentElement.clientHeight) ||
     (win.document.body && win.document.body.clientHeight)
   );
 }
@@ -178,7 +179,8 @@ export function getWindowHeight(win: Window): number {
 export function getWindowWidth(win: Window): number {
   return (
     win.innerWidth ||
-    (win.document.documentElement && win.document.documentElement.clientWidth) ||
+    (win.document.documentElement &&
+      win.document.documentElement.clientWidth) ||
     (win.document.body && win.document.body.clientWidth)
   );
 }
@@ -371,10 +373,10 @@ export function isSerializedStylesheet<TNode extends Node | RRNode>(
 ): boolean {
   return Boolean(
     n.nodeName === 'LINK' &&
-    n.nodeType === n.ELEMENT_NODE &&
-    (n as HTMLElement).getAttribute &&
-    (n as HTMLElement).getAttribute('rel') === 'stylesheet' &&
-    mirror.getMeta(n),
+      n.nodeType === n.ELEMENT_NODE &&
+      (n as HTMLElement).getAttribute &&
+      (n as HTMLElement).getAttribute('rel') === 'stylesheet' &&
+      mirror.getMeta(n),
   );
 }
 
@@ -444,7 +446,7 @@ export function uniqueTextMutations(mutations: textMutation[]): textMutation[] {
   const idSet = new Set<number>();
   const uniqueMutations: textMutation[] = [];
 
-  for (let i = mutations.length; i--;) {
+  for (let i = mutations.length; i--; ) {
     const mutation = mutations[i];
     if (!idSet.has(mutation.id)) {
       uniqueMutations.push(mutation);

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -110,16 +110,16 @@ export function hookSetter<T>(
     isRevoked
       ? d
       : {
-          set(value) {
-            // put hooked setter into event loop to avoid of set latency
-            setTimeout(() => {
-              d.set!.call(this, value);
-            }, 0);
-            if (original && original.set) {
-              original.set.call(this, value);
-            }
-          },
+        set(value) {
+          // put hooked setter into event loop to avoid of set latency
+          setTimeout(() => {
+            d.set!.call(this, value);
+          }, 0);
+          if (original && original.set) {
+            original.set.call(this, value);
+          }
         },
+      },
   );
   return () => hookSetter(target, key, original || {}, true);
 }
@@ -167,19 +167,19 @@ export function patch(
   }
 }
 
-export function getWindowHeight(): number {
+export function getWindowHeight(win: Window): number {
   return (
-    window.innerHeight ||
-    (document.documentElement && document.documentElement.clientHeight) ||
-    (document.body && document.body.clientHeight)
+    win.innerHeight ||
+    (win.document.documentElement && win.document.documentElement.clientHeight) ||
+    (win.document.body && win.document.body.clientHeight)
   );
 }
 
-export function getWindowWidth(): number {
+export function getWindowWidth(win: Window): number {
   return (
-    window.innerWidth ||
-    (document.documentElement && document.documentElement.clientWidth) ||
-    (document.body && document.body.clientWidth)
+    win.innerWidth ||
+    (win.document.documentElement && win.document.documentElement.clientWidth) ||
+    (win.document.body && win.document.body.clientWidth)
   );
 }
 
@@ -371,10 +371,10 @@ export function isSerializedStylesheet<TNode extends Node | RRNode>(
 ): boolean {
   return Boolean(
     n.nodeName === 'LINK' &&
-      n.nodeType === n.ELEMENT_NODE &&
-      (n as HTMLElement).getAttribute &&
-      (n as HTMLElement).getAttribute('rel') === 'stylesheet' &&
-      mirror.getMeta(n),
+    n.nodeType === n.ELEMENT_NODE &&
+    (n as HTMLElement).getAttribute &&
+    (n as HTMLElement).getAttribute('rel') === 'stylesheet' &&
+    mirror.getMeta(n),
   );
 }
 
@@ -444,7 +444,7 @@ export function uniqueTextMutations(mutations: textMutation[]): textMutation[] {
   const idSet = new Set<number>();
   const uniqueMutations: textMutation[] = [];
 
-  for (let i = mutations.length; i--; ) {
+  for (let i = mutations.length; i--;) {
     const mutation = mutations[i];
     if (!idSet.has(mutation.id)) {
       uniqueMutations.push(mutation);

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -1,5 +1,172 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`be loaded from an iframe captures activity in outer frame 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [],
+                \\"id\\": 3
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"input\\",
+                    \\"attributes\\": {
+                      \\"type\\": \\"text\\",
+                      \\"size\\": \\"40\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"iframe\\",
+                    \\"attributes\\": {
+                      \\"srcdoc\\": \\"<div>rrweb loaded in here!</div>\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n        </body>\\\\n      </html>\\\\n    \\",
+                        \\"id\\": 9
+                      }
+                    ],
+                    \\"id\\": 8
+                  }
+                ],
+                \\"id\\": 4
+              }
+            ],
+            \\"id\\": 2
+          }
+        ],
+        \\"compatMode\\": \\"BackCompat\\",
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"adds\\": [
+        {
+          \\"parentId\\": 8,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 0,
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"html\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"head\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [],
+                    \\"rootId\\": 10,
+                    \\"id\\": 12
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"body\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"div\\",
+                        \\"attributes\\": {},
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"rrweb loaded in here!\\",
+                            \\"rootId\\": 10,
+                            \\"id\\": 15
+                          }
+                        ],
+                        \\"rootId\\": 10,
+                        \\"id\\": 14
+                      }
+                    ],
+                    \\"rootId\\": 10,
+                    \\"id\\": 13
+                  }
+                ],
+                \\"rootId\\": 10,
+                \\"id\\": 11
+              }
+            ],
+            \\"id\\": 10
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"isAttachIframe\\": true
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 6
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"a\\",
+      \\"isChecked\\": false,
+      \\"id\\": 6
+    }
+  }
+]"
+`;
+
 exports[`record can add custom event 1`] = `
 "[
   {

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -927,14 +927,13 @@ describe('be loaded from an iframe', function (this: ISuite) {
     });
 
     expect(await ctx.page.evaluate('typeof rrweb')).toEqual('undefined');
-    await ctx.page.type('input', 'a');  // ensuring that typing in outer gets recorded by inner rrweb
+    await ctx.page.type('input', 'a'); // ensuring that typing in outer gets recorded by inner rrweb
 
     expect(ctx.events.length).toEqual(5);
 
     expect(
-      ctx.events.filter(
-        (event: eventWithTime) => event.type === EventType.Meta,
-      ).length,
+      ctx.events.filter((event: eventWithTime) => event.type === EventType.Meta)
+        .length,
     ).toEqual(1);
 
     expect(


### PR DESCRIPTION
First, thanks for this awesome project 👏 

Currently, rrweb does not allow recording a user session from an iframe. This is a bit annoying for those who run rrweb in a third-party tool injected as a Javascript tag.

I would like to suggest a different implementation of #294.

#294 offers to look up the top `Window` object on the current page. This is a good start, but I would rather let the developer choose what `Window` HTML Element is the best: `window` or `window.top` or `window.parent` or `window.parent.parent.[...]` or `document.querySelector('iframe').contentWindow`...

PS: can anybody translate the doc to Chinese? :pray:
