### PR TITLE
Improve contributor experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,18 @@ We actively welcome your pull requests.
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
+## Run locally
+
+- Install dependencies: `yarn`
+- Run recorder on a website: `yarn repl`
+- Run a cobrowsing/mirroring session locally: `yarn live-stream`
+- Test: `yarn test` or `yarn test:watch`
+- Lint: `yarn lint`
+
+## Coding style
+
+See [documentation](docs/development/coding-style.md)
+
 ## License
 
 rrweb is [MIT licensed](https://github.com/rrweb-io/rrweb/blob/master/LICENSE).

--- a/packages/rrweb/scripts/repl.js
+++ b/packages/rrweb/scripts/repl.js
@@ -21,7 +21,7 @@ void (async () => {
   const code = getCode();
   let events = [];
 
-  await start();
+  await start('https://react-redux.realworld.io');
 
   const fakeGoto = async (page, url) => {
     const intercept = async (request) => {
@@ -38,16 +38,20 @@ void (async () => {
     page.off('request', intercept);
   };
 
-  async function start() {
+  async function start(defaultURL) {
     events = [];
-    const { url } = await inquirer.prompt([
+    let { url } = await inquirer.prompt([
       {
         type: 'input',
         name: 'url',
         message:
-          'Enter the url you want to record, e.g https://react-redux.realworld.io: ',
+          `Enter the url you want to record, e.g [${defaultURL}]: `,
       },
     ]);
+
+    if (url === '') {
+      url = defaultURL;
+    }
 
     console.log(`Going to open ${url}...`);
     await record(url);
@@ -92,7 +96,7 @@ void (async () => {
     ]);
 
     if (shouldRecordAnother) {
-      start();
+      start(url);
     } else {
       process.exit();
     }
@@ -207,9 +211,9 @@ void (async () => {
     <script>
       /*<!--*/
       const events = ${JSON.stringify(events).replace(
-        /<\/script>/g,
-        '<\\/script>',
-      )};
+      /<\/script>/g,
+      '<\\/script>',
+    )};
       /*-->*/
       const replayer = new rrweb.Replayer(events, {
         UNSAFE_replayCanvas: true


### PR DESCRIPTION
Hi there,

I'm adding some documentation for helping contributors get into the project.

Also adding an improvement to the "repl" script:
- when running the script in a loop, it defaults to the same URL instead of `https://react-redux.realworld.io`
- just type `<enter>` to fall back on the default URL instead of copy-pasting `https://react-redux.realworld.io` into the prompt
