### PR TITLE
Update Player.svelte: fix the bug.

### DIFF
--- a/packages/rrweb-player/src/Player.svelte
+++ b/packages/rrweb-player/src/Player.svelte
@@ -24,7 +24,7 @@
   export let tags: Record<string, string> = {};
 
   let replayer: Replayer;
-  
+
   export const getMirror = () => replayer.getMirror();
 
   const controllerHeight = 80;
@@ -59,8 +59,7 @@
     const scale = [widthScale, heightScale];
     if (maxScale) scale.push(maxScale);
     el.style.transform =
-      `scale(${Math.min(...scale)})` +
-      'translate(-50%, -50%)';
+      `scale(${Math.min(...scale)})` + 'translate(-50%, -50%)';
   };
 
   export const triggerResize = () => {
@@ -124,7 +123,7 @@
     afterHook: undefined | (() => void) = undefined,
   ) => {
     controller.playRange(timeOffset, endTimeOffset, startLooping, afterHook);
-  };  
+  };
 
   onMount(() => {
     // runtime type check
@@ -168,7 +167,8 @@
           _width = width;
           _height = height;
           width = player.offsetWidth;
-          height = player.offsetHeight;
+          height =
+            player.offsetHeight - (showController ? controllerHeight : 0);
           updateScale(replayer.wrapper, {
             width: replayer.iframe.offsetWidth,
             height: replayer.iframe.offsetHeight,
@@ -229,6 +229,7 @@
       {speedOption}
       {skipInactive}
       {tags}
-      on:fullscreen={() => toggleFullscreen()} />
+      on:fullscreen={() => toggleFullscreen()}
+    />
   {/if}
 </div>


### PR DESCRIPTION
# Before fixing the bug:
In full-screen mode, there is no progress bar or control panel.
Bugs appear in browsers: Chrome, Safari and Edge.
![3491666005407_ pic](https://user-images.githubusercontent.com/55265314/196165924-a43a6ef1-1313-44a0-af8d-88bb567111ee.jpg)

# Causes of bugs and repair ideas:
By checking the component code, the height of the content under the rr-player__frame tag is incorrectly calculated in full-screen mode, causing bugs to occur when the progress bar and control bar are rendered off-screen under the rr-controller tag. Fix the bug by modifying the way tag height is calculated.
![3501666005410_ pic](https://user-images.githubusercontent.com/55265314/196165943-050731bb-7222-4776-a195-085109f28f2e.jpg)

# After the bug fix:
In full-screen mode, the progress bar and control bar can be displayed under the playback screen normally.
![3511666005414_ pic](https://user-images.githubusercontent.com/55265314/196165975-14ca0b3b-f342-4ff7-ab4d-0cd6638eae5e.jpg)

Close #801.