### PR TITLE
Fix: isBlocked throws on invalid element

### DIFF
--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -213,7 +213,7 @@ export function isBlocked(
     if (classMatchesRegex(el, blockClass, checkAncestors)) return true;
   }
   if (blockSelector) {
-    if ((node as HTMLElement).matches(blockSelector)) return true;
+    if (el.matches(blockSelector)) return true;
     if (checkAncestors && el.closest(blockSelector) !== null) return true;
   }
   return false;


### PR DESCRIPTION
If node is not an HTML element, matches throws an error. Use el instead.