### PR TITLE
Implement: Inactive activity indicator on progress bar 

### DIFF
--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -24,6 +24,7 @@
   export let speedOption: number[];
   export let speed = speedOption.length ? speedOption[0] : 1;
   export let tags: Record<string, string> = {};
+  export let inactiveColor: string;
 
   let currentTime = 0;
   $: {
@@ -128,7 +129,7 @@
       };
       return periods.map((period) => ({
         name: 'inactive period',
-        background: 'rgb(212 212 212)',
+        background: inactiveColor,
         position: `${position(start, end, period[0])}%`,
         width: `${getWidth(start, end, period[0], period[1])}%`,
       }));

--- a/packages/rrweb-player/src/Player.svelte
+++ b/packages/rrweb-player/src/Player.svelte
@@ -22,6 +22,8 @@
   export let speed = 1;
   export let showController = true;
   export let tags: Record<string, string> = {};
+  // color of inactive periods indicator
+  export let inactiveColor = '#D4D4D4';
 
   let replayer: Replayer;
 
@@ -229,6 +231,7 @@
       {speedOption}
       {skipInactive}
       {tags}
+      {inactiveColor}
       on:fullscreen={() => toggleFullscreen()}
     />
   {/if}

--- a/packages/rrweb-player/src/utils.ts
+++ b/packages/rrweb-player/src/utils.ts
@@ -15,6 +15,9 @@ declare global {
   }
 }
 
+import { EventType, IncrementalSource } from 'rrweb';
+import type { eventWithTime } from 'rrweb/typings/types';
+
 export function inlineCss(cssObj: Record<string, string>): string {
   let style = '';
   Object.keys(cssObj).forEach((key) => {
@@ -140,4 +143,41 @@ export function typeOf(
   };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
   return map[toString.call(obj)];
+}
+
+/**
+ * Forked from 'rrweb' replay/index.ts. The original function is not exported.
+ * Determine whether the event is a user interaction event
+ * @param event - event to be determined
+ * @returns true if the event is a user interaction event
+ */
+function isUserInteraction(event: eventWithTime): boolean {
+  if (event.type !== EventType.IncrementalSnapshot) {
+    return false;
+  }
+  return (
+    event.data.source > IncrementalSource.Mutation &&
+    event.data.source <= IncrementalSource.Input
+  );
+}
+
+// Forked from 'rrweb' replay/index.ts. A const threshold of inactive time.
+const SKIP_TIME_THRESHOLD = 10 * 1000;
+
+/**
+ * Get periods of time when no user interaction happened from a list of events.
+ * @param events - all events
+ * @returns periods of time consist with [start time, end time]
+ */
+export function getInactivePeriods(events: eventWithTime[]) {
+  const inactivePeriods: [number, number][] = [];
+  let lastActiveTime = events[0].timestamp;
+  for (const event of events) {
+    if (!isUserInteraction(event)) continue;
+    if (event.timestamp - lastActiveTime > SKIP_TIME_THRESHOLD) {
+      inactivePeriods.push([lastActiveTime, event.timestamp]);
+    }
+    lastActiveTime = event.timestamp;
+  }
+  return inactivePeriods;
 }

--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -50,6 +50,11 @@ export type RRwebPlayerOptions = {
      * @defaultValue `{}`
      */
     tags?: Record<string, string>;
+    /**
+     * Customize the color of inactive periods indicator in the progress bar with a valid CSS color string.
+     * @defaultValue `#D4D4D4`
+     */
+    inactiveColor?: string;
   } & Partial<playerConfig>;
 };
 


### PR DESCRIPTION
# Before implementing this feature: 

There was no way to view which part of the replay is inactive.  
![before](https://user-images.githubusercontent.com/82929929/198828816-ea550049-7346-49e7-8a27-99fca9938949.jpg)

# After implementing this feature: 

The part of progress bar that contains non-active user behavior becomes gray so that the user can choose to skip it or not. We have created a function to detect inactive events or cycles and added a div tag to the progress bar within a cycle as an indicator 
![after](https://user-images.githubusercontent.com/82929929/198828840-a41c61c7-16fd-4712-ac07-700119cb00ac.jpg)

# Demonstration video:

The screen on the left is the previous replayer, the one on the right is latest replayer after implementing this feature:

https://user-images.githubusercontent.com/82929929/198828965-1b157b57-d719-400c-9825-3233d6dd410f.mp4



close #621 