### PR TITLE
fix: bug when handling shadow doms

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -394,15 +394,20 @@ export default class MutationBuffer {
             }
             // nextId !== -1 && parentId === -1 This branch can happen if the node is the child of shadow root
             else {
-              const nodeInShadowDom = _node.value;
-              // Get the host of the shadow dom and treat it as parent node.
-              const shadowHost: Element | null = nodeInShadowDom.getRootNode
-                ? (nodeInShadowDom.getRootNode() as ShadowRoot)?.host
-                : null;
-              const parentId = this.mirror.getId(shadowHost);
-              if (parentId !== -1) {
-                node = _node;
-                break;
+              const unhandledNode = _node.value;
+              // If the node is the direct child of a shadow root, we treat the shadow host as its parent node.
+              if (
+                unhandledNode.parentNode &&
+                unhandledNode.parentNode.nodeType ===
+                  Node.DOCUMENT_FRAGMENT_NODE
+              ) {
+                const shadowHost = (unhandledNode.parentNode as ShadowRoot)
+                  .host;
+                const parentId = this.mirror.getId(shadowHost);
+                if (parentId !== -1) {
+                  node = _node;
+                  break;
+                }
               }
             }
           }


### PR DESCRIPTION
## Bug
On the website https://mixpanel.com/project/2195193/view/139237/app/dashboards#id=3679845, the bottom chart makes the recorder crash (in an infinite loop)

### How to reproduce:
1. Create an account and log in
2. goto the website and start recording
3. scroll down to the bottom of the page
4. when the chart is loaded, the whole browser would freeze (fall into an infinite loop)
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/27533910/199014744-60ae868d-d679-4aba-b5da-6cddf3778efb.png">

### How to fix:

The chart is an SVG inside a shadow dom. The complicated dom structure raises a corner case for the recording code of shadow dom #956. In this case, the unhandled node is not a direct child of the shadow host and its parent node is not supposed to be the shadow host element. So I add code to check whether the unhandled node is a direct child of shadow dom or not. I tried to reproduce this through a simplified test case but I failed.