### PR TITLE
Fix: Post message can break cross origin iframe recording

### DIFF
--- a/packages/rrweb/src/plugins/canvas-webrtc/record/index.ts
+++ b/packages/rrweb/src/plugins/canvas-webrtc/record/index.ts
@@ -262,10 +262,12 @@ export class RRWebPluginCanvasWebRTCRecord {
   }
 
   private isCrossOriginIframeMessageEventContent(
-    event: MessageEvent,
+    event: MessageEvent<unknown>,
   ): event is MessageEvent<CrossOriginIframeMessageEventContent> {
     return Boolean(
-      'type' in event.data &&
+      event.data &&
+        typeof event.data === 'object' &&
+        'type' in event.data &&
         'data' in event.data &&
         (event.data as CrossOriginIframeMessageEventContent).type ===
           'rrweb-canvas-webrtc' &&


### PR DESCRIPTION
Codepen does a bunch of postmessage calls which can break rrweb's cross origin iframe recording.
This PR is a little more strict when handling MessageEvents