### PR TITLE
Handle errors when observing iframes

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -565,7 +565,12 @@ function record<T = eventWithTime>(
     };
 
     iframeManager.addLoadListener((iframeEl) => {
-      handlers.push(observe(iframeEl.contentDocument!));
+      try {
+        handlers.push(observe(iframeEl.contentDocument!));
+      } catch (error) {
+        // TODO: handle internal error
+        console.warn(error);
+      }
     });
 
     const init = () => {


### PR DESCRIPTION
Currently, any errors in setting up the observers etc. are caught and logged out via `console.warn`. However, when the setup is done for any iframes, they are not caught. This can lead to errors popping up for users when e.g. some iframe have a weird setup.

This PR ensures the handling is the same for setting up observers in iframes.

Closes https://github.com/rrweb-io/rrweb/issues/1057