### PR TITLE
Fix muted not being set correctly

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1216,13 +1216,13 @@ export class Replayer {
         }
         const mediaEl = target as HTMLMediaElement | RRMediaElement;
         try {
-          if (d.currentTime) {
+          if (d.currentTime !== undefined) {
             mediaEl.currentTime = d.currentTime;
           }
-          if (d.volume) {
+          if (d.volume !== undefined) {
             mediaEl.volume = d.volume;
           }
-          if (d.muted) {
+          if (d.muted !== undefined) {
             mediaEl.muted = d.muted;
           }
           if (d.type === MediaInteractions.Pause) {


### PR DESCRIPTION
Since muted is a boolean, checking `d.muted` to see if property is defined or not fails for when `d.muted` is defined but set to false. Explicitly check for undefined instead. Also applies to `currentTime` and `volume`