### PR TITLE
Export `recordOptions` types

### DIFF
--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -10,6 +10,10 @@ export {
   ReplayerEvents,
 } from '@rrweb/types';
 
+export type {
+  recordOptions,
+} from './types';
+
 const { addCustomEvent } = record;
 const { freezePage } = record;
 


### PR DESCRIPTION
It would be very helpful to have `recordingOptions` properly exported. As of now, this is not part of `entries/all.d.ts`, which is generated, and is thus tree shaken away.

See https://github.com/getsentry/sentry-javascript/pull/6448

Note to self: `eventWithTime` can be imported from `@rrweb/types` in v2.