### PR TITLE
fix: do not assume event listeners are passive

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -196,9 +196,9 @@ function initMoveObserver({
     },
   );
   const handlers = [
-    on('mousemove', updatePosition, doc),
-    on('touchmove', updatePosition, doc),
-    on('drag', updatePosition, doc),
+    on('mousemove', updatePosition, doc, false),
+    on('touchmove', updatePosition, doc, false),
+    on('drag', updatePosition, doc, false),
   ];
   return () => {
     handlers.forEach((h) => h());

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -17,8 +17,13 @@ export function on(
   type: string,
   fn: EventListenerOrEventListenerObject,
   target: Document | IWindow = document,
+  isPassive?: boolean,
 ): listenerHandler {
-  const options = { capture: true };
+  const options: AddEventListenerOptions = {
+    capture: true,
+    passive: isPassive ?? true,
+  };
+
   target.addEventListener(type, fn, options);
   return () => target.removeEventListener(type, fn, options);
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -18,7 +18,7 @@ export function on(
   fn: EventListenerOrEventListenerObject,
   target: Document | IWindow = document,
 ): listenerHandler {
-  const options = { capture: true, passive: true };
+  const options = { capture: true };
   target.addEventListener(type, fn, options);
   return () => target.removeEventListener(type, fn, options);
 }


### PR DESCRIPTION
Without this rrweb interferes with the behavior of the `onPointermove` listener of the standard drag and drop Angular component, which calls `preventDefault` internally.

To reproduce, compare the console logs of `yarn repl` on `https://v7.material.angular.io/cdk/drag-drop/overview`:

- on master: https://www.loom.com/share/ce576beab57c4b0a9a29073b59af9ebb
- with this change: https://www.loom.com/share/880381abb15f42009b21536b94f4184b

This has already been reported as an issue for session recorders like Logrocket:

https://github.com/angular/components/issues/24979