### PR TITLE
fix: module error

### DIFF
--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -15,7 +15,7 @@
     "rrdom-nodejs"
   ],
   "license": "MIT",
-  "main": "lib/rrdom-nodejs.js",
+  "main": "lib/rrdom-nodejs.cjs",
   "module": "es/rrdom-nodejs.js",
   "typings": "es",
   "files": [

--- a/packages/rrdom/jest.config.js
+++ b/packages/rrdom/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
 };

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.7",
   "homepage": "https://github.com/rrweb-io/rrweb/tree/main/packages/rrdom#readme",
   "license": "MIT",
-  "main": "lib/rrdom.js",
+  "main": "lib/rrdom.cjs",
   "module": "es/rrdom.js",
   "typings": "es",
   "unpkg": "dist/rrdom.js",
@@ -13,6 +13,7 @@
     "es",
     "typings"
   ],
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rrweb-io/rrweb.git"

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -37,7 +37,7 @@
     "lint": "yarn eslint src/**/*.ts"
   },
   "description": "rrweb's replayer UI",
-  "main": "lib/index.js",
+  "main": "lib/index.cjs",
   "module": "dist/index.mjs",
   "unpkg": "dist/index.js",
   "files": [
@@ -46,6 +46,7 @@
     "typings"
   ],
   "typings": "typings/index.d.ts",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rrweb-io/rrweb.git"

--- a/packages/rrweb-snapshot/jest.config.js
+++ b/packages/rrweb-snapshot/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/**.test.ts'],

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -14,6 +14,7 @@
     "prepublish": "npm run typings && npm run bundle",
     "lint": "yarn eslint src"
   },
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rrweb-io/rrweb.git"
@@ -23,7 +24,7 @@
     "snapshot",
     "DOM"
   ],
-  "main": "lib/rrweb-snapshot.js",
+  "main": "lib/rrweb-snapshot.cjs",
   "module": "es/rrweb-snapshot.js",
   "unpkg": "dist/rrweb-snapshot.js",
   "typings": "typings/index.d.ts",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -27,7 +27,7 @@
   "keywords": [
     "rrweb"
   ],
-  "main": "lib/rrweb-all.js",
+  "main": "lib/rrweb-all.cjs",
   "module": "es/rrweb/packages/rrweb/src/entries/all.js",
   "unpkg": "dist/rrweb.js",
   "sideEffects": false,

--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -186,7 +186,7 @@ for (const c of baseConfigs) {
     output: [
       {
         format: 'cjs',
-        file: c.pathFn('lib/rrweb.js'),
+        file: c.pathFn('lib/rrweb.cjs'),
       },
     ],
   });


### PR DESCRIPTION
Fix #1056 

### Reason
In #976, a property `type: "module"` was added to the package.json. When it is set to "module", the type field allows a package to specify all .js files within are ES modules. If the "type" field is omitted or set to "commonjs", all .js files are treated as CommonJS. So all scripts under rrweb/lib/** are treated as esm format by JS bundlers unexpectedly.

### Fix
Change all suffixes of bundled scripts with commonjs module from 'js' to cjs.

### ⚠️Breaking Change⚠️:
The file suffix of all scripts under rrweb/lib/* is changed from **js** to **cjs**. This may cause programs that import rrweb through CDN links to fail.
