### PR TITLE
feat: Guard against missing `window.CSSStyleSheet`

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -536,6 +536,13 @@ function initStyleSheetObserver(
   { styleSheetRuleCb, mirror, stylesheetManager }: observerParam,
   { win }: { win: IWindow },
 ): listenerHandler {
+  if (!win.CSSStyleSheet || !win.CSSStyleSheet.prototype) {
+    // If, for whatever reason, CSSStyleSheet is not available, we skip the observation of stylesheets.
+    return () => {
+      // Do nothing
+    };
+  }
+
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const insertRule = win.CSSStyleSheet.prototype.insertRule;
   win.CSSStyleSheet.prototype.insertRule = function (


### PR DESCRIPTION
We get a lot of reports from users of sentry that seem to originate from browsers where `window.CSSStyleSheet` is not available. See e.g. https://github.com/getsentry/sentry-javascript/issues/6534

This adds a simple guard that skips stylesheet observing when this is not defined.