### PR TITLE
improve rrdom robustness

### DIFF
--- a/packages/rrdom/src/document.ts
+++ b/packages/rrdom/src/document.ts
@@ -204,6 +204,12 @@ export function BaseRRDocumentImpl<
     public readonly RRNodeType = RRNodeType.Document;
     public textContent: string | null = null;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...args: any[]) {
+      super(args);
+      this.ownerDocument = this;
+    }
+
     public get documentElement(): IRRElement | null {
       return (
         (this.childNodes.find(
@@ -258,6 +264,7 @@ export function BaseRRDocumentImpl<
       }
       childNode.parentElement = null;
       childNode.parentNode = this;
+      childNode.ownerDocument = this.ownerDocument;
       this.childNodes.push(childNode);
       return childNode;
     }
@@ -285,6 +292,7 @@ export function BaseRRDocumentImpl<
       this.childNodes.splice(childIndex, 0, newChild);
       newChild.parentElement = null;
       newChild.parentNode = this;
+      newChild.ownerDocument = this.ownerDocument;
       return newChild;
     }
 
@@ -522,6 +530,7 @@ export function BaseRRElementImpl<
       this.childNodes.push(newChild);
       newChild.parentNode = this;
       newChild.parentElement = this;
+      newChild.ownerDocument = this.ownerDocument;
       return newChild;
     }
 
@@ -535,6 +544,7 @@ export function BaseRRElementImpl<
       this.childNodes.splice(childIndex, 0, newChild);
       newChild.parentElement = this;
       newChild.parentNode = this;
+      newChild.ownerDocument = this.ownerDocument;
       return newChild;
     }
 

--- a/packages/rrdom/test/diff.test.ts
+++ b/packages/rrdom/test/diff.test.ts
@@ -1060,7 +1060,15 @@ describe('diff algorithm for rrdom', () => {
       } as serializedNodeWithId;
       mirror.add(unreliableChild, unreliableSN);
       parentNode.appendChild(unreliableChild);
-      mirror.add(document.createElement('div'), { ...unreliableSN, id: 2 });
+      createTree(
+        {
+          tagName: 'div',
+          id: 2,
+          children: [],
+        },
+        undefined,
+        mirror,
+      );
 
       const rrParentNode = createTree(
         {

--- a/packages/rrdom/test/diff.test.ts
+++ b/packages/rrdom/test/diff.test.ts
@@ -1283,7 +1283,7 @@ describe('diff algorithm for rrdom', () => {
        * If the selector match is case insensitive, it will cause some CSS style problems in the replayer.
        * This test result executed in JSDom is different from that in real browser so we use puppeteer as test environment.
        */
-      let browser = await puppeteer.launch();
+      const browser = await puppeteer.launch();
       const page = await browser.newPage();
       await page.goto('about:blank');
 

--- a/packages/rrdom/test/diff.test.ts
+++ b/packages/rrdom/test/diff.test.ts
@@ -1124,6 +1124,8 @@ describe('diff algorithm for rrdom', () => {
   });
 
   describe('diff iframe elements', () => {
+    jest.setTimeout(60_000);
+
     it('should add an element to the contentDocument of an iframe element', () => {
       document.write('<html></html>');
       const node = document.createElement('iframe');

--- a/packages/rrdom/test/document.test.ts
+++ b/packages/rrdom/test/document.test.ts
@@ -133,7 +133,7 @@ describe('Basic RRDocument implementation', () => {
       expect(node.parentElement).toEqual(null);
       expect(node.childNodes).toBeInstanceOf(Array);
       expect(node.childNodes.length).toBe(0);
-      expect(node.ownerDocument).toBeUndefined();
+      expect(node.ownerDocument).toBe(node);
       expect(node.textContent).toBeNull();
       expect(node.RRNodeType).toBe(RRNodeType.Document);
       expect(node.nodeType).toBe(document.nodeType);

--- a/packages/rrdom/test/utils.ts
+++ b/packages/rrdom/test/utils.ts
@@ -1,0 +1,26 @@
+import * as rollup from 'rollup';
+import * as typescript from 'rollup-plugin-typescript2';
+import resolve from '@rollup/plugin-node-resolve';
+const _typescript = (typescript as unknown) as typeof typescript.default;
+
+/**
+ * Use rollup to compile an input TS script into JS code string.
+ */
+export async function compileTSCode(inputFilePath: string) {
+  const bundle = await rollup.rollup({
+    input: inputFilePath,
+    plugins: [
+      (resolve() as unknown) as rollup.Plugin,
+      (_typescript({
+        tsconfigOverride: { compilerOptions: { module: 'ESNext' } },
+      }) as unknown) as rollup.Plugin,
+    ],
+  });
+  const {
+    output: [{ code: _code }],
+  } = await bundle.generate({
+    name: 'rrdom',
+    format: 'iife',
+  });
+  return _code;
+}

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -230,6 +230,11 @@ export class Replayer {
             else if (data.source === IncrementalSource.StyleDeclaration)
               this.applyStyleDeclaration(data, styleSheet);
           },
+          afterAppend: (node: Node, id: number) => {
+            for (const plugin of this.config.plugins || []) {
+              if (plugin.onBuild) plugin.onBuild(node, { id, replayer: this });
+            }
+          },
         };
         if (this.iframe.contentDocument)
           try {
@@ -863,6 +868,8 @@ export class Replayer {
         );
       }
 
+      // Skip the plugin onBuild callback in the virtual dom mode
+      if (this.usingVirtualDom) return;
       for (const plugin of this.config.plugins || []) {
         if (plugin.onBuild)
           plugin.onBuild(builtNode, {
@@ -1480,6 +1487,8 @@ export class Replayer {
         return;
       }
       const afterAppend = (node: Node | RRNode, id: number) => {
+        // Skip the plugin onBuild callback for virtual dom
+        if (this.usingVirtualDom) return;
         for (const plugin of this.config.plugins || []) {
           if (plugin.onBuild) plugin.onBuild(node, { id, replayer: this });
         }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -231,13 +231,18 @@ export class Replayer {
               this.applyStyleDeclaration(data, styleSheet);
           },
         };
-        this.iframe.contentDocument &&
-          diff(
-            this.iframe.contentDocument,
-            this.virtualDom,
-            replayerHandler,
-            this.virtualDom.mirror,
-          );
+        if (this.iframe.contentDocument)
+          try {
+            diff(
+              this.iframe.contentDocument,
+              this.virtualDom,
+              replayerHandler,
+              this.virtualDom.mirror,
+            );
+          } catch (e) {
+            console.warn(e);
+          }
+
         this.virtualDom.destroyTree();
         this.usingVirtualDom = false;
 


### PR DESCRIPTION
To improve the robustness of the virtual-dom implementation imported in #853 and fix some common errors such as #1042

Changes:
1. Add node type check in the diff function
   Now node matching doesn't only rely on the equality of serialized Ids
2. Fix a wired style problem in iframes
https://rrwebdebug.com/play/index.html?url=https%3A%2F%2Fgist.github.com%2FMark-Fenng%2Fdd95c2246c948ac1bda1c67336210fb1&version=1.0.0-alpha.4&play=on
<img width="757" alt="image" src="https://user-images.githubusercontent.com/27533910/216062380-c7372394-5ede-4285-a994-213136f5ac39.png">
<img width="764" alt="image" src="https://user-images.githubusercontent.com/27533910/216063480-07906a31-5929-4cc8-8ce3-9d46c8fa4d16.png">

Thanks for @pdwittig 's really helpful events
This bug is because class selector matching in auto-mounted iframes is case-insensitive.

3. fix #1065 including a test case
4. add `afterAppend` hook to the diff function
    fix: virtual nodes are passed to plugin's onBuild callback
   
@bhavitsharma Could you please also review this PR in case I'm missing anything important? Since you have followed some related problems and you are also familiar with the code.