### PR TITLE
fix: regression of issue: ShadowHost can't be a string (issue 941)

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -27,6 +27,7 @@ import {
   isSerializedIframe,
   isSerializedStylesheet,
   inDom,
+  getShadowHost,
 } from '../utils';
 
 type DoubleLinkedListNode = {
@@ -268,18 +269,11 @@ export default class MutationBuffer {
       return nextId;
     };
     const pushAdd = (n: Node) => {
-      let shadowHost: Element | null = null;
-      if (
-        n.getRootNode?.()?.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
-        (n.getRootNode() as ShadowRoot).host
-      )
-        shadowHost = (n.getRootNode() as ShadowRoot).host;
-
       if (!n.parentNode || !inDom(n)) {
         return;
       }
       const parentId = isShadowRoot(n.parentNode)
-        ? this.mirror.getId(shadowHost)
+        ? this.mirror.getId(getShadowHost(n))
         : this.mirror.getId(n.parentNode);
       const nextId = getNextId(n);
       if (parentId === -1 || nextId === -1) {

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -519,13 +519,12 @@ export class StyleSheetMirror {
   }
 }
 
-export function getRootShadowHost(n: Node): Node | null {
-  const shadowHost = (n.getRootNode() as ShadowRoot).host;
-  // If n is in a nested shadow dom.
-  let rootShadowHost = shadowHost;
+export function getRootShadowHost(n: Node): Node {
+  let rootShadowHost: Node = n;
 
+  // If n is in a nested shadow dom.
   while (
-    rootShadowHost?.getRootNode?.()?.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
+    rootShadowHost.getRootNode?.()?.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
     (rootShadowHost.getRootNode() as ShadowRoot).host
   )
     rootShadowHost = (rootShadowHost.getRootNode() as ShadowRoot).host;
@@ -537,7 +536,7 @@ export function shadowHostInDom(n: Node): boolean {
   const doc = n.ownerDocument;
   if (!doc) return false;
   const shadowHost = getRootShadowHost(n);
-  return Boolean(shadowHost && doc.contains(shadowHost));
+  return doc.contains(shadowHost);
 }
 
 export function inDom(n: Node): boolean {

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -519,15 +519,29 @@ export class StyleSheetMirror {
   }
 }
 
+/**
+ * Get the direct shadow host of a node in shadow dom. Returns null if it is not in a shadow dom.
+ */
+export function getShadowHost(n: Node): Element | null {
+  let shadowHost: Element | null = null;
+  if (
+    n.getRootNode?.()?.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
+    (n.getRootNode() as ShadowRoot).host
+  )
+    shadowHost = (n.getRootNode() as ShadowRoot).host;
+  return shadowHost;
+}
+
+/**
+ * Get the root shadow host of a node in nested shadow doms. Returns the node itself if it is not in a shadow dom.
+ */
 export function getRootShadowHost(n: Node): Node {
   let rootShadowHost: Node = n;
 
+  let shadowHost: Element | null;
   // If n is in a nested shadow dom.
-  while (
-    rootShadowHost.getRootNode?.()?.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
-    (rootShadowHost.getRootNode() as ShadowRoot).host
-  )
-    rootShadowHost = (rootShadowHost.getRootNode() as ShadowRoot).host;
+  while ((shadowHost = getShadowHost(rootShadowHost)))
+    rootShadowHost = shadowHost;
 
   return rootShadowHost;
 }

--- a/packages/rrweb/test/util.test.ts
+++ b/packages/rrweb/test/util.test.ts
@@ -6,6 +6,7 @@ import {
   StyleSheetMirror,
   inDom,
   shadowHostInDom,
+  getShadowHost,
 } from '../src/utils';
 
 describe('Utilities for other modules', () => {
@@ -91,12 +92,14 @@ describe('Utilities for other modules', () => {
       shadowRoot.appendChild(shadowHost2);
       shadowRoot2.appendChild(div);
       // Not in Dom yet.
+      expect(getShadowHost(div)).toBe(shadowHost2);
       expect(getRootShadowHost(div)).toBe(shadowHost);
       expect(shadowHostInDom(div)).toBeFalsy();
       expect(inDom(div)).toBeFalsy();
 
       // Added to the Dom.
       document.body.appendChild(shadowHost);
+      expect(getShadowHost(div)).toBe(shadowHost2);
       expect(getRootShadowHost(div)).toBe(shadowHost);
       expect(shadowHostInDom(div)).toBeTruthy();
       expect(inDom(div)).toBeTruthy();
@@ -105,12 +108,14 @@ describe('Utilities for other modules', () => {
     it('should get correct result given a normal node', () => {
       const div = document.createElement('div');
       // Not in Dom yet.
+      expect(getShadowHost(div)).toBeNull();
       expect(getRootShadowHost(div)).toBe(div);
       expect(shadowHostInDom(div)).toBeFalsy();
       expect(inDom(div)).toBeFalsy();
 
       // Added to the Dom.
       document.body.appendChild(div);
+      expect(getShadowHost(div)).toBeNull();
       expect(getRootShadowHost(div)).toBe(div);
       expect(shadowHostInDom(div)).toBeTruthy();
       expect(inDom(div)).toBeTruthy();
@@ -125,12 +130,14 @@ describe('Utilities for other modules', () => {
       a.href = 'example.com';
       a.textContent = 'something';
       // Not in Dom yet.
+      expect(getShadowHost(a.childNodes[0])).toBeNull();
       expect(getRootShadowHost(a.childNodes[0])).toBe(a.childNodes[0]);
       expect(shadowHostInDom(a.childNodes[0])).toBeFalsy();
       expect(inDom(a.childNodes[0])).toBeFalsy();
 
       // Added to the Dom.
       document.body.appendChild(a);
+      expect(getShadowHost(a.childNodes[0])).toBeNull();
       expect(getRootShadowHost(a.childNodes[0])).toBe(a.childNodes[0]);
       expect(shadowHostInDom(a.childNodes[0])).toBeTruthy();
       expect(inDom(a.childNodes[0])).toBeTruthy();


### PR DESCRIPTION
### Bug
<img width="683" alt="image" src="https://user-images.githubusercontent.com/27533910/212243402-bac0687c-81e9-448a-90ff-7ba4854114e6.png">
This PR is to fix a bug which is a regression of #941.
The original one has been fixed but imported again in #1049 

### Reason
Given the text node of a detached HTMLAnchorElement, getRootNode() will return the anchor element itself and its host property is a string.
<img width="289" alt="image" src="https://user-images.githubusercontent.com/27533910/212246341-072b06fd-082f-4eeb-a1fe-708bc0daf91e.png">

### Fix
The fix is like #1020. I added unit tests to cover all key codes and I hope this bug won't show up anymore.