### PR TITLE
fix: wrong rootId value in special iframes

### DIFF
--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -1,5 +1,5 @@
 import type { Mirror, serializedNodeWithId } from 'rrweb-snapshot';
-import { genId } from 'rrweb-snapshot';
+import { genId, NodeType } from 'rrweb-snapshot';
 import type { CrossOriginIframeMessageEvent } from '../types';
 import CrossOriginIframeMirror from './cross-origin-iframe-mirror';
 import { EventType, IncrementalSource } from '@rrweb/types';
@@ -14,6 +14,10 @@ export class IframeManager {
   > = new WeakMap();
   public crossOriginIframeMirror = new CrossOriginIframeMirror(genId);
   public crossOriginIframeStyleMirror: CrossOriginIframeMirror;
+  public crossOriginIframeRootIdMap: WeakMap<
+    HTMLIFrameElement,
+    number
+  > = new WeakMap();
   private mirror: Mirror;
   private mutationCb: mutationCallBack;
   private wrappedEmit: (e: eventWithTime, isCheckout?: boolean) => void;
@@ -121,6 +125,9 @@ export class IframeManager {
          * Replaces the original id of the iframe with a new set of unique ids
          */
         this.replaceIdOnNode(e.data.node, iframeEl);
+        const rootId = e.data.node.id;
+        this.crossOriginIframeRootIdMap.set(iframeEl, rootId);
+        this.patchRootIdOnNode(e.data.node, rootId);
         return {
           timestamp: e.timestamp,
           type: EventType.IncrementalSnapshot,
@@ -171,6 +178,8 @@ export class IframeManager {
                 'previousId',
               ]);
               this.replaceIdOnNode(n.node, iframeEl);
+              const rootId = this.crossOriginIframeRootIdMap.get(iframeEl);
+              rootId && this.patchRootIdOnNode(n.node, rootId);
             });
             e.data.removes.forEach((n) => {
               this.replaceIds(n, iframeEl, ['parentId', 'id']);
@@ -273,10 +282,19 @@ export class IframeManager {
     node: serializedNodeWithId,
     iframeEl: HTMLIFrameElement,
   ) {
-    this.replaceIds(node, iframeEl, ['id']);
+    this.replaceIds(node, iframeEl, ['id', 'rootId']);
     if ('childNodes' in node) {
       node.childNodes.forEach((child) => {
         this.replaceIdOnNode(child, iframeEl);
+      });
+    }
+  }
+
+  private patchRootIdOnNode(node: serializedNodeWithId, rootId: number) {
+    if (node.type !== NodeType.Document && !node.rootId) node.rootId = rootId;
+    if ('childNodes' in node) {
+      node.childNodes.forEach((child) => {
+        this.patchRootIdOnNode(child, rootId);
       });
     }
   }

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Page } from 'puppeteer';
-import type { eventWithTime, recordOptions } from '../../src/types';
+import type { eventWithTime } from '@rrweb/types';
+import type { recordOptions } from '../../src/types';
 import { startServer, launchPuppeteer, ISuite, getServerURL } from '../utils';
 
 const suites: Array<

--- a/packages/rrweb/test/benchmark/replay-fast-forward.test.ts
+++ b/packages/rrweb/test/benchmark/replay-fast-forward.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { eventWithTime, recordOptions } from '../../src/types';
+import type { eventWithTime } from '@rrweb/types';
+import type { recordOptions } from '../../src/types';
 import { launchPuppeteer, ISuite } from '../utils';
 
 const suites: Array<{

--- a/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
+++ b/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
@@ -106,6 +106,7 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -123,6 +124,7 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       },
                       {
@@ -132,11 +134,13 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           \\"charset\\": \\"UTF-8\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 16
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 17
                       },
                       {
@@ -147,11 +151,13 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           \\"content\\": \\"IE=edge\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
@@ -162,11 +168,13 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           \\"content\\": \\"width=device-width, initial-scale=1.0\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 20
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 21
                       },
                       {
@@ -177,14 +185,17 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"Audio\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 23
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 22
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
@@ -197,17 +208,21 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 25
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\",
+                    \\"rootId\\": 11,
                     \\"id\\": 27
                   },
                   {
@@ -218,6 +233,7 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 29
                       },
                       {
@@ -228,14 +244,17 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"1 minute of silence\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 30
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       },
                       {
@@ -250,6 +269,7 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 34
                           },
                           {
@@ -260,25 +280,31 @@ exports[`cross origin iframes audio.html should emit contents of iframe once 1`]
                               \\"type\\": \\"audio/mpeg\\"
                             },
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 35
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      Your browser does not support the audio element.\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 36
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 33
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 37
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 28
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -428,12 +454,15 @@ exports[`cross origin iframes blank.html should filter out forwarded cross origi
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 15
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 14
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 13
                   },
                   {
@@ -444,12 +473,15 @@ exports[`cross origin iframes blank.html should filter out forwarded cross origi
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 17
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 16
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 12
               }
             ],
@@ -480,6 +512,7 @@ exports[`cross origin iframes blank.html should filter out forwarded cross origi
             \\"tagName\\": \\"iframe\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 18
           }
         }
@@ -517,12 +550,15 @@ exports[`cross origin iframes blank.html should filter out forwarded cross origi
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 19,
                             \\"id\\": 23
                           }
                         ],
+                        \\"rootId\\": 19,
                         \\"id\\": 22
                       }
                     ],
+                    \\"rootId\\": 19,
                     \\"id\\": 21
                   },
                   {
@@ -533,12 +569,259 @@ exports[`cross origin iframes blank.html should filter out forwarded cross origi
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n\\\\n\\",
+                        \\"rootId\\": 19,
                         \\"id\\": 25
                       }
                     ],
+                    \\"rootId\\": 19,
                     \\"id\\": 24
                   }
                 ],
+                \\"rootId\\": 19,
+                \\"id\\": 20
+              }
+            ],
+            \\"compatMode\\": \\"BackCompat\\",
+            \\"id\\": 19
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"isAttachIframe\\": true
+    }
+  }
+]"
+`;
+
+exports[`cross origin iframes blank.html should record same-origin iframe in cross-origin iframe 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {
+                      \\"type\\": \\"\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 6
+                      }
+                    ],
+                    \\"id\\": 5
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\",
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"iframe\\",
+                    \\"attributes\\": {
+                      \\"rr_src\\": \\"http://localhost:3030/html/blank.html\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n      \\\\n    \\\\n  \\",
+                    \\"id\\": 10
+                  }
+                ],
+                \\"id\\": 7
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"adds\\": [
+        {
+          \\"parentId\\": 9,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 0,
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"html\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"head\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"script\\",
+                        \\"attributes\\": {
+                          \\"type\\": \\"\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 15
+                          }
+                        ],
+                        \\"rootId\\": 11,
+                        \\"id\\": 14
+                      }
+                    ],
+                    \\"rootId\\": 11,
+                    \\"id\\": 13
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"body\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n\\\\n\\",
+                        \\"rootId\\": 11,
+                        \\"id\\": 17
+                      }
+                    ],
+                    \\"rootId\\": 11,
+                    \\"id\\": 16
+                  }
+                ],
+                \\"rootId\\": 11,
+                \\"id\\": 12
+              }
+            ],
+            \\"compatMode\\": \\"BackCompat\\",
+            \\"id\\": 11
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"isAttachIframe\\": true
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 16,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"iframe\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"rootId\\": 11,
+            \\"id\\": 18
+          }
+        }
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"adds\\": [
+        {
+          \\"parentId\\": 18,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 0,
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"html\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"head\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [],
+                    \\"rootId\\": 19,
+                    \\"id\\": 21
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"body\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"Same-origin iframe in cross-origin iframe\\",
+                        \\"rootId\\": 19,
+                        \\"id\\": 23
+                      }
+                    ],
+                    \\"rootId\\": 19,
+                    \\"id\\": 22
+                  }
+                ],
+                \\"rootId\\": 19,
                 \\"id\\": 20
               }
             ],
@@ -679,12 +962,15 @@ exports[`cross origin iframes blank.html should support packFn option in record(
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 15
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 14
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 13
                   },
                   {
@@ -695,12 +981,15 @@ exports[`cross origin iframes blank.html should support packFn option in record(
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 17
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 16
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 12
               }
             ],
@@ -826,6 +1115,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -843,6 +1133,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       },
                       {
@@ -852,11 +1143,13 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           \\"charset\\": \\"UTF-8\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 16
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 17
                       },
                       {
@@ -867,11 +1160,13 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           \\"content\\": \\"width=device-width, initial-scale=1.0\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
@@ -882,11 +1177,13 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           \\"content\\": \\"ie=edge\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 20
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 21
                       },
                       {
@@ -897,14 +1194,17 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"form fields\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 23
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 22
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
@@ -917,17 +1217,21 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 25
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n\\\\n  \\",
+                    \\"rootId\\": 11,
                     \\"id\\": 27
                   },
                   {
@@ -938,6 +1242,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 29
                       },
                       {
@@ -948,6 +1253,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           },
                           {
@@ -960,6 +1266,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 33
                               },
                               {
@@ -969,19 +1276,23 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   \\"type\\": \\"text\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 34
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 35
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 32
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 36
                           },
                           {
@@ -992,6 +1303,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 38
                               },
                               {
@@ -1003,19 +1315,23 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   \\"value\\": \\"on\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 39
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 40
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 37
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 41
                           },
                           {
@@ -1026,6 +1342,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 43
                               },
                               {
@@ -1038,19 +1355,23 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   \\"checked\\": true
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 44
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 45
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 42
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 46
                           },
                           {
@@ -1063,6 +1384,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 48
                               },
                               {
@@ -1072,19 +1394,23 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   \\"type\\": \\"checkbox\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 49
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 50
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 51
                           },
                           {
@@ -1097,6 +1423,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 53
                               },
                               {
@@ -1109,19 +1436,23 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   \\"rows\\": \\"10\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 54
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 55
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 52
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 56
                           },
                           {
@@ -1134,6 +1465,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 58
                               },
                               {
@@ -1148,6 +1480,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 60
                                   },
                                   {
@@ -1161,14 +1494,17 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                       {
                                         \\"type\\": 3,
                                         \\"textContent\\": \\"1\\",
+                                        \\"rootId\\": 11,
                                         \\"id\\": 62
                                       }
                                     ],
+                                    \\"rootId\\": 11,
                                     \\"id\\": 61
                                   },
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 63
                                   },
                                   {
@@ -1181,30 +1517,37 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                       {
                                         \\"type\\": 3,
                                         \\"textContent\\": \\"2\\",
+                                        \\"rootId\\": 11,
                                         \\"id\\": 65
                                       }
                                     ],
+                                    \\"rootId\\": 11,
                                     \\"id\\": 64
                                   },
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"\\\\n        \\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 66
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 59
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 67
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 57
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 68
                           },
                           {
@@ -1217,6 +1560,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 70
                               },
                               {
@@ -1226,33 +1570,41 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                   \\"type\\": \\"password\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 71
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 72
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 73
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 30
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 74
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 28
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -1757,6 +2109,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -1774,6 +2127,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       },
                       {
@@ -1783,11 +2137,13 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           \\"charset\\": \\"UTF-8\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 16
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 17
                       },
                       {
@@ -1798,11 +2154,13 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           \\"content\\": \\"width=device-width, initial-scale=1.0\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
@@ -1813,11 +2171,13 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           \\"content\\": \\"ie=edge\\"
                         },
                         \\"childNodes\\": [],
+                        \\"rootId\\": 11,
                         \\"id\\": 20
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 21
                       },
                       {
@@ -1828,14 +2188,17 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"form fields\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 23
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 22
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
@@ -1848,17 +2211,21 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 25
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n\\\\n  \\",
+                    \\"rootId\\": 11,
                     \\"id\\": 27
                   },
                   {
@@ -1869,6 +2236,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 29
                       },
                       {
@@ -1879,6 +2247,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           },
                           {
@@ -1891,6 +2260,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 33
                               },
                               {
@@ -1900,19 +2270,23 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   \\"type\\": \\"text\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 34
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 35
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 32
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 36
                           },
                           {
@@ -1923,6 +2297,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 38
                               },
                               {
@@ -1934,19 +2309,23 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   \\"value\\": \\"on\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 39
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 40
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 37
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 41
                           },
                           {
@@ -1957,6 +2336,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 43
                               },
                               {
@@ -1969,19 +2349,23 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   \\"checked\\": true
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 44
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 45
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 42
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 46
                           },
                           {
@@ -1994,6 +2378,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 48
                               },
                               {
@@ -2003,19 +2388,23 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   \\"type\\": \\"checkbox\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 49
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 50
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 51
                           },
                           {
@@ -2028,6 +2417,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 53
                               },
                               {
@@ -2040,19 +2430,23 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   \\"rows\\": \\"10\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 54
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 55
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 52
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 56
                           },
                           {
@@ -2065,6 +2459,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 58
                               },
                               {
@@ -2079,6 +2474,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 60
                                   },
                                   {
@@ -2092,14 +2488,17 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                       {
                                         \\"type\\": 3,
                                         \\"textContent\\": \\"1\\",
+                                        \\"rootId\\": 11,
                                         \\"id\\": 62
                                       }
                                     ],
+                                    \\"rootId\\": 11,
                                     \\"id\\": 61
                                   },
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 63
                                   },
                                   {
@@ -2112,30 +2511,37 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                       {
                                         \\"type\\": 3,
                                         \\"textContent\\": \\"2\\",
+                                        \\"rootId\\": 11,
                                         \\"id\\": 65
                                       }
                                     ],
+                                    \\"rootId\\": 11,
                                     \\"id\\": 64
                                   },
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"\\\\n        \\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 66
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 59
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 67
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 57
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 68
                           },
                           {
@@ -2148,6 +2554,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 70
                               },
                               {
@@ -2157,33 +2564,41 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                   \\"type\\": \\"password\\"
                                 },
                                 \\"childNodes\\": [],
+                                \\"rootId\\": 11,
                                 \\"id\\": 71
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 72
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 73
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 30
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 74
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 28
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -2335,6 +2750,7 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -2357,12 +2773,15 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -2373,6 +2792,7 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -2383,6 +2803,7 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -2390,19 +2811,23 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -2413,6 +2838,7 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -2423,6 +2849,7 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -2433,36 +2860,45 @@ exports[`cross origin iframes move-node.html captures mutations on adopted style
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -2728,6 +3164,7 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -2750,12 +3187,15 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -2766,6 +3206,7 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -2776,6 +3217,7 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -2783,19 +3225,23 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -2806,6 +3252,7 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -2816,6 +3263,7 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -2826,36 +3274,45 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -2907,6 +3364,7 @@ exports[`cross origin iframes move-node.html captures mutations on stylesheets 1
             \\"tagName\\": \\"style\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 34
           }
         }
@@ -3125,6 +3583,7 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -3147,12 +3606,15 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -3163,6 +3625,7 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -3173,6 +3636,7 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -3180,19 +3644,23 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -3203,6 +3671,7 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -3213,6 +3682,7 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -3223,36 +3693,45 @@ exports[`cross origin iframes move-node.html should record DOM attribute changes
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -3392,6 +3871,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -3414,12 +3894,15 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -3430,6 +3913,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -3440,6 +3924,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -3447,19 +3932,23 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -3470,6 +3959,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -3480,6 +3970,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -3490,36 +3981,45 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -3552,6 +4052,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"\\\\n      \\",
+            \\"rootId\\": 11,
             \\"id\\": 25
           }
         },
@@ -3563,6 +4064,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
             \\"tagName\\": \\"i\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 26
           }
         },
@@ -3572,6 +4074,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"\\\\n        \\",
+            \\"rootId\\": 11,
             \\"id\\": 27
           }
         },
@@ -3583,6 +4086,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
             \\"tagName\\": \\"b\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 28
           }
         },
@@ -3592,6 +4096,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"1\\",
+            \\"rootId\\": 11,
             \\"id\\": 29
           }
         },
@@ -3601,6 +4106,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"\\\\n      \\",
+            \\"rootId\\": 11,
             \\"id\\": 30
           }
         },
@@ -3610,6 +4116,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"\\\\n    \\",
+            \\"rootId\\": 11,
             \\"id\\": 31
           }
         },
@@ -3621,6 +4128,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
             \\"tagName\\": \\"div\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 33
           }
         },
@@ -3632,6 +4140,7 @@ exports[`cross origin iframes move-node.html should record DOM node movement 1`]
             \\"tagName\\": \\"span\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 24
           }
         }
@@ -3747,6 +4256,7 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -3769,12 +4279,15 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -3785,6 +4298,7 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -3795,6 +4309,7 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -3802,19 +4317,23 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -3825,6 +4344,7 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -3835,6 +4355,7 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -3845,36 +4366,45 @@ exports[`cross origin iframes move-node.html should record DOM node removal 1`] 
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -4012,6 +4542,7 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -4034,12 +4565,15 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -4050,6 +4584,7 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -4060,6 +4595,7 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -4067,19 +4603,23 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -4090,6 +4630,7 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -4100,6 +4641,7 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -4110,36 +4652,45 @@ exports[`cross origin iframes move-node.html should record DOM text changes 1`] 
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -4277,6 +4828,7 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -4299,12 +4851,15 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -4315,6 +4870,7 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -4325,6 +4881,7 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -4332,19 +4889,23 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -4355,6 +4916,7 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -4365,6 +4927,7 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -4375,36 +4938,45 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],
@@ -4434,6 +5006,7 @@ exports[`cross origin iframes move-node.html should record canvas elements 1`] =
             \\"tagName\\": \\"canvas\\",
             \\"attributes\\": {},
             \\"childNodes\\": [],
+            \\"rootId\\": 11,
             \\"id\\": 33
           }
         }
@@ -4578,6 +5151,7 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                 \\"name\\": \\"html\\",
                 \\"publicId\\": \\"\\",
                 \\"systemId\\": \\"\\",
+                \\"rootId\\": 11,
                 \\"id\\": 12
               },
               {
@@ -4600,12 +5174,15 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                            \\"rootId\\": 11,
                             \\"id\\": 16
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 15
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 14
                   },
                   {
@@ -4616,6 +5193,7 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 18
                       },
                       {
@@ -4626,6 +5204,7 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 20
                           },
                           {
@@ -4633,19 +5212,23 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                             \\"tagName\\": \\"p\\",
                             \\"attributes\\": {},
                             \\"childNodes\\": [],
+                            \\"rootId\\": 11,
                             \\"id\\": 21
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 22
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 19
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
+                        \\"rootId\\": 11,
                         \\"id\\": 23
                       },
                       {
@@ -4656,6 +5239,7 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 25
                           },
                           {
@@ -4666,6 +5250,7 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 27
                               },
                               {
@@ -4676,36 +5261,45 @@ exports[`cross origin iframes move-node.html should record custom events 1`] = `
                                   {
                                     \\"type\\": 3,
                                     \\"textContent\\": \\"1\\",
+                                    \\"rootId\\": 11,
                                     \\"id\\": 29
                                   }
                                 ],
+                                \\"rootId\\": 11,
                                 \\"id\\": 28
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
                                 \\"id\\": 30
                               }
                             ],
+                            \\"rootId\\": 11,
                             \\"id\\": 26
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
                             \\"id\\": 31
                           }
                         ],
+                        \\"rootId\\": 11,
                         \\"id\\": 24
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
+                        \\"rootId\\": 11,
                         \\"id\\": 32
                       }
                     ],
+                    \\"rootId\\": 11,
                     \\"id\\": 17
                   }
                 ],
+                \\"rootId\\": 11,
                 \\"id\\": 13
               }
             ],

--- a/packages/rrweb/test/record/cross-origin-iframes.test.ts
+++ b/packages/rrweb/test/record/cross-origin-iframes.test.ts
@@ -517,6 +517,24 @@ describe('cross origin iframes', function (this: ISuite) {
       serverBURL: string;
     };
 
+    it('should record same-origin iframe in cross-origin iframe', async () => {
+      const frame = ctx.page.mainFrame().childFrames()[0];
+      await frame.evaluate(() => {
+        const iframe2 = document.createElement('iframe');
+        // Append a same-origin iframe in a cross-origin iframe.
+        document.body.appendChild(iframe2);
+        iframe2.contentDocument!.body.appendChild(
+          document.createTextNode('Same-origin iframe in cross-origin iframe'),
+        );
+      });
+
+      await waitForRAF(ctx.page);
+      const snapshots = (await ctx.page.evaluate(
+        'window.snapshots',
+      )) as eventWithTime[];
+      assertSnapshot(snapshots);
+    });
+
     it('should filter out forwarded cross origin rrweb messages', async () => {
       const frame = ctx.page.mainFrame().childFrames()[0];
       const iframe2URL = `${ctx.serverBURL}/html/blank.html`;
@@ -533,10 +551,11 @@ describe('cross origin iframes', function (this: ISuite) {
 
       // Wait for iframe2 to load
       await ctx.page.waitForFrame(iframe2URL);
+      const iframe2 = frame.childFrames()[0];
       // Record iframe2
-      await injectRecordScript(frame.childFrames()[0]);
+      await injectRecordScript(iframe2);
 
-      await waitForRAF(frame.childFrames()[0]);
+      await waitForRAF(iframe2);
       const snapshots = (await ctx.page.evaluate(
         'window.snapshots',
       )) as eventWithTime[];


### PR DESCRIPTION
This pull request fixes two problems:

1. When some same-origin iframes are nested in cross-origin iframes, their `rootId`s are wrong.
    For the scenario, please refer to the test case: 
https://github.com/rrweb-io/rrweb/pull/1100/files#diff-bf7ca29c8daccc947cedb2b10b13e757062bd5d893aad3598bc111f5c07564efR520-R536

2. The property `rootId` is missing in serialized cross-origin iframes