### PR TITLE
fix: Ensure CSS support is checked more robustly

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -61,17 +61,14 @@ function isCSSStyleSheetMonkeyPatchable(
     | 'CSSSupportsRule'
     | 'CSSConditionRule',
 ): boolean {
-  /* eslint-disable @typescript-eslint/ban-ts-comment,@typescript-eslint/unbound-method */
   return Boolean(
     typeof window[prop] !== 'undefined' &&
       // Note: Generally, this check _shouldn't_ be necessary
       // However, in some scenarios (e.g. jsdom) this can sometimes fail, so we check for it here
       window[prop].prototype &&
-      // @ts-ignore ensure it is actually set
-      window[prop].prototype.insertRule &&
-      window[prop].prototype.deleteRule,
+      'insertRule' in window[prop].prototype &&
+      'deleteRule' in window[prop].prototype,
   );
-  /* eslint-enable @typescript-eslint/ban-ts-comment,@typescript-eslint/unbound-method */
 }
 
 const isCSSGroupingRuleSupported = isCSSStyleSheetMonkeyPatchable(

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -54,10 +54,34 @@ type WindowWithAngularZone = IWindow & {
 export const mutationBuffers: MutationBuffer[] = [];
 export const processedNodeManager = new ProcessedNodeManager();
 
-const isCSSGroupingRuleSupported = typeof CSSGroupingRule !== 'undefined';
-const isCSSMediaRuleSupported = typeof CSSMediaRule !== 'undefined';
-const isCSSSupportsRuleSupported = typeof CSSSupportsRule !== 'undefined';
-const isCSSConditionRuleSupported = typeof CSSConditionRule !== 'undefined';
+function isCSSStyleSheetMonkeyPatchable(
+  prop:
+    | 'CSSGroupingRule'
+    | 'CSSMediaRule'
+    | 'CSSSupportsRule'
+    | 'CSSConditionRule',
+): boolean {
+  return Boolean(
+    typeof window[prop] !== 'undefined' &&
+      // Note: Generally, this check _shouldn't_ be necessary
+      // However, in some scenarios (e.g. jsdom) this can sometimes fail, so we check for it here
+      window[prop].prototype &&
+      // @ts-ignore ensure it is actually set
+      window[prop].prototype.insertRule &&
+      window[prop].prototype.deleteRule
+  );
+}
+
+const isCSSGroupingRuleSupported = isCSSStyleSheetMonkeyPatchable(
+  'CSSGroupingRule',
+);
+const isCSSMediaRuleSupported = isCSSStyleSheetMonkeyPatchable('CSSMediaRule');
+const isCSSSupportsRuleSupported = isCSSStyleSheetMonkeyPatchable(
+  'CSSSupportsRule',
+);
+const isCSSConditionRuleSupported = isCSSStyleSheetMonkeyPatchable(
+  'CSSConditionRule',
+);
 
 // Event.path is non-standard and used in some older browsers
 type NonStandardEvent = Omit<Event, 'composedPath'> & {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -61,6 +61,7 @@ function isCSSStyleSheetMonkeyPatchable(
     | 'CSSSupportsRule'
     | 'CSSConditionRule',
 ): boolean {
+  /* eslint-disable @typescript-eslint/ban-ts-comment,@typescript-eslint/unbound-method */
   return Boolean(
     typeof window[prop] !== 'undefined' &&
       // Note: Generally, this check _shouldn't_ be necessary
@@ -70,6 +71,7 @@ function isCSSStyleSheetMonkeyPatchable(
       window[prop].prototype.insertRule &&
       window[prop].prototype.deleteRule,
   );
+  /* eslint-enable @typescript-eslint/ban-ts-comment,@typescript-eslint/unbound-method */
 }
 
 const isCSSGroupingRuleSupported = isCSSStyleSheetMonkeyPatchable(

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -68,7 +68,7 @@ function isCSSStyleSheetMonkeyPatchable(
       window[prop].prototype &&
       // @ts-ignore ensure it is actually set
       window[prop].prototype.insertRule &&
-      window[prop].prototype.deleteRule
+      window[prop].prototype.deleteRule,
   );
 }
 


### PR DESCRIPTION
Noticed this while debugging tests in sentry-javascript. it seems jsdom has a weird support for `CSSMediaRule`, where it is defined but if you look at `CSSMediaRule.prototype` it is:

```
CSSRule {
        parentRule: null,
        parentStyleSheet: null,
        constructor: [Function: CSSMediaRule],
        type: 4
      }
```


I guess this could also be the case for other "weird" browsers or engines. I think it's safer to make sure everything we need is actually there at this point.

ref https://github.com/getsentry/rrweb/pull/42