### PR TITLE
[fix] Don't trigger Finish event when in liveMode

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -709,7 +709,10 @@ export class Replayer {
 
       // events are kept sorted by timestamp, check if this is the last event
       const last_index = this.service.state.context.events.length - 1;
-      if (event === this.service.state.context.events[last_index]) {
+      if (
+        !this.config.liveMode &&
+        event === this.service.state.context.events[last_index]
+      ) {
         const finish = () => {
           if (last_index < this.service.state.context.events.length - 1) {
             // more events have been added since the setTimeout

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -20,12 +20,16 @@ import StyleSheetTextMutation from './events/style-sheet-text-mutation';
 import canvasInIframe from './events/canvas-in-iframe';
 import adoptedStyleSheet from './events/adopted-style-sheet';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
+import { ReplayerEvents } from '@rrweb/types';
 
 interface ISuite {
   code: string;
   browser: puppeteer.Browser;
   page: puppeteer.Page;
 }
+
+type IWindow = Window &
+  typeof globalThis & { rrweb: typeof import('../src'); events: typeof events };
 
 describe('replayer', function () {
   jest.setTimeout(10_000);
@@ -45,7 +49,7 @@ describe('replayer', function () {
     page = await browser.newPage();
     await page.goto('about:blank');
     await page.evaluate(code);
-    await page.evaluate(`let events = ${JSON.stringify(events)}`);
+    await page.evaluate(`var events = ${JSON.stringify(events)}`);
 
     page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
   });
@@ -677,6 +681,29 @@ describe('replayer', function () {
       replayer.service.state.value;
     `);
     expect(status).toEqual('live');
+  });
+
+  it("shouldn't trigger ReplayerEvents.Finish in live mode", async () => {
+    const status = await page.evaluate((FinishState) => {
+      return new Promise((resolve) => {
+        const win = window as IWindow;
+        let triggeredFinish = false;
+        const { Replayer } = win.rrweb;
+        const replayer = new Replayer([], {
+          liveMode: true,
+        });
+        replayer.on(FinishState, () => {
+          triggeredFinish = true;
+        });
+        replayer.startLive();
+        replayer.addEvent(win.events[0]);
+        requestAnimationFrame(() => {
+          resolve(triggeredFinish);
+        });
+      });
+    }, ReplayerEvents.Finish);
+
+    expect(status).toEqual(false);
   });
 
   it('replays same timestamp events in correct order', async () => {


### PR DESCRIPTION
ReplayerEvents.Finish is used to set the rrweb-player to pause. This shouldn't trigger as long as live mode is enabled as new events may still come in