### PR TITLE
fix: outdated ':hover' styles can't be removed from iframes or shadow doms

### DIFF
--- a/.changeset/tidy-yaks-joke.md
+++ b/.changeset/tidy-yaks-joke.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Fix: outdated ':hover' styles can't be removed from iframes or shadow doms

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -149,6 +149,9 @@ export class Replayer {
   private mousePos: mouseMovePos | null = null;
   private touchActive: boolean | null = null;
 
+  // Keep the rootNode of the last hovered element. So  when hovering a new element, we can remove the last hovered element's :hover style.
+  private lastHoveredRootNode: Document | ShadowRoot;
+
   // In the fast-forward mode, only the last selection data needs to be applied.
   private lastSelectionData: selectionData | null = null;
 
@@ -2091,11 +2094,12 @@ export class Replayer {
   }
 
   private hoverElements(el: Element) {
-    this.iframe.contentDocument
+    (this.lastHoveredRootNode || this.iframe.contentDocument)
       ?.querySelectorAll('.\\:hover')
       .forEach((hoveredEl) => {
         hoveredEl.classList.remove(':hover');
       });
+    this.lastHoveredRootNode = el.getRootNode() as Document | ShadowRoot;
     let currentEl: Element | null = el;
     while (currentEl) {
       if (currentEl.classList) {

--- a/packages/rrweb/test/events/iframe-shadowdom-hover.ts
+++ b/packages/rrweb/test/events/iframe-shadowdom-hover.ts
@@ -1,0 +1,206 @@
+import { EventType, IncrementalSource } from '@rrweb/types';
+import type { eventWithTime } from '@rrweb/types';
+
+const now = Date.now();
+
+const events: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1200,
+      height: 500,
+    },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          { id: 2, name: 'html', type: 1, publicId: '', systemId: '' },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: { lang: 'en' },
+            childNodes: [
+              {
+                id: 4,
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+              },
+              {
+                id: 5,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 6,
+                    type: 2,
+                    tagName: 'iframe',
+                    attributes: {},
+                    childNodes: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: { top: 0, left: 0 },
+    },
+    timestamp: now + 200,
+  },
+  // add iframe
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      adds: [
+        {
+          parentId: 6,
+          nextId: null,
+          node: {
+            type: 0,
+            childNodes: [
+              {
+                type: 1,
+                name: 'html',
+                publicId: '',
+                systemId: '',
+                rootId: 7,
+                id: 8,
+              },
+              {
+                type: 2,
+                tagName: 'html',
+                attributes: { lang: 'en' },
+                childNodes: [
+                  {
+                    type: 2,
+                    tagName: 'head',
+                    attributes: {},
+                    childNodes: [],
+                    rootId: 7,
+                    id: 10,
+                  },
+                  {
+                    type: 2,
+                    tagName: 'body',
+                    attributes: {},
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'div',
+                        attributes: {},
+                        childNodes: [
+                          {
+                            type: 2,
+                            tagName: 'div',
+                            attributes: {},
+                            childNodes: [],
+                            rootId: 7,
+                            id: 13,
+                            isShadow: true,
+                          },
+                        ],
+                        isShadowHost: true,
+                        rootId: 7,
+                        id: 12,
+                      },
+                      {
+                        type: 2,
+                        tagName: 'span',
+                        attributes: {},
+                        childNodes: [],
+                        rootId: 7,
+                        id: 14,
+                      },
+                      { type: 3, textContent: '\t\n', rootId: 7, id: 15 },
+                    ],
+                    rootId: 7,
+                    id: 11,
+                  },
+                ],
+                rootId: 7,
+                id: 9,
+              },
+            ],
+            id: 7,
+          },
+        },
+      ],
+      removes: [],
+      texts: [],
+      attributes: [],
+      isAttachIframe: true,
+    },
+    timestamp: now + 500,
+  },
+  // hover element in iframe
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseMove,
+      positions: [
+        {
+          x: 0,
+          y: 0,
+          id: 14,
+          timeOffset: 0,
+        },
+      ],
+    },
+    timestamp: now + 500,
+  },
+  // hover element in shadow dom
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseMove,
+      positions: [
+        {
+          x: 0,
+          y: 0,
+          id: 13,
+          timeOffset: 0,
+        },
+      ],
+    },
+    timestamp: now + 1000,
+  },
+  // hover element in iframe again
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseMove,
+      positions: [
+        {
+          x: 0,
+          y: 0,
+          id: 14,
+          timeOffset: 0,
+        },
+      ],
+    },
+    timestamp: now + 1500,
+  },
+];
+
+export default events;


### PR DESCRIPTION
### bug
hover styles can't be removed in iframes or shadow doms

https://user-images.githubusercontent.com/27533910/218257572-506f520e-c83b-4153-b3a8-3f4a0727f799.mp4

### after the fix

https://user-images.githubusercontent.com/27533910/218257698-ed7e828b-36d1-4a94-bf2f-a57ef5c8b570.mp4

