### PR TITLE
Record pointerType on clicks

### DIFF
--- a/.changeset/little-suits-leave.md
+++ b/.changeset/little-suits-leave.md
@@ -1,6 +1,6 @@
 ---
-"rrweb": minor
-"@rrweb/types": minor
+'rrweb': minor
+'@rrweb/types': minor
 ---
 
 click events (as well as mousedown/mouseup/touchstart/touchend events) now include a `.pointerType` attribute which distinguishes between ['pen', 'mouse' and 'touch' events](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType)

--- a/.changeset/little-suits-leave.md
+++ b/.changeset/little-suits-leave.md
@@ -1,0 +1,6 @@
+---
+"rrweb": minor
+"@rrweb/types": minor
+---
+
+click events (as well as mousedown/mouseup/touchstart/touchend events) now include a `.pointerType` attribute which distinguishes between ['pen', 'mouse' and 'touch' events](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType)

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -240,13 +240,14 @@ function initMouseInteractionObserver({
       let pointerType: PointerTypes | null = null;
       let e = event;
       if ('pointerType' in e) {
-        Object.keys(PointerTypes)
-          .forEach((pointerKey: keyof typeof PointerKeys) => {
+        Object.keys(PointerTypes).forEach(
+          (pointerKey: keyof typeof PointerKeys) => {
             if ((e as PointerEvent).pointerType === pointerKey.toLowerCase()) {
               pointerType = PointerTypes[pointerKey];
               return;
             }
-          });
+          },
+        );
         if (pointerType === PointerTypes.Touch) {
           if (MouseInteractions[eventKey] === MouseInteractions.MouseDown) {
             // we are actually listening on 'pointerdown'

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -9,7 +9,7 @@ import {
   getWindowHeight,
   getWindowWidth,
   isBlocked,
-  isTouchEvent,
+  legacy_isTouchEvent,
   patch,
   StyleSheetMirror,
 } from '../utils';
@@ -170,7 +170,8 @@ function initMoveObserver({
     throttle<MouseEvent | TouchEvent | DragEvent>(
       callbackWrapper((evt) => {
         const target = getEventTarget(evt);
-        const { clientX, clientY } = isTouchEvent(evt)
+        // 'legacy' here as we could switch to https://developer.mozilla.org/en-US/docs/Web/API/Element/pointermove_event
+        const { clientX, clientY } = legacy_isTouchEvent(evt)
           ? evt.changedTouches[0]
           : evt;
         if (!timeBaseline) {
@@ -228,13 +229,38 @@ function initMouseInteractionObserver({
       : sampling.mouseInteraction;
 
   const handlers: listenerHandler[] = [];
+  let currentPointerType = null;
   const getHandler = (eventKey: keyof typeof MouseInteractions) => {
-    return (event: MouseEvent | TouchEvent) => {
+    return (event: MouseEvent | TouchEvent | PointerEvent) => {
       const target = getEventTarget(event) as Node;
       if (isBlocked(target, blockClass, blockSelector, true)) {
         return;
       }
-      const e = isTouchEvent(event) ? event.changedTouches[0] : event;
+      let pointerType = null;
+      let e = event;
+      if ('pointerType' in e) {
+        pointerType = (e as PointerEvent).pointerType; // touch / pen / mouse
+        if (pointerType === 'touch') {
+          if (MouseInteractions[eventKey] === MouseInteractions.MouseDown) {
+            // we are actually listening on 'pointerdown'
+            eventKey = 'TouchStart';
+          } else if (MouseInteractions[eventKey] === MouseInteractions.MouseUp) {
+            // we are actually listening on 'pointerup'
+            eventKey = 'TouchEnd';
+          }
+        } else if (pointerType == 'pen') {
+          // TODO: these will get incorrectly emitted as MouseDown/MouseUp
+        }
+      } else if (legacy_isTouchEvent(event)) {
+        e = event.changedTouches[0];
+        pointerType = 'touch';
+      }
+      if (pointerType) {
+        currentPointerType = pointerType;
+      } else if (MouseInteractions[eventKey] === MouseInteractions.Click) {
+        pointerType = currentPointerType;
+        currentPointerType = null;  // cleanup as we've used it
+      }
       if (!e) {
         return;
       }
@@ -245,6 +271,7 @@ function initMouseInteractionObserver({
         id,
         x: clientX,
         y: clientY,
+        ...pointerType && { pointerType }
       });
     };
   };
@@ -256,8 +283,20 @@ function initMouseInteractionObserver({
         disableMap[key] !== false,
     )
     .forEach((eventKey: keyof typeof MouseInteractions) => {
-      const eventName = eventKey.toLowerCase();
+      let eventName = eventKey.toLowerCase();
       const handler = getHandler(eventKey);
+      if (window.PointerEvent) {
+        switch(MouseInteractions[eventKey]) {
+        case MouseInteractions.MouseDown:
+        case MouseInteractions.MouseUp:
+          eventName = eventName.replace('mouse', 'pointer');
+          break;
+        case MouseInteractions.TouchStart:
+        case MouseInteractions.TouchEnd:
+          // these are handled by pointerdown/pointerup
+          return;
+        }
+      }
       handlers.push(on(eventName, handler, doc));
     });
   return callbackWrapper(() => {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -244,7 +244,9 @@ function initMouseInteractionObserver({
           if (MouseInteractions[eventKey] === MouseInteractions.MouseDown) {
             // we are actually listening on 'pointerdown'
             eventKey = 'TouchStart';
-          } else if (MouseInteractions[eventKey] === MouseInteractions.MouseUp) {
+          } else if (
+            MouseInteractions[eventKey] === MouseInteractions.MouseUp
+          ) {
             // we are actually listening on 'pointerup'
             eventKey = 'TouchEnd';
           }
@@ -259,7 +261,7 @@ function initMouseInteractionObserver({
         currentPointerType = pointerType;
       } else if (MouseInteractions[eventKey] === MouseInteractions.Click) {
         pointerType = currentPointerType;
-        currentPointerType = null;  // cleanup as we've used it
+        currentPointerType = null; // cleanup as we've used it
       }
       if (!e) {
         return;
@@ -271,7 +273,7 @@ function initMouseInteractionObserver({
         id,
         x: clientX,
         y: clientY,
-        ...pointerType && { pointerType }
+        ...(pointerType && { pointerType }),
       });
     };
   };
@@ -286,15 +288,15 @@ function initMouseInteractionObserver({
       let eventName = eventKey.toLowerCase();
       const handler = getHandler(eventKey);
       if (window.PointerEvent) {
-        switch(MouseInteractions[eventKey]) {
-        case MouseInteractions.MouseDown:
-        case MouseInteractions.MouseUp:
-          eventName = eventName.replace('mouse', 'pointer');
-          break;
-        case MouseInteractions.TouchStart:
-        case MouseInteractions.TouchEnd:
-          // these are handled by pointerdown/pointerup
-          return;
+        switch (MouseInteractions[eventKey]) {
+          case MouseInteractions.MouseDown:
+          case MouseInteractions.MouseUp:
+            eventName = eventName.replace('mouse', 'pointer');
+            break;
+          case MouseInteractions.TouchStart:
+          case MouseInteractions.TouchEnd:
+            // these are handled by pointerdown/pointerup
+            return;
         }
       }
       handlers.push(on(eventName, handler, doc));

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -20,6 +20,7 @@ import {
   mousePosition,
   mouseInteractionCallBack,
   MouseInteractions,
+  PointerTypes,
   listenerHandler,
   scrollCallback,
   styleSheetRuleCallback,
@@ -236,11 +237,17 @@ function initMouseInteractionObserver({
       if (isBlocked(target, blockClass, blockSelector, true)) {
         return;
       }
-      let pointerType = null;
+      let pointerType: PointerTypes | null = null;
       let e = event;
       if ('pointerType' in e) {
-        pointerType = (e as PointerEvent).pointerType; // touch / pen / mouse
-        if (pointerType === 'touch') {
+        Object.keys(PointerTypes)
+          .forEach((pointerKey: keyof typeof PointerKeys) => {
+            if ((e as PointerEvent).pointerType === pointerKey.toLowerCase()) {
+              pointerType = PointerTypes[pointerKey];
+              return;
+            }
+          });
+        if (pointerType === PointerTypes.Touch) {
           if (MouseInteractions[eventKey] === MouseInteractions.MouseDown) {
             // we are actually listening on 'pointerdown'
             eventKey = 'TouchStart';
@@ -250,14 +257,14 @@ function initMouseInteractionObserver({
             // we are actually listening on 'pointerup'
             eventKey = 'TouchEnd';
           }
-        } else if (pointerType == 'pen') {
+        } else if (pointerType == PointerTypes.Pen) {
           // TODO: these will get incorrectly emitted as MouseDown/MouseUp
         }
       } else if (legacy_isTouchEvent(event)) {
         e = event.changedTouches[0];
-        pointerType = 'touch';
+        pointerType = PointerTypes.Touch;
       }
-      if (pointerType) {
+      if (pointerType !== null) {
         currentPointerType = pointerType;
       } else if (MouseInteractions[eventKey] === MouseInteractions.Click) {
         pointerType = currentPointerType;
@@ -273,7 +280,7 @@ function initMouseInteractionObserver({
         id,
         x: clientX,
         y: clientY,
-        ...(pointerType && { pointerType }),
+        ...(pointerType !== null && { pointerType }),
       });
     };
   };

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -277,8 +277,8 @@ export function isAncestorRemoved(target: Node, mirror: Mirror): boolean {
   return isAncestorRemoved(target.parentNode, mirror);
 }
 
-export function isTouchEvent(
-  event: MouseEvent | TouchEvent,
+export function legacy_isTouchEvent(
+  event: MouseEvent | TouchEvent | PointerEvent,
 ): event is TouchEvent {
   return Boolean((event as TouchEvent).changedTouches);
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -404,6 +404,7 @@ type mouseInteractionParam = {
   id: number;
   x: number;
   y: number;
+  pointerType?: string;
 };
 
 export type mouseInteractionCallBack = (d: mouseInteractionParam) => void;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -362,6 +362,12 @@ export enum MouseInteractions {
   TouchCancel,
 }
 
+export enum PointerTypes {
+  Mouse,
+  Pen,
+  Touch,
+}
+
 export enum CanvasContext {
   '2D',
   WebGL,
@@ -404,7 +410,7 @@ type mouseInteractionParam = {
   id: number;
   x: number;
   y: number;
-  pointerType?: string;
+  pointerType?: PointerTypes;
 };
 
 export type mouseInteractionCallBack = (d: mouseInteractionParam) => void;


### PR DESCRIPTION
- could be useful for displaying e.g. a circle rather than a point during replay

touchscreen laptops can have both mouse and touch within the same session