### PR TITLE
Fix relative path detection in stylesheet URLs

### DIFF
--- a/.changeset/large-ants-prove.md
+++ b/.changeset/large-ants-prove.md
@@ -1,6 +1,6 @@
 ---
-"rrweb-snapshot": patch
-"rrweb": patch
+'rrweb-snapshot': patch
+'rrweb': patch
 ---
 
 Fix: Make relative path detection in stylesheet URLs to detect more types of URL protocols when inlining stylesheets.

--- a/.changeset/large-ants-prove.md
+++ b/.changeset/large-ants-prove.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Fix: Make relative path detection in stylesheet URLs to detect more types of URL protocols when inlining stylesheets.

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -72,7 +72,7 @@ let canvasCtx: CanvasRenderingContext2D | null;
 
 const URL_IN_CSS_REF = /url\((?:(')([^']*)'|(")(.*?)"|([^)]*))\)/gm;
 const URL_PROTOCOL_MATCH = /^(?:[a-z+]+:)?\/\//i;
-const URL_WWW_MATCH = /^www\..*/i
+const URL_WWW_MATCH = /^www\..*/i;
 const DATA_URI = /^(data:)([^,]*),(.*)/i;
 export function absoluteToStylesheet(
   cssText: string | null,

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -71,7 +71,7 @@ let canvasService: HTMLCanvasElement | null;
 let canvasCtx: CanvasRenderingContext2D | null;
 
 const URL_IN_CSS_REF = /url\((?:(')([^']*)'|(")(.*?)"|([^)]*))\)/gm;
-const RELATIVE_PATH = /^(?!www\.|(?:http|ftp)s?:\/\/|[A-Za-z]:\\|\/\/|#).*/;
+const ABSOLUTE_PATH = /^(?:[a-z+]+:)?\/\//i;
 const DATA_URI = /^(data:)([^,]*),(.*)/i;
 export function absoluteToStylesheet(
   cssText: string | null,
@@ -92,7 +92,7 @@ export function absoluteToStylesheet(
       if (!filePath) {
         return origin;
       }
-      if (!RELATIVE_PATH.test(filePath)) {
+      if (ABSOLUTE_PATH.test(filePath)) {
         return `url(${maybeQuote}${filePath}${maybeQuote})`;
       }
       if (DATA_URI.test(filePath)) {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -93,7 +93,7 @@ export function absoluteToStylesheet(
       if (!filePath) {
         return origin;
       }
-      if (URL_PROTOCOL_MATCH.test(filePath) || URL_WWW_MATCH.test(filePath) {
+      if (URL_PROTOCOL_MATCH.test(filePath) || URL_WWW_MATCH.test(filePath)) {
         return `url(${maybeQuote}${filePath}${maybeQuote})`;
       }
       if (DATA_URI.test(filePath)) {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -71,7 +71,8 @@ let canvasService: HTMLCanvasElement | null;
 let canvasCtx: CanvasRenderingContext2D | null;
 
 const URL_IN_CSS_REF = /url\((?:(')([^']*)'|(")(.*?)"|([^)]*))\)/gm;
-const ABSOLUTE_PATH = /^(?:[a-z+]+:)?\/\//i;
+const URL_PROTOCOL_MATCH = /^(?:[a-z+]+:)?\/\//i;
+const URL_WWW_MATCH = /^www\..*/i
 const DATA_URI = /^(data:)([^,]*),(.*)/i;
 export function absoluteToStylesheet(
   cssText: string | null,
@@ -92,7 +93,7 @@ export function absoluteToStylesheet(
       if (!filePath) {
         return origin;
       }
-      if (ABSOLUTE_PATH.test(filePath)) {
+      if (URL_PROTOCOL_MATCH.test(filePath) || URL_WWW_MATCH.test(filePath) {
         return `url(${maybeQuote}${filePath}${maybeQuote})`;
       }
       if (DATA_URI.test(filePath)) {


### PR DESCRIPTION
There can URLs with protocols other than HTTP / HTTPs / FTP

Example:
If you have loom installed in your browser, it adds some stylesheets that refer to `chrome-extension` protocol

![image](https://user-images.githubusercontent.com/11289825/218636526-bd5b66f1-2a4e-4f0f-b15f-00cedcef0429.png)

For such URLs, rrweb is pre-pending the webpage origin in the CSS.

This PR is meant to make the relative URL detection more generic.
The regex I have added has been taken from stack overflow - https://stackoverflow.com/a/19709846
It checks for the existence of a protocol in the URL.