### PR TITLE
fix: Recursive logging bug with console recording

### DIFF
--- a/.changeset/violet-melons-itch.md
+++ b/.changeset/violet-melons-itch.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+fix: Recursive logging bug with console recording

--- a/.changeset/violet-melons-itch.md
+++ b/.changeset/violet-melons-itch.md
@@ -1,5 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 fix: Recursive logging bug with console recording

--- a/packages/rrweb/src/plugins/console/record/index.ts
+++ b/packages/rrweb/src/plugins/console/record/index.ts
@@ -194,7 +194,7 @@ function initLogObserver(
             // likely a proxy method called from stringify. We don't want to log this as it will cause an infinite loop
             return;
           }
-          inStack = true
+          inStack = true;
           try {
             const trace = ErrorStackParser.parse(new Error())
               .map((stackFrame: StackFrame) => stackFrame.toString())

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -4723,6 +4723,186 @@ exports[`record integration tests mutations should work when blocked class is un
 ]"
 `;
 
+exports[`record integration tests should handle recursive console messages 1`] = `
+"[
+  {
+    \\"type\\": 0,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 1,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {
+              \\"lang\\": \\"en\\"
+            },
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"charset\\": \\"UTF-8\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"name\\": \\"viewport\\",
+                      \\"content\\": \\"width=device-width, initial-scale=1.0\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"http-equiv\\": \\"X-UA-Compatible\\",
+                      \\"content\\": \\"ie=edge\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 10
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 11
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"title\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"Log record\\",
+                        \\"id\\": 13
+                      }
+                    ],
+                    \\"id\\": 12
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 14
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 15
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 17
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 19
+                      }
+                    ],
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
+                    \\"id\\": 20
+                  }
+                ],
+                \\"id\\": 16
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 6,
+    \\"data\\": {
+      \\"plugin\\": \\"rrweb/console@1\\",
+      \\"payload\\": {
+        \\"level\\": \\"log\\",
+        \\"trace\\": [
+          \\"__puppeteer_evaluation_script__:20:21\\"
+        ],
+        \\"payload\\": [
+          \\"\\\\\\"Proxied object:\\\\\\"\\",
+          \\"\\\\\\"[object Object]\\\\\\"\\"
+        ]
+      }
+    }
+  }
+]"
+`;
+
 exports[`record integration tests should mask texts 1`] = `
 "[
   {

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -542,6 +542,52 @@ describe('record integration tests', function (this: ISuite) {
     assertSnapshot(snapshots);
   });
 
+  it('should handle recursive console messages', async () => {
+    const page: puppeteer.Page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.setContent(
+      getHtml('log.html', {
+        plugins: ('[rrwebConsoleRecord.getRecordConsolePlugin()]' as unknown) as RecordPlugin<unknown>[],
+      }),
+    );
+
+    await page.evaluate(() => {
+      // Some frameworks like Vue.js use proxies to implement reactivity.
+      // This can cause infinite loops when logging objects.
+      let recursiveTarget = {  foo: 'bar', proxied: "i-am", proxy: null };
+      let count = 0;
+
+      const handler = {
+        get(target: any, prop: any, ...args: any[]) {
+          if (prop === 'proxied') {
+            if (count > 9) {
+              return
+            }
+            count++; // We don't want out test to get into an infinite loop...
+            console.warn(
+              'proxied was accessed so triggering a console.warn',
+              target,
+            );
+          }
+          return Reflect.get(target, prop, ...args);
+        },
+      };
+
+      const proxy = new Proxy(recursiveTarget, handler);
+      recursiveTarget.proxy = proxy;
+
+      console.log("Proxied object:", proxy);
+    });
+
+    await waitForRAF(page);
+    
+    const snapshots = (await page.evaluate(
+      'window.snapshots',
+    )) as eventWithTime[];
+    // The snapshots should containe 1 console log, not multiple.
+    assertSnapshot(snapshots);
+  });
+
   it('should nest record iframe', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto(`${serverURL}/html`);

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -547,21 +547,22 @@ describe('record integration tests', function (this: ISuite) {
     await page.goto('about:blank');
     await page.setContent(
       getHtml('log.html', {
-        plugins: ('[rrwebConsoleRecord.getRecordConsolePlugin()]' as unknown) as RecordPlugin<unknown>[],
+        plugins:
+          '[rrwebConsoleRecord.getRecordConsolePlugin()]' as unknown as RecordPlugin<unknown>[],
       }),
     );
 
     await page.evaluate(() => {
       // Some frameworks like Vue.js use proxies to implement reactivity.
       // This can cause infinite loops when logging objects.
-      let recursiveTarget = {  foo: 'bar', proxied: "i-am", proxy: null };
+      let recursiveTarget = { foo: 'bar', proxied: 'i-am', proxy: null };
       let count = 0;
 
       const handler = {
         get(target: any, prop: any, ...args: any[]) {
           if (prop === 'proxied') {
             if (count > 9) {
-              return
+              return;
             }
             count++; // We don't want out test to get into an infinite loop...
             console.warn(
@@ -576,11 +577,11 @@ describe('record integration tests', function (this: ISuite) {
       const proxy = new Proxy(recursiveTarget, handler);
       recursiveTarget.proxy = proxy;
 
-      console.log("Proxied object:", proxy);
+      console.log('Proxied object:', proxy);
     });
 
     await waitForRAF(page);
-    
+
     const snapshots = (await page.evaluate(
       'window.snapshots',
     )) as eventWithTime[];


### PR DESCRIPTION
Originally reported [here](https://github.com/PostHog/posthog-js/issues/517)

## Problem
Thanks to some debugging with a customer, we found an interesting "edge" case that can trigger an infinite loop via console logs. The context is this was a Vue.js app that was logging some warnings which contained objects within that warning with Proxied methods that triggered logs themselves.

The situation is like this (**WARNING**: If you run this with console log recording enabled your browser will freeze).

```js
let target = {
  foo: "bar"
};

const handler = {
  get(target, prop, receiver) {
    if (prop === "foo") {
      console.warn("foo was accessed. This shouldn't be done... Context:", target)
    }
    return Reflect.get(...arguments);
  },
};

const proxy = new Proxy(target, handler);
target.proxy = proxy

console.log(proxy); 
```

1. We log the `proxy` object
2. The console log is intercepted by our code
3. It creates a "copy" of the [object via stringifying](https://github.com/rrweb-io/rrweb/blob/master/packages/rrweb/src/plugins/console/record/index.ts#L166)
4. This triggers the proxied `get` call which itself is logging a warning
5. ... which triggers Step 2 and now we have a loop 🙈 

## Solution

* Flag when we enter the block to stringify and callback the code. If any console logs occur in that time, we don't capture them to avoid infinite loops