### PR TITLE
fix: isCheckout is not included in fullsnapshot event

### DIFF
--- a/.changeset/stupid-ghosts-help.md
+++ b/.changeset/stupid-ghosts-help.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Fix: isCheckout is missed in all fullsnapshot events

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -398,6 +398,7 @@ function record<T = eventWithTime>(
           initialOffset: getWindowScroll(window),
         },
       }),
+      isCheckout,
     );
     mutationBuffers.forEach((buf) => buf.unlock()); // generate & emit any mutations that happened during snapshotting, as can now apply against the newly built mirror
 


### PR DESCRIPTION
### bug
When taking a fullsnapshot with the option `isCheckout`, the property is not included in the fullsnapshot event. I guess this property is important for a lot of use cases.