### PR TITLE
Extend the suppression of warnings to take into account anscestors

### DIFF
--- a/.changeset/proud-experts-jam.md
+++ b/.changeset/proud-experts-jam.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+For a mutation which removes a node, reduce the number of spurious warnings to take into account that an anscestor (rather than just a parent) may have been just removed

--- a/.changeset/proud-experts-jam.md
+++ b/.changeset/proud-experts-jam.md
@@ -1,5 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 For a mutation which removes a node, reduce the number of spurious warnings to take into account that an anscestor (rather than just a parent) may have been just removed

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1361,14 +1361,20 @@ export class Replayer {
     const mirror = this.usingVirtualDom ? this.virtualDom.mirror : this.mirror;
     type TNode = typeof mirror extends Mirror ? Node : RRNode;
 
+    d.removes = d.removes.filter((mutation) => {
+      // warn of absence from mirror before we start applying each removal
+      // as earlier removals could remove a tree that includes a later removal
+      if (!mirror.getNode(mutation.id)) {
+        this.warnNodeNotFound(d, mutation.id);
+        return false;
+      }
+      return true;
+    });
     d.removes.forEach((mutation) => {
       const target = mirror.getNode(mutation.id);
       if (!target) {
-        if (d.removes.find((r) => r.id === mutation.parentId)) {
-          // no need to warn, parent was already removed
-          return;
-        }
-        return this.warnNodeNotFound(d, mutation.id);
+        // no need to warn here, an ancestor may have already been removed
+        return;
       }
       let parent: Node | null | ShadowRoot | RRNode = mirror.getNode(
         mutation.parentId,


### PR DESCRIPTION
Take account that a prior removal may not have been against the immediate parent of a subsequent removal, but rather some anscestor