### PR TITLE
chore: web-extension vite.config.ts needs these changes to work for node 14

### DIFF
--- a/packages/web-extension/vite.config.ts
+++ b/packages/web-extension/vite.config.ts
@@ -21,9 +21,10 @@ function useSpecialFormat(
         (config.build?.lib as LibraryOptions)?.entry,
       );
       if (shouldUse) {
-        config.build ??= {};
+        config.build = config.build ?? {};
         // @ts-expect-error: lib needs to be an object, forcing it.
-        config.build.lib ||= {};
+        config.build.lib =
+          typeof config.build.lib == 'object' ? config.build.lib : {};
         // @ts-expect-error: lib is an object
         config.build.lib.formats = [format];
       }


### PR DESCRIPTION
I am using node 14 to build this project. web-extension fails to build. vite.config.ts needs 2 lines to be backward compatible.

yarn test at root fails. with node 14.19.3.
