### PR TITLE
improve: add try catch to snapshot.ts 's masking text function

### DIFF
--- a/.changeset/pretty-schools-remember.md
+++ b/.changeset/pretty-schools-remember.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': patch
+---
+
+Improve: Add try catch to snapshot.ts 's masking text function. Fixes [#1118](https://github.com/rrweb-io/rrweb/issues/1118).

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -257,20 +257,24 @@ export function _isBlockedElement(
   blockClass: string | RegExp,
   blockSelector: string | null,
 ): boolean {
-  if (typeof blockClass === 'string') {
-    if (element.classList.contains(blockClass)) {
-      return true;
-    }
-  } else {
-    for (let eIndex = element.classList.length; eIndex--; ) {
-      const className = element.classList[eIndex];
-      if (blockClass.test(className)) {
+  try {
+    if (typeof blockClass === 'string') {
+      if (element.classList.contains(blockClass)) {
         return true;
       }
+    } else {
+      for (let eIndex = element.classList.length; eIndex--; ) {
+        const className = element.classList[eIndex];
+        if (blockClass.test(className)) {
+          return true;
+        }
+      }
     }
-  }
-  if (blockSelector) {
-    return element.matches(blockSelector);
+    if (blockSelector) {
+      return element.matches(blockSelector);
+    }
+  } catch (e) {
+    //
   }
 
   return false;
@@ -302,22 +306,26 @@ export function needMaskingText(
   maskTextClass: string | RegExp,
   maskTextSelector: string | null,
 ): boolean {
-  const el: HTMLElement | null =
-    node.nodeType === node.ELEMENT_NODE
-      ? (node as HTMLElement)
-      : node.parentElement;
-  if (el === null) return false;
+  try {
+    const el: HTMLElement | null =
+      node.nodeType === node.ELEMENT_NODE
+        ? (node as HTMLElement)
+        : node.parentElement;
+    if (el === null) return false;
 
-  if (typeof maskTextClass === 'string') {
-    if (el.classList.contains(maskTextClass)) return true;
-    if (el.closest(`.${maskTextClass}`)) return true;
-  } else {
-    if (classMatchesRegex(el, maskTextClass, true)) return true;
-  }
+    if (typeof maskTextClass === 'string') {
+      if (el.classList.contains(maskTextClass)) return true;
+      if (el.closest(`.${maskTextClass}`)) return true;
+    } else {
+      if (classMatchesRegex(el, maskTextClass, true)) return true;
+    }
 
-  if (maskTextSelector) {
-    if (el.matches(maskTextSelector)) return true;
-    if (el.closest(maskTextSelector)) return true;
+    if (maskTextSelector) {
+      if (el.matches(maskTextSelector)) return true;
+      if (el.closest(maskTextSelector)) return true;
+    }
+  } catch (e) {
+    //
   }
   return false;
 }


### PR DESCRIPTION
fixes #1118 

Some websites polyfill classList functions of HTML elements. Their implementation may throw errors and cause the snapshot to fail. I add try-catch statements to make the code robust.