### PR TITLE
fix: First record is checkout

### DIFF
--- a/.changeset/metal-eels-tie.md
+++ b/.changeset/metal-eels-tie.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+fix: Ensure isCheckout is true on initial snapshots

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -567,7 +567,7 @@ function record<T = eventWithTime>(
     });
 
     const init = () => {
-      takeFullSnapshot();
+      takeFullSnapshot(true);
       handlers.push(observe(document));
       recording = true;
     };


### PR DESCRIPTION
I am honestly not 100% sure if this is a bug, or somehow intended.
Currently, the initial full snapshot will never have `isCheckout === true`. If I understand the `isCheckout` flag correctly, I wonder why that is the case, and why this isn't `true` for the initial full snapshot? Maybe there is a good reason for that, or I am misunderstanding something, but IMHO it makes more sense to mark this as a checkout in that case?