### PR TITLE
feat: Ignore `autoplay` attribute on video/audio elements

### DIFF
--- a/.changeset/old-dryers-hide.md
+++ b/.changeset/old-dryers-hide.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': minor
+---
+
+feat: Ignore `autoplay` attribute on video/audio elements

--- a/packages/rrweb-snapshot/src/index.ts
+++ b/packages/rrweb-snapshot/src/index.ts
@@ -1,6 +1,7 @@
 import snapshot, {
   serializeNodeWithId,
   transformAttribute,
+  ignoreAttribute,
   visitSnapshot,
   cleanupSnapshot,
   needMaskingText,
@@ -24,6 +25,7 @@ export {
   addHoverClass,
   createCache,
   transformAttribute,
+  ignoreAttribute,
   visitSnapshot,
   cleanupSnapshot,
   needMaskingText,

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -252,6 +252,10 @@ export function transformAttribute(
   }
 }
 
+function ignoreAttribute(tagName: string, name: string, _value: unknown) {
+  return (tagName === 'video' || tagName === 'audio') && name === 'autplay';
+}
+
 export function _isBlockedElement(
   element: HTMLElement,
   blockClass: string | RegExp,
@@ -614,12 +618,14 @@ function serializeElementNode(
   const len = n.attributes.length;
   for (let i = 0; i < len; i++) {
     const attr = n.attributes[i];
-    attributes[attr.name] = transformAttribute(
-      doc,
-      tagName,
-      attr.name,
-      attr.value,
-    );
+    if (!ignoreAttribute(tagName, attr.name, attr.value)) {
+      attributes[attr.name] = transformAttribute(
+        doc,
+        tagName,
+        attr.name,
+        attr.value,
+      );
+    }
   }
   // remote css
   if (tagName === 'link' && inlineStylesheet) {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -252,7 +252,11 @@ export function transformAttribute(
   }
 }
 
-export function ignoreAttribute(tagName: string, name: string, _value: unknown): boolean {
+export function ignoreAttribute(
+  tagName: string,
+  name: string,
+  _value: unknown,
+): boolean {
   return (tagName === 'video' || tagName === 'audio') && name === 'autoplay';
 }
 

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -252,8 +252,8 @@ export function transformAttribute(
   }
 }
 
-function ignoreAttribute(tagName: string, name: string, _value: unknown) {
-  return (tagName === 'video' || tagName === 'audio') && name === 'autplay';
+export function ignoreAttribute(tagName: string, name: string, _value: unknown): boolean {
+  return (tagName === 'video' || tagName === 'audio') && name === 'autoplay';
 }
 
 export function _isBlockedElement(

--- a/packages/rrweb-snapshot/test/html/video.html
+++ b/packages/rrweb-snapshot/test/html/video.html
@@ -7,7 +7,7 @@
     <title>video</title>
   </head>
   <body>
-    <video controls>
+    <video controls autoplay>
       <source src=http://techslides.com/demos/sample-videos/small.webm
       type=video/webm> <source
       src=http://techslides.com/demos/sample-videos/small.ogv type=video/ogg>

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -558,7 +558,7 @@ export default class MutationBuffer {
               styleObj[pname] = false; // delete
             }
           }
-        } else if(!ignoreAttribute(target.tagName, m.attributeName!, value)) {
+        } else if (!ignoreAttribute(target.tagName, m.attributeName!, value)) {
           // overwrite attribute if the mutations was triggered in same time
           item.attributes[m.attributeName!] = transformAttribute(
             this.doc,

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -2,6 +2,7 @@ import {
   serializeNodeWithId,
   transformAttribute,
   IGNORED_NODE,
+  ignoreAttribute,
   isShadowRoot,
   needMaskingText,
   maskInputValue,
@@ -557,7 +558,7 @@ export default class MutationBuffer {
               styleObj[pname] = false; // delete
             }
           }
-        } else {
+        } else if(!ignoreAttribute(target.tagName, m.attributeName!, value)) {
           // overwrite attribute if the mutations was triggered in same time
           item.attributes[m.attributeName!] = transformAttribute(
             this.doc,


### PR DESCRIPTION
This element leads to weird issues when replaying, so it's better to strip this out.

Not sure if there is a better way to do this, but this seems OK to me. The test snapshot not needing to be updated is basically the test that this is properly stripped.