### PR TITLE
fix the statement which is getting changed by Microbundle

### DIFF
--- a/.changeset/chatty-cherries-train.md
+++ b/.changeset/chatty-cherries-train.md
@@ -1,5 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 Fix the statement which is getting changed by Microbundle

--- a/.changeset/chatty-cherries-train.md
+++ b/.changeset/chatty-cherries-train.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Fix the statement which is getting changed by Microbundle

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -94,8 +94,9 @@ function record<T = eventWithTime>(
   let passEmitsToParent = false;
   if (!inEmittingFrame) {
     try {
-      window.parent.document; // throws if parent is cross-origin
-      passEmitsToParent = false; // if parent is same origin we collect iframe events from the parent
+      if (window.parent.document) { // throws if parent is cross-origin
+        passEmitsToParent = false; // if parent is same origin we collect iframe events from the parent
+      }
     } catch (e) {
       passEmitsToParent = true;
     }

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -94,7 +94,8 @@ function record<T = eventWithTime>(
   let passEmitsToParent = false;
   if (!inEmittingFrame) {
     try {
-      if (window.parent.document) { // throws if parent is cross-origin
+      if (window.parent.document) {
+        // throws if parent is cross-origin
         passEmitsToParent = false; // if parent is same origin we collect iframe events from the parent
       }
     } catch (e) {

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -94,8 +94,8 @@ function record<T = eventWithTime>(
   let passEmitsToParent = false;
   if (!inEmittingFrame) {
     try {
+      // throws if parent is cross-origin
       if (window.parent.document) {
-        // throws if parent is cross-origin
         passEmitsToParent = false; // if parent is same origin we collect iframe events from the parent
       }
     } catch (e) {


### PR DESCRIPTION
While testing the cross-origin iframe feature, I realized that with the compressed version, it's not working and without compression, it's working, after digging into it, I found that, the microbundle is not converting a single line statement properly, please see the attached screenshot.

I will also add this issue to the microbundle issue list as well, however, I think it should be good if we could change the statement properly, or else anyway it will crash, and catch will handle it for cross-origin iframes.

We can see in the below image, `window.parent.document` is there as a normal statement, which gets trimmed somehow as `window` in the next compressed version of the image. 

<img width="1064" alt="uncompress" src="https://user-images.githubusercontent.com/5871757/221484273-241dc008-b525-4d53-9c5b-0a267b980550.png">


We can see here, it's getting replaced as `window` only, which is causing cross-origin iframe not able to work as expected.

<img width="1047" alt="compress" src="https://user-images.githubusercontent.com/5871757/221484292-b4b460cc-396d-42da-982d-219ad6bfe4ae.png">

So, if we use this as a proper statement as per this pull request, it's working fine, please see if we can merge it @Juice10 


