### PR TITLE
Set userTriggered to false on Input attribute modifications

### DIFF
--- a/.changeset/young-timers-grow.md
+++ b/.changeset/young-timers-grow.md
@@ -1,0 +1,5 @@
+---
+"rrweb": bugfix
+---
+
+For users of userTriggeredOnInput setting: also set userTriggered to false on Input attribute modifications; this was previously empty this variant of IncrementalSource.Input

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -453,7 +453,10 @@ function initInputObserver({
           {
             set() {
               // mock to a normal event
-              eventHandler({ target: this as EventTarget } as Event);
+              eventHandler({
+                target: this as EventTarget,
+                isTrusted: false, // userTriggered to false as this could well be programmatic
+              } as Event);
             },
           },
           false,


### PR DESCRIPTION
 - the fact we are intercepting them via hook rather than an event suggests to me that they could well be programmatic

This is an extension on #495 so I'll need some more input as to whether this aligns with the spirit of that