### PR TITLE
improve: some websites rebuild imcomplete

### DIFF
--- a/.changeset/yellow-mails-cheat.md
+++ b/.changeset/yellow-mails-cheat.md
@@ -1,0 +1,8 @@
+---
+'rrweb': patch
+---
+
+Fix: some websites rebuild imcomplete
+
+1. Some websites, addedSet in emit function is not empty, but the result converted from Array.from is empty.
+2. Some websites polyfill classList functions of HTML elements. Their implementation may throw errors and cause the snapshot to fail. I add try-catch statements to make the code robust.

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -332,7 +332,7 @@ export default class MutationBuffer {
       this.mirror.removeNodeFromMap(this.mapRemoves.shift()!);
     }
 
-    for (const n of Array.from(this.movedSet.values())) {
+    for (const n of this.movedSet) {
       if (
         isParentRemoved(this.removes, n, this.mirror) &&
         !this.movedSet.has(n.parentNode!)
@@ -342,7 +342,7 @@ export default class MutationBuffer {
       pushAdd(n);
     }
 
-    for (const n of Array.from(this.addedSet.values())) {
+    for (const n of this.addedSet) {
       if (
         !isAncestorInSet(this.droppedSet, n) &&
         !isParentRemoved(this.removes, n, this.mirror)

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -228,11 +228,15 @@ export function isBlocked(
       : node.parentElement;
   if (!el) return false;
 
-  if (typeof blockClass === 'string') {
-    if (el.classList.contains(blockClass)) return true;
-    if (checkAncestors && el.closest('.' + blockClass) !== null) return true;
-  } else {
-    if (classMatchesRegex(el, blockClass, checkAncestors)) return true;
+  try {
+    if (typeof blockClass === 'string') {
+      if (el.classList.contains(blockClass)) return true;
+      if (checkAncestors && el.closest('.' + blockClass) !== null) return true;
+    } else {
+      if (classMatchesRegex(el, blockClass, checkAncestors)) return true;
+    }
+  } catch (e) {
+    // e
   }
   if (blockSelector) {
     if (el.matches(blockSelector)) return true;


### PR DESCRIPTION
fixed https://github.com/rrweb-io/rrweb/issues/1118

Some websites, addedSet in emit function is not empty, but the result converted from Array.from is empty

Some websites polyfill classList functions of HTML elements. Their implementation may throw errors and cause the snapshot to fail. I add try-catch statements to make the code robust.