### PR TITLE
feat: Better masking of option/radio/checkbox values

### DIFF
--- a/.changeset/little-moons-camp.md
+++ b/.changeset/little-moons-camp.md
@@ -1,0 +1,6 @@
+---
+'rrweb-snapshot': minor
+'rrweb': minor
+---
+
+feat: Better masking of option/radio/checkbox values

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -133,6 +133,8 @@ export type MaskInputOptions = Partial<{
   textarea: boolean;
   select: boolean;
   password: boolean;
+  radio: boolean;
+  checkbox: boolean;
 }>;
 
 export type SlimDOMOptions = Partial<{

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -174,17 +174,21 @@ export function maskInputValue({
 }: {
   element: HTMLElement;
   maskInputOptions: MaskInputOptions;
-  tagName: string;
-  type: string | null;
+  tagName: Uppercase<string>;
+  type: Lowercase<string> | null;
   value: string | null;
   maskInputFn?: MaskInputFn;
 }): string {
   let text = value || '';
-  const actualType = type && toLowerCase(type);
+
+  // Handle `option` like `select
+  if (tagName === 'OPTION') {
+    tagName = 'SELECT';
+  }
 
   if (
     maskInputOptions[tagName.toLowerCase() as keyof MaskInputOptions] ||
-    (actualType && maskInputOptions[actualType as keyof MaskInputOptions])
+    (type && maskInputOptions[type as keyof MaskInputOptions])
   ) {
     if (maskInputFn) {
       text = maskInputFn(text, element);
@@ -197,6 +201,10 @@ export function maskInputValue({
 
 export function toLowerCase<T extends string>(str: T): Lowercase<T> {
   return str.toLowerCase() as unknown as Lowercase<T>;
+}
+
+export function toUpperCase<T extends string>(str: T): Uppercase<T> {
+  return str.toUpperCase() as unknown as Uppercase<T>;
 }
 
 const ORIGINAL_ATTRIBUTE_NAME = '__rrweb_original__';
@@ -282,4 +290,22 @@ export function getInputType(element: HTMLElement): Lowercase<string> | null {
     ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       toLowerCase(type)
     : null;
+}
+
+export function getInputValue(
+  el:
+    | HTMLInputElement
+    | HTMLTextAreaElement
+    | HTMLSelectElement
+    | HTMLOptionElement,
+  tagName: Uppercase<string>,
+  type: Lowercase<string> | null,
+): string {
+  if (tagName === 'INPUT' && (type === 'radio' || type === 'checkbox')) {
+    // checkboxes & radio buttons return `on` as their el.value when no value is specified
+    // we only want to get the value if it is specified as `value='xxx'`
+    return el.getAttribute('value') || '';
+  }
+
+  return el.value;
 }

--- a/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -363,6 +363,12 @@ exports[`integration tests [html file]: picture-in-frame.html 1`] = `
   </body></html>"
 `;
 
+exports[`integration tests [html file]: picture-with-inline-onload.html 1`] = `
+"<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><head></head><body>
+    <img src=\\"http://localhost:3030/images/robot.png\\" alt=\\"This is a robot\\" style=\\"opacity: 1;\\" _onload=\\"this.style.opacity=1\\" />
+  </body></html>"
+`;
+
 exports[`integration tests [html file]: preload.html 1`] = `
 "<!DOCTYPE html><html lang=\\"en\\"><head>
     <meta charset=\\"UTF-8\\" />

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -140,6 +140,8 @@ function record<T = eventWithTime>(
           textarea: true,
           select: true,
           password: true,
+          radio: true,
+          checkbox: true,
         }
       : _maskInputOptions !== undefined
       ? _maskInputOptions

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -10,6 +10,7 @@ import {
   isNativeShadowDom,
   getInputType,
   toLowerCase,
+  getInputValue,
 } from 'rrweb-snapshot';
 import type { observerParam, MutationBufferParam } from '../types';
 import type {
@@ -504,6 +505,7 @@ export default class MutationBuffer {
         }
         break;
       }
+
       case 'attributes': {
         const target = m.target as HTMLElement;
         let attributeName = m.attributeName as string;
@@ -511,11 +513,13 @@ export default class MutationBuffer {
 
         if (attributeName === 'value') {
           const type = getInputType(target);
+          const tagName = target.tagName as unknown as Uppercase<string>;
+          value = getInputValue(target as HTMLInputElement, tagName, type);
 
           value = maskInputValue({
             element: target,
             maskInputOptions: this.maskInputOptions,
-            tagName: target.tagName,
+            tagName,
             type,
             value,
             maskInputFn: this.maskInputFn,

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1797,8 +1797,7 @@ exports[`record integration tests can record form interactions 1`] = `
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
-                              \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"on\\"
+                              \\"name\\": \\"toggle\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 27
@@ -1832,7 +1831,7 @@ exports[`record integration tests can record form interactions 1`] = `
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
                               \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"off\\",
+                              \\"value\\": \\"radio-on\\",
                               \\"checked\\": true
                             },
                             \\"childNodes\\": [],
@@ -1854,9 +1853,7 @@ exports[`record integration tests can record form interactions 1`] = `
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"checkbox\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -1867,7 +1864,9 @@ exports[`record integration tests can record form interactions 1`] = `
                             \\"type\\": 2,
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"type\\": \\"checkbox\\"
+                              \\"type\\": \\"radio\\",
+                              \\"name\\": \\"toggle\\",
+                              \\"value\\": \\"radio-off\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 37
@@ -1889,7 +1888,7 @@ exports[`record integration tests can record form interactions 1`] = `
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
                         \\"attributes\\": {
-                          \\"for\\": \\"textarea\\"
+                          \\"for\\": \\"checkbox\\"
                         },
                         \\"childNodes\\": [
                           {
@@ -1899,13 +1898,9 @@ exports[`record integration tests can record form interactions 1`] = `
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"textarea\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"cols\\": \\"30\\",
-                              \\"rows\\": \\"10\\",
-                              \\"data-unmask-example\\": \\"true\\"
+                              \\"type\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 42
@@ -1926,9 +1921,7 @@ exports[`record integration tests can record form interactions 1`] = `
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"select\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -1937,66 +1930,19 @@ exports[`record integration tests can record form interactions 1`] = `
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"select\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"value\\": \\"1\\"
+                              \\"type\\": \\"checkbox\\",
+                              \\"value\\": \\"check-on\\",
+                              \\"checked\\": true
                             },
-                            \\"childNodes\\": [
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 48
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"1\\",
-                                  \\"selected\\": true
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"1\\",
-                                    \\"id\\": 50
-                                  }
-                                ],
-                                \\"id\\": 49
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 51
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"2\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"2\\",
-                                    \\"id\\": 53
-                                  }
-                                ],
-                                \\"id\\": 52
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n        \\",
-                                \\"id\\": 54
-                              }
-                            ],
+                            \\"childNodes\\": [],
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 55
+                            \\"id\\": 48
                           }
                         ],
                         \\"id\\": 45
@@ -2004,7 +1950,128 @@ exports[`record integration tests can record form interactions 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n      \\",
-                        \\"id\\": 56
+                        \\"id\\": 49
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"textarea\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 51
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"textarea\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"cols\\": \\"30\\",
+                              \\"rows\\": \\"10\\",
+                              \\"data-unmask-example\\": \\"true\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"id\\": 52
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 53
+                          }
+                        ],
+                        \\"id\\": 50
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 54
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"select\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 56
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"select\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"value\\": \\"AA\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 58
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"AA\\",
+                                  \\"selected\\": true
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"Option A\\",
+                                    \\"id\\": 60
+                                  }
+                                ],
+                                \\"id\\": 59
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 61
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"BB\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"Opt. B\\",
+                                    \\"id\\": 63
+                                  }
+                                ],
+                                \\"id\\": 62
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"id\\": 64
+                              }
+                            ],
+                            \\"id\\": 57
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 65
+                          }
+                        ],
+                        \\"id\\": 55
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 66
                       },
                       {
                         \\"type\\": 2,
@@ -2016,7 +2083,7 @@ exports[`record integration tests can record form interactions 1`] = `
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n        \\",
-                            \\"id\\": 58
+                            \\"id\\": 68
                           },
                           {
                             \\"type\\": 2,
@@ -2025,20 +2092,20 @@ exports[`record integration tests can record form interactions 1`] = `
                               \\"type\\": \\"password\\"
                             },
                             \\"childNodes\\": [],
-                            \\"id\\": 59
+                            \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 60
+                            \\"id\\": 70
                           }
                         ],
-                        \\"id\\": 57
+                        \\"id\\": 67
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
-                        \\"id\\": 61
+                        \\"id\\": 71
                       }
                     ],
                     \\"id\\": 18
@@ -2046,7 +2113,7 @@ exports[`record integration tests can record form interactions 1`] = `
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 62
+                    \\"id\\": 72
                   },
                   {
                     \\"type\\": 2,
@@ -2056,15 +2123,15 @@ exports[`record integration tests can record form interactions 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 64
+                        \\"id\\": 74
                       }
                     ],
-                    \\"id\\": 63
+                    \\"id\\": 73
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 65
+                    \\"id\\": 75
                   }
                 ],
                 \\"id\\": 16
@@ -2170,7 +2237,7 @@ exports[`record integration tests can record form interactions 1`] = `
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"id\\": 27
     }
@@ -2179,7 +2246,7 @@ exports[`record integration tests can record form interactions 1`] = `
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"off\\",
+      \\"text\\": \\"radio-on\\",
       \\"isChecked\\": false,
       \\"id\\": 32
     }
@@ -2187,9 +2254,18 @@ exports[`record integration tests can record form interactions 1`] = `
   {
     \\"type\\": 3,
     \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"radio-off\\",
+      \\"isChecked\\": false,
+      \\"id\\": 37
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 1,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -2198,48 +2274,6 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 2,
       \\"type\\": 6,
       \\"id\\": 27
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 0,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 2,
-      \\"id\\": 37,
-      \\"pointerType\\": 0
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"on\\",
-      \\"isChecked\\": true,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 37
     }
   },
   {
@@ -2248,6 +2282,48 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 2,
       \\"type\\": 5,
       \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 0,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 2,
+      \\"id\\": 42,
+      \\"pointerType\\": 0
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"\\",
+      \\"isChecked\\": true,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 6,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 52
     }
   },
   {
@@ -2256,7 +2332,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"t\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2265,7 +2341,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"te\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2274,7 +2350,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"tex\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2283,7 +2359,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"text\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2292,7 +2368,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"texta\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2301,7 +2377,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textar\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2310,7 +2386,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textare\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2319,7 +2395,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textarea\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2328,7 +2404,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textarea \\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2337,7 +2413,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textarea t\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2346,7 +2422,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textarea te\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2355,7 +2431,7 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textarea tes\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -2364,16 +2440,16 @@ exports[`record integration tests can record form interactions 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"textarea test\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"1\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": false,
-      \\"id\\": 47
+      \\"id\\": 57
     }
   }
 ]"
@@ -3578,8 +3654,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
-                              \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"on\\"
+                              \\"name\\": \\"toggle\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 27
@@ -3613,7 +3688,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
                               \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"off\\",
+                              \\"value\\": \\"radio-on\\",
                               \\"checked\\": true
                             },
                             \\"childNodes\\": [],
@@ -3635,9 +3710,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"checkbox\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -3648,7 +3721,9 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                             \\"type\\": 2,
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"type\\": \\"checkbox\\"
+                              \\"type\\": \\"radio\\",
+                              \\"name\\": \\"toggle\\",
+                              \\"value\\": \\"radio-off\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 37
@@ -3670,7 +3745,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
                         \\"attributes\\": {
-                          \\"for\\": \\"textarea\\"
+                          \\"for\\": \\"checkbox\\"
                         },
                         \\"childNodes\\": [
                           {
@@ -3680,13 +3755,9 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"textarea\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"cols\\": \\"30\\",
-                              \\"rows\\": \\"10\\",
-                              \\"data-unmask-example\\": \\"true\\"
+                              \\"type\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 42
@@ -3707,9 +3778,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"select\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -3718,66 +3787,19 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"select\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"value\\": \\"1\\"
+                              \\"type\\": \\"checkbox\\",
+                              \\"value\\": \\"check-on\\",
+                              \\"checked\\": true
                             },
-                            \\"childNodes\\": [
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 48
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"1\\",
-                                  \\"selected\\": true
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"1\\",
-                                    \\"id\\": 50
-                                  }
-                                ],
-                                \\"id\\": 49
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 51
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"2\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"2\\",
-                                    \\"id\\": 53
-                                  }
-                                ],
-                                \\"id\\": 52
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n        \\",
-                                \\"id\\": 54
-                              }
-                            ],
+                            \\"childNodes\\": [],
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 55
+                            \\"id\\": 48
                           }
                         ],
                         \\"id\\": 45
@@ -3785,7 +3807,128 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n      \\",
-                        \\"id\\": 56
+                        \\"id\\": 49
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"textarea\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 51
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"textarea\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"cols\\": \\"30\\",
+                              \\"rows\\": \\"10\\",
+                              \\"data-unmask-example\\": \\"true\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"id\\": 52
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 53
+                          }
+                        ],
+                        \\"id\\": 50
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 54
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"select\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 56
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"select\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"value\\": \\"AA\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 58
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"AA\\",
+                                  \\"selected\\": true
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"Option A\\",
+                                    \\"id\\": 60
+                                  }
+                                ],
+                                \\"id\\": 59
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 61
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"BB\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"Opt. B\\",
+                                    \\"id\\": 63
+                                  }
+                                ],
+                                \\"id\\": 62
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"id\\": 64
+                              }
+                            ],
+                            \\"id\\": 57
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 65
+                          }
+                        ],
+                        \\"id\\": 55
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 66
                       },
                       {
                         \\"type\\": 2,
@@ -3797,7 +3940,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n        \\",
-                            \\"id\\": 58
+                            \\"id\\": 68
                           },
                           {
                             \\"type\\": 2,
@@ -3806,20 +3949,20 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                               \\"type\\": \\"password\\"
                             },
                             \\"childNodes\\": [],
-                            \\"id\\": 59
+                            \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 60
+                            \\"id\\": 70
                           }
                         ],
-                        \\"id\\": 57
+                        \\"id\\": 67
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
-                        \\"id\\": 61
+                        \\"id\\": 71
                       }
                     ],
                     \\"id\\": 18
@@ -3827,7 +3970,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 62
+                    \\"id\\": 72
                   },
                   {
                     \\"type\\": 2,
@@ -3837,15 +3980,15 @@ exports[`record integration tests can use maskInputOptions to configure which ty
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 64
+                        \\"id\\": 74
                       }
                     ],
-                    \\"id\\": 63
+                    \\"id\\": 73
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 65
+                    \\"id\\": 75
                   }
                 ],
                 \\"id\\": 16
@@ -3951,7 +4094,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"id\\": 27
     }
@@ -3960,7 +4103,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"off\\",
+      \\"text\\": \\"radio-on\\",
       \\"isChecked\\": false,
       \\"id\\": 32
     }
@@ -3968,9 +4111,18 @@ exports[`record integration tests can use maskInputOptions to configure which ty
   {
     \\"type\\": 3,
     \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"radio-off\\",
+      \\"isChecked\\": false,
+      \\"id\\": 37
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 1,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -3979,48 +4131,6 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 2,
       \\"type\\": 6,
       \\"id\\": 27
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 0,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 2,
-      \\"id\\": 37,
-      \\"pointerType\\": 0
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"on\\",
-      \\"isChecked\\": true,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 37
     }
   },
   {
@@ -4029,6 +4139,48 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 2,
       \\"type\\": 5,
       \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 0,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 2,
+      \\"id\\": 42,
+      \\"pointerType\\": 0
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"\\",
+      \\"isChecked\\": true,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 6,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 52
     }
   },
   {
@@ -4037,7 +4189,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"t\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4046,7 +4198,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"te\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4055,7 +4207,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"tex\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4064,7 +4216,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"text\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4073,7 +4225,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"texta\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4082,7 +4234,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textar\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4091,7 +4243,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textare\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4100,7 +4252,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textarea\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4109,7 +4261,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textarea \\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4118,7 +4270,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textarea t\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4127,7 +4279,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textarea te\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4136,7 +4288,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textarea tes\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4145,7 +4297,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"textarea test\\",
       \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4153,7 +4305,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 6,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -4161,7 +4313,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4170,7 +4322,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"*\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4179,7 +4331,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"**\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4188,7 +4340,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"***\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4197,7 +4349,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"****\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4206,7 +4358,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"*****\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4215,7 +4367,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"******\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4224,7 +4376,7 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"*******\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -4233,16 +4385,16 @@ exports[`record integration tests can use maskInputOptions to configure which ty
       \\"source\\": 5,
       \\"text\\": \\"********\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"1\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": false,
-      \\"id\\": 47
+      \\"id\\": 57
     }
   }
 ]"
@@ -5579,8 +5731,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
-                              \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"on\\"
+                              \\"name\\": \\"toggle\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 27
@@ -5614,7 +5765,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
                               \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"off\\",
+                              \\"value\\": \\"********\\",
                               \\"checked\\": true
                             },
                             \\"childNodes\\": [],
@@ -5636,9 +5787,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"checkbox\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -5649,7 +5798,9 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                             \\"type\\": 2,
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"type\\": \\"checkbox\\"
+                              \\"type\\": \\"radio\\",
+                              \\"name\\": \\"toggle\\",
+                              \\"value\\": \\"*********\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 37
@@ -5671,7 +5822,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
                         \\"attributes\\": {
-                          \\"for\\": \\"textarea\\"
+                          \\"for\\": \\"checkbox\\"
                         },
                         \\"childNodes\\": [
                           {
@@ -5681,13 +5832,9 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"textarea\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"cols\\": \\"30\\",
-                              \\"rows\\": \\"10\\",
-                              \\"data-unmask-example\\": \\"true\\"
+                              \\"type\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 42
@@ -5708,9 +5855,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"select\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -5719,65 +5864,19 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"select\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"value\\": \\"*\\"
+                              \\"type\\": \\"checkbox\\",
+                              \\"value\\": \\"********\\",
+                              \\"checked\\": true
                             },
-                            \\"childNodes\\": [
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 48
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"1\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"1\\",
-                                    \\"id\\": 50
-                                  }
-                                ],
-                                \\"id\\": 49
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 51
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"2\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"2\\",
-                                    \\"id\\": 53
-                                  }
-                                ],
-                                \\"id\\": 52
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n        \\",
-                                \\"id\\": 54
-                              }
-                            ],
+                            \\"childNodes\\": [],
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 55
+                            \\"id\\": 48
                           }
                         ],
                         \\"id\\": 45
@@ -5785,7 +5884,127 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n      \\",
-                        \\"id\\": 56
+                        \\"id\\": 49
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"textarea\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 51
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"textarea\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"cols\\": \\"30\\",
+                              \\"rows\\": \\"10\\",
+                              \\"data-unmask-example\\": \\"true\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"id\\": 52
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 53
+                          }
+                        ],
+                        \\"id\\": 50
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 54
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"select\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 56
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"select\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"value\\": \\"**\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 58
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"**\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"********\\",
+                                    \\"id\\": 60
+                                  }
+                                ],
+                                \\"id\\": 59
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 61
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"**\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"******\\",
+                                    \\"id\\": 63
+                                  }
+                                ],
+                                \\"id\\": 62
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"id\\": 64
+                              }
+                            ],
+                            \\"id\\": 57
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 65
+                          }
+                        ],
+                        \\"id\\": 55
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 66
                       },
                       {
                         \\"type\\": 2,
@@ -5797,7 +6016,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n        \\",
-                            \\"id\\": 58
+                            \\"id\\": 68
                           },
                           {
                             \\"type\\": 2,
@@ -5806,20 +6025,20 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                               \\"type\\": \\"password\\"
                             },
                             \\"childNodes\\": [],
-                            \\"id\\": 59
+                            \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 60
+                            \\"id\\": 70
                           }
                         ],
-                        \\"id\\": 57
+                        \\"id\\": 67
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
-                        \\"id\\": 61
+                        \\"id\\": 71
                       }
                     ],
                     \\"id\\": 18
@@ -5827,7 +6046,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 62
+                    \\"id\\": 72
                   },
                   {
                     \\"type\\": 2,
@@ -5837,15 +6056,15 @@ exports[`record integration tests should mask inputs via function call 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 64
+                        \\"id\\": 74
                       }
                     ],
-                    \\"id\\": 63
+                    \\"id\\": 73
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 65
+                    \\"id\\": 75
                   }
                 ],
                 \\"id\\": 16
@@ -5951,147 +6170,9 @@ exports[`record integration tests should mask inputs via function call 1`] = `
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"id\\": 27
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"off\\",
-      \\"isChecked\\": false,
-      \\"id\\": 32
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 1,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 27
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 0,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 2,
-      \\"id\\": 37,
-      \\"pointerType\\": 0
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"on\\",
-      \\"isChecked\\": true,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"**\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"***\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"****\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*****\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"******\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*******\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
     }
   },
   {
@@ -6100,7 +6181,24 @@ exports[`record integration tests should mask inputs via function call 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"********\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 32
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 37
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 1,
+      \\"id\\": 42
     }
   },
   {
@@ -6108,7 +6206,7 @@ exports[`record integration tests should mask inputs via function call 1`] = `
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 6,
-      \\"id\\": 59
+      \\"id\\": 27
     }
   },
   {
@@ -6122,118 +6220,43 @@ exports[`record integration tests should mask inputs via function call 1`] = `
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"t\\",
-      \\"isChecked\\": false,
+      \\"source\\": 2,
+      \\"type\\": 0,
       \\"id\\": 42
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"te\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"source\\": 2,
+      \\"type\\": 2,
+      \\"id\\": 42,
+      \\"pointerType\\": 0
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"tex\\",
-      \\"isChecked\\": false,
+      \\"text\\": \\"\\",
+      \\"isChecked\\": true,
       \\"id\\": 42
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"text\\",
-      \\"isChecked\\": false,
+      \\"source\\": 2,
+      \\"type\\": 6,
       \\"id\\": 42
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"texta\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textar\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textare\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textarea\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textarea \\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textarea t\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textarea te\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textarea tes\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"textarea test\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 69
     }
   },
   {
@@ -6242,7 +6265,212 @@ exports[`record integration tests should mask inputs via function call 1`] = `
       \\"source\\": 5,
       \\"text\\": \\"*\\",
       \\"isChecked\\": false,
-      \\"id\\": 47
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"**\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"***\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"****\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*****\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"******\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*******\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 6,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"t\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"te\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"tex\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"text\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"texta\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textar\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textare\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textarea\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textarea \\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textarea t\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textarea te\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textarea tes\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"textarea test\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"\\",
+      \\"isChecked\\": false,
+      \\"id\\": 57
     }
   }
 ]"
@@ -8844,6 +9072,15 @@ exports[`record integration tests should not record input values if dynamically 
   {
     \\"type\\": 3,
     \\"data\\": {
+      \\"source\\": 3,
+      \\"id\\": 21,
+      \\"x\\": 24,
+      \\"y\\": 0
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
       \\"source\\": 5,
       \\"text\\": \\"*************************\\",
       \\"isChecked\\": false,
@@ -9040,8 +9277,7 @@ exports[`record integration tests should not record input values if maskAllInput
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
-                              \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"on\\"
+                              \\"name\\": \\"toggle\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 27
@@ -9075,7 +9311,7 @@ exports[`record integration tests should not record input values if maskAllInput
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
                               \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"off\\",
+                              \\"value\\": \\"********\\",
                               \\"checked\\": true
                             },
                             \\"childNodes\\": [],
@@ -9097,9 +9333,7 @@ exports[`record integration tests should not record input values if maskAllInput
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"checkbox\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -9110,7 +9344,9 @@ exports[`record integration tests should not record input values if maskAllInput
                             \\"type\\": 2,
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"type\\": \\"checkbox\\"
+                              \\"type\\": \\"radio\\",
+                              \\"name\\": \\"toggle\\",
+                              \\"value\\": \\"*********\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 37
@@ -9132,7 +9368,7 @@ exports[`record integration tests should not record input values if maskAllInput
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
                         \\"attributes\\": {
-                          \\"for\\": \\"textarea\\"
+                          \\"for\\": \\"checkbox\\"
                         },
                         \\"childNodes\\": [
                           {
@@ -9142,13 +9378,9 @@ exports[`record integration tests should not record input values if maskAllInput
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"textarea\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"cols\\": \\"30\\",
-                              \\"rows\\": \\"10\\",
-                              \\"data-unmask-example\\": \\"true\\"
+                              \\"type\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 42
@@ -9169,9 +9401,7 @@ exports[`record integration tests should not record input values if maskAllInput
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"select\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -9180,65 +9410,19 @@ exports[`record integration tests should not record input values if maskAllInput
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"select\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"value\\": \\"*\\"
+                              \\"type\\": \\"checkbox\\",
+                              \\"value\\": \\"********\\",
+                              \\"checked\\": true
                             },
-                            \\"childNodes\\": [
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 48
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"1\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"1\\",
-                                    \\"id\\": 50
-                                  }
-                                ],
-                                \\"id\\": 49
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 51
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"2\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"2\\",
-                                    \\"id\\": 53
-                                  }
-                                ],
-                                \\"id\\": 52
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n        \\",
-                                \\"id\\": 54
-                              }
-                            ],
+                            \\"childNodes\\": [],
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 55
+                            \\"id\\": 48
                           }
                         ],
                         \\"id\\": 45
@@ -9246,7 +9430,127 @@ exports[`record integration tests should not record input values if maskAllInput
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n      \\",
-                        \\"id\\": 56
+                        \\"id\\": 49
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"textarea\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 51
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"textarea\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"cols\\": \\"30\\",
+                              \\"rows\\": \\"10\\",
+                              \\"data-unmask-example\\": \\"true\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"id\\": 52
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 53
+                          }
+                        ],
+                        \\"id\\": 50
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 54
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"select\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 56
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"select\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"value\\": \\"**\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 58
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"**\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"********\\",
+                                    \\"id\\": 60
+                                  }
+                                ],
+                                \\"id\\": 59
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 61
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"**\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"******\\",
+                                    \\"id\\": 63
+                                  }
+                                ],
+                                \\"id\\": 62
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"id\\": 64
+                              }
+                            ],
+                            \\"id\\": 57
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 65
+                          }
+                        ],
+                        \\"id\\": 55
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 66
                       },
                       {
                         \\"type\\": 2,
@@ -9258,7 +9562,7 @@ exports[`record integration tests should not record input values if maskAllInput
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n        \\",
-                            \\"id\\": 58
+                            \\"id\\": 68
                           },
                           {
                             \\"type\\": 2,
@@ -9267,20 +9571,20 @@ exports[`record integration tests should not record input values if maskAllInput
                               \\"type\\": \\"password\\"
                             },
                             \\"childNodes\\": [],
-                            \\"id\\": 59
+                            \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 60
+                            \\"id\\": 70
                           }
                         ],
-                        \\"id\\": 57
+                        \\"id\\": 67
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
-                        \\"id\\": 61
+                        \\"id\\": 71
                       }
                     ],
                     \\"id\\": 18
@@ -9288,7 +9592,7 @@ exports[`record integration tests should not record input values if maskAllInput
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 62
+                    \\"id\\": 72
                   },
                   {
                     \\"type\\": 2,
@@ -9298,15 +9602,15 @@ exports[`record integration tests should not record input values if maskAllInput
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 64
+                        \\"id\\": 74
                       }
                     ],
-                    \\"id\\": 63
+                    \\"id\\": 73
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 65
+                    \\"id\\": 75
                   }
                 ],
                 \\"id\\": 16
@@ -9412,7 +9716,7 @@ exports[`record integration tests should not record input values if maskAllInput
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"id\\": 27
     }
@@ -9421,235 +9725,9 @@ exports[`record integration tests should not record input values if maskAllInput
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"off\\",
+      \\"text\\": \\"********\\",
       \\"isChecked\\": false,
       \\"id\\": 32
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 1,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 27
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 0,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 2,
-      \\"id\\": 37,
-      \\"pointerType\\": 0
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"on\\",
-      \\"isChecked\\": true,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 37
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"**\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"***\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"****\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*****\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"******\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*******\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"********\\",
-      \\"isChecked\\": false,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 6,
-      \\"id\\": 59
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"**\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"***\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"****\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*****\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"******\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"*******\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"********\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
     }
   },
   {
@@ -9658,43 +9736,73 @@ exports[`record integration tests should not record input values if maskAllInput
       \\"source\\": 5,
       \\"text\\": \\"*********\\",
       \\"isChecked\\": false,
+      \\"id\\": 37
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 1,
       \\"id\\": 42
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"**********\\",
-      \\"isChecked\\": false,
+      \\"source\\": 2,
+      \\"type\\": 6,
+      \\"id\\": 27
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
       \\"id\\": 42
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"***********\\",
-      \\"isChecked\\": false,
+      \\"source\\": 2,
+      \\"type\\": 0,
       \\"id\\": 42
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"************\\",
-      \\"isChecked\\": false,
-      \\"id\\": 42
+      \\"source\\": 2,
+      \\"type\\": 2,
+      \\"id\\": 42,
+      \\"pointerType\\": 0
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"*************\\",
-      \\"isChecked\\": false,
+      \\"text\\": \\"\\",
+      \\"isChecked\\": true,
       \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 6,
+      \\"id\\": 42
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 69
     }
   },
   {
@@ -9703,7 +9811,212 @@ exports[`record integration tests should not record input values if maskAllInput
       \\"source\\": 5,
       \\"text\\": \\"*\\",
       \\"isChecked\\": false,
-      \\"id\\": 47
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"**\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"***\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"****\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*****\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"******\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*******\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 6,
+      \\"id\\": 69
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"**\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"***\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"****\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*****\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"******\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*******\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"**********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"***********\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"************\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"*************\\",
+      \\"isChecked\\": false,
+      \\"id\\": 52
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"\\",
+      \\"isChecked\\": false,
+      \\"id\\": 57
     }
   }
 ]"
@@ -12748,8 +13061,7 @@ exports[`record integration tests should record input userTriggered values if us
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
-                              \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"on\\"
+                              \\"name\\": \\"toggle\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 27
@@ -12783,7 +13095,7 @@ exports[`record integration tests should record input userTriggered values if us
                             \\"attributes\\": {
                               \\"type\\": \\"radio\\",
                               \\"name\\": \\"toggle\\",
-                              \\"value\\": \\"off\\",
+                              \\"value\\": \\"radio-on\\",
                               \\"checked\\": true
                             },
                             \\"childNodes\\": [],
@@ -12805,9 +13117,7 @@ exports[`record integration tests should record input userTriggered values if us
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"checkbox\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -12818,7 +13128,9 @@ exports[`record integration tests should record input userTriggered values if us
                             \\"type\\": 2,
                             \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"type\\": \\"checkbox\\"
+                              \\"type\\": \\"radio\\",
+                              \\"name\\": \\"toggle\\",
+                              \\"value\\": \\"radio-off\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 37
@@ -12840,7 +13152,7 @@ exports[`record integration tests should record input userTriggered values if us
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
                         \\"attributes\\": {
-                          \\"for\\": \\"textarea\\"
+                          \\"for\\": \\"checkbox\\"
                         },
                         \\"childNodes\\": [
                           {
@@ -12850,13 +13162,9 @@ exports[`record integration tests should record input userTriggered values if us
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"textarea\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"cols\\": \\"30\\",
-                              \\"rows\\": \\"10\\",
-                              \\"data-unmask-example\\": \\"true\\"
+                              \\"type\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [],
                             \\"id\\": 42
@@ -12877,9 +13185,7 @@ exports[`record integration tests should record input userTriggered values if us
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"label\\",
-                        \\"attributes\\": {
-                          \\"for\\": \\"select\\"
-                        },
+                        \\"attributes\\": {},
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
@@ -12888,66 +13194,19 @@ exports[`record integration tests should record input userTriggered values if us
                           },
                           {
                             \\"type\\": 2,
-                            \\"tagName\\": \\"select\\",
+                            \\"tagName\\": \\"input\\",
                             \\"attributes\\": {
-                              \\"name\\": \\"\\",
-                              \\"id\\": \\"\\",
-                              \\"value\\": \\"1\\"
+                              \\"type\\": \\"checkbox\\",
+                              \\"value\\": \\"check-on\\",
+                              \\"checked\\": true
                             },
-                            \\"childNodes\\": [
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 48
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"1\\",
-                                  \\"selected\\": true
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"1\\",
-                                    \\"id\\": 50
-                                  }
-                                ],
-                                \\"id\\": 49
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n          \\",
-                                \\"id\\": 51
-                              },
-                              {
-                                \\"type\\": 2,
-                                \\"tagName\\": \\"option\\",
-                                \\"attributes\\": {
-                                  \\"value\\": \\"2\\"
-                                },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"2\\",
-                                    \\"id\\": 53
-                                  }
-                                ],
-                                \\"id\\": 52
-                              },
-                              {
-                                \\"type\\": 3,
-                                \\"textContent\\": \\"\\\\n        \\",
-                                \\"id\\": 54
-                              }
-                            ],
+                            \\"childNodes\\": [],
                             \\"id\\": 47
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 55
+                            \\"id\\": 48
                           }
                         ],
                         \\"id\\": 45
@@ -12955,7 +13214,128 @@ exports[`record integration tests should record input userTriggered values if us
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n      \\",
-                        \\"id\\": 56
+                        \\"id\\": 49
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"textarea\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 51
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"textarea\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"cols\\": \\"30\\",
+                              \\"rows\\": \\"10\\",
+                              \\"data-unmask-example\\": \\"true\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"id\\": 52
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 53
+                          }
+                        ],
+                        \\"id\\": 50
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 54
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"label\\",
+                        \\"attributes\\": {
+                          \\"for\\": \\"select\\"
+                        },
+                        \\"childNodes\\": [
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n        \\",
+                            \\"id\\": 56
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"select\\",
+                            \\"attributes\\": {
+                              \\"name\\": \\"\\",
+                              \\"id\\": \\"\\",
+                              \\"value\\": \\"AA\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 58
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"AA\\",
+                                  \\"selected\\": true
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"Option A\\",
+                                    \\"id\\": 60
+                                  }
+                                ],
+                                \\"id\\": 59
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n          \\",
+                                \\"id\\": 61
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"option\\",
+                                \\"attributes\\": {
+                                  \\"value\\": \\"BB\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"Opt. B\\",
+                                    \\"id\\": 63
+                                  }
+                                ],
+                                \\"id\\": 62
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"id\\": 64
+                              }
+                            ],
+                            \\"id\\": 57
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"id\\": 65
+                          }
+                        ],
+                        \\"id\\": 55
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      \\",
+                        \\"id\\": 66
                       },
                       {
                         \\"type\\": 2,
@@ -12967,7 +13347,7 @@ exports[`record integration tests should record input userTriggered values if us
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n        \\",
-                            \\"id\\": 58
+                            \\"id\\": 68
                           },
                           {
                             \\"type\\": 2,
@@ -12976,20 +13356,20 @@ exports[`record integration tests should record input userTriggered values if us
                               \\"type\\": \\"password\\"
                             },
                             \\"childNodes\\": [],
-                            \\"id\\": 59
+                            \\"id\\": 69
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
-                            \\"id\\": 60
+                            \\"id\\": 70
                           }
                         ],
-                        \\"id\\": 57
+                        \\"id\\": 67
                       },
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n    \\",
-                        \\"id\\": 61
+                        \\"id\\": 71
                       }
                     ],
                     \\"id\\": 18
@@ -12997,7 +13377,7 @@ exports[`record integration tests should record input userTriggered values if us
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 62
+                    \\"id\\": 72
                   },
                   {
                     \\"type\\": 2,
@@ -13007,15 +13387,15 @@ exports[`record integration tests should record input userTriggered values if us
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 64
+                        \\"id\\": 74
                       }
                     ],
-                    \\"id\\": 63
+                    \\"id\\": 73
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 65
+                    \\"id\\": 75
                   }
                 ],
                 \\"id\\": 16
@@ -13125,7 +13505,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"userTriggered\\": true,
       \\"id\\": 27
@@ -13135,7 +13515,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"off\\",
+      \\"text\\": \\"radio-on\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": false,
       \\"id\\": 32
@@ -13144,9 +13524,19 @@ exports[`record integration tests should record input userTriggered values if us
   {
     \\"type\\": 3,
     \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"radio-off\\",
+      \\"isChecked\\": false,
+      \\"userTriggered\\": false,
+      \\"id\\": 37
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 1,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -13162,7 +13552,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -13170,7 +13560,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 0,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -13178,7 +13568,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 2,
-      \\"id\\": 37,
+      \\"id\\": 42,
       \\"pointerType\\": 0
     }
   },
@@ -13186,10 +13576,10 @@ exports[`record integration tests should record input userTriggered values if us
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"userTriggered\\": true,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -13197,7 +13587,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 6,
-      \\"id\\": 37
+      \\"id\\": 42
     }
   },
   {
@@ -13205,7 +13595,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13215,7 +13605,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"*\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13225,7 +13615,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"**\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13235,7 +13625,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"***\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13245,7 +13635,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"****\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13255,7 +13645,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"*****\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13265,7 +13655,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"******\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13275,7 +13665,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"*******\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13285,7 +13675,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"********\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13293,7 +13683,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 6,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   },
   {
@@ -13301,7 +13691,7 @@ exports[`record integration tests should record input userTriggered values if us
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13311,7 +13701,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"t\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13321,7 +13711,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"te\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13331,7 +13721,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"tex\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13341,7 +13731,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"text\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13351,7 +13741,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"texta\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13361,7 +13751,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textar\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13371,7 +13761,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textare\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13381,7 +13771,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textarea\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13391,7 +13781,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textarea \\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13401,7 +13791,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textarea t\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13411,7 +13801,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textarea te\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13421,7 +13811,7 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textarea tes\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
@@ -13431,17 +13821,17 @@ exports[`record integration tests should record input userTriggered values if us
       \\"text\\": \\"textarea test\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": true,
-      \\"id\\": 42
+      \\"id\\": 52
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"1\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": false,
       \\"userTriggered\\": false,
-      \\"id\\": 47
+      \\"id\\": 57
     }
   }
 ]"

--- a/packages/rrweb/test/html/form.html
+++ b/packages/rrweb/test/html/form.html
@@ -13,21 +13,27 @@
         <input type="text" />
       </label>
       <label>
-        <input type="radio" name="toggle" value="on" />
+        <input type="radio" name="toggle" />
       </label>
       <label>
-        <input type="radio" name="toggle" value="off" checked />
+        <input type="radio" name="toggle" value="radio-on" checked />
+      </label>
+      <label>
+        <input type="radio" name="toggle" value="radio-off" />
       </label>
       <label for="checkbox">
         <input type="checkbox" />
+      </label>
+      <label>
+        <input type="checkbox" value="check-on" checked />
       </label>
       <label for="textarea">
         <textarea name="" id="" cols="30" rows="10" data-unmask-example="true"></textarea>
       </label>
       <label for="select">
-        <select name="" id="">
-          <option value="1">1</option>
-          <option value="2">2</option>
+        <select name="" id="" value="AA">
+          <option value="AA">Option A</option>
+          <option value="BB">Opt. B</option>
         </select>
       </label>
       <label for="password">

--- a/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
+++ b/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
@@ -1311,8 +1311,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                 \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
                                   \\"type\\": \\"radio\\",
-                                  \\"name\\": \\"toggle\\",
-                                  \\"value\\": \\"on\\"
+                                  \\"name\\": \\"toggle\\"
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
@@ -1351,7 +1350,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                 \\"attributes\\": {
                                   \\"type\\": \\"radio\\",
                                   \\"name\\": \\"toggle\\",
-                                  \\"value\\": \\"off\\",
+                                  \\"value\\": \\"radio-on\\",
                                   \\"checked\\": true
                                 },
                                 \\"childNodes\\": [],
@@ -1377,9 +1376,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           {
                             \\"type\\": 2,
                             \\"tagName\\": \\"label\\",
-                            \\"attributes\\": {
-                              \\"for\\": \\"checkbox\\"
-                            },
+                            \\"attributes\\": {},
                             \\"childNodes\\": [
                               {
                                 \\"type\\": 3,
@@ -1391,7 +1388,9 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                 \\"type\\": 2,
                                 \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
-                                  \\"type\\": \\"checkbox\\"
+                                  \\"type\\": \\"radio\\",
+                                  \\"name\\": \\"toggle\\",
+                                  \\"value\\": \\"radio-off\\"
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
@@ -1417,7 +1416,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                             \\"type\\": 2,
                             \\"tagName\\": \\"label\\",
                             \\"attributes\\": {
-                              \\"for\\": \\"textarea\\"
+                              \\"for\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [
                               {
@@ -1428,13 +1427,9 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               },
                               {
                                 \\"type\\": 2,
-                                \\"tagName\\": \\"textarea\\",
+                                \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
-                                  \\"name\\": \\"\\",
-                                  \\"id\\": \\"\\",
-                                  \\"cols\\": \\"30\\",
-                                  \\"rows\\": \\"10\\",
-                                  \\"data-unmask-example\\": \\"true\\"
+                                  \\"type\\": \\"checkbox\\"
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
@@ -1459,9 +1454,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                           {
                             \\"type\\": 2,
                             \\"tagName\\": \\"label\\",
-                            \\"attributes\\": {
-                              \\"for\\": \\"select\\"
-                            },
+                            \\"attributes\\": {},
                             \\"childNodes\\": [
                               {
                                 \\"type\\": 3,
@@ -1471,67 +1464,13 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                               },
                               {
                                 \\"type\\": 2,
-                                \\"tagName\\": \\"select\\",
+                                \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
-                                  \\"name\\": \\"\\",
-                                  \\"id\\": \\"\\",
-                                  \\"value\\": \\"1\\"
+                                  \\"type\\": \\"checkbox\\",
+                                  \\"value\\": \\"check-on\\",
+                                  \\"checked\\": true
                                 },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"\\\\n          \\",
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 60
-                                  },
-                                  {
-                                    \\"type\\": 2,
-                                    \\"tagName\\": \\"option\\",
-                                    \\"attributes\\": {
-                                      \\"value\\": \\"1\\",
-                                      \\"selected\\": true
-                                    },
-                                    \\"childNodes\\": [
-                                      {
-                                        \\"type\\": 3,
-                                        \\"textContent\\": \\"1\\",
-                                        \\"rootId\\": 11,
-                                        \\"id\\": 62
-                                      }
-                                    ],
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 61
-                                  },
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"\\\\n          \\",
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 63
-                                  },
-                                  {
-                                    \\"type\\": 2,
-                                    \\"tagName\\": \\"option\\",
-                                    \\"attributes\\": {
-                                      \\"value\\": \\"2\\"
-                                    },
-                                    \\"childNodes\\": [
-                                      {
-                                        \\"type\\": 3,
-                                        \\"textContent\\": \\"2\\",
-                                        \\"rootId\\": 11,
-                                        \\"id\\": 65
-                                      }
-                                    ],
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 64
-                                  },
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"\\\\n        \\",
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 66
-                                  }
-                                ],
+                                \\"childNodes\\": [],
                                 \\"rootId\\": 11,
                                 \\"id\\": 59
                               },
@@ -1539,7 +1478,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
                                 \\"rootId\\": 11,
-                                \\"id\\": 67
+                                \\"id\\": 60
                               }
                             ],
                             \\"rootId\\": 11,
@@ -1549,7 +1488,145 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
                             \\"rootId\\": 11,
-                            \\"id\\": 68
+                            \\"id\\": 61
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"label\\",
+                            \\"attributes\\": {
+                              \\"for\\": \\"textarea\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 63
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"textarea\\",
+                                \\"attributes\\": {
+                                  \\"name\\": \\"\\",
+                                  \\"id\\": \\"\\",
+                                  \\"cols\\": \\"30\\",
+                                  \\"rows\\": \\"10\\",
+                                  \\"data-unmask-example\\": \\"true\\"
+                                },
+                                \\"childNodes\\": [],
+                                \\"rootId\\": 11,
+                                \\"id\\": 64
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 65
+                              }
+                            ],
+                            \\"rootId\\": 11,
+                            \\"id\\": 62
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 66
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"label\\",
+                            \\"attributes\\": {
+                              \\"for\\": \\"select\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 68
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"select\\",
+                                \\"attributes\\": {
+                                  \\"name\\": \\"\\",
+                                  \\"id\\": \\"\\",
+                                  \\"value\\": \\"AA\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 70
+                                  },
+                                  {
+                                    \\"type\\": 2,
+                                    \\"tagName\\": \\"option\\",
+                                    \\"attributes\\": {
+                                      \\"value\\": \\"AA\\",
+                                      \\"selected\\": true
+                                    },
+                                    \\"childNodes\\": [
+                                      {
+                                        \\"type\\": 3,
+                                        \\"textContent\\": \\"Option A\\",
+                                        \\"rootId\\": 11,
+                                        \\"id\\": 72
+                                      }
+                                    ],
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 71
+                                  },
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 73
+                                  },
+                                  {
+                                    \\"type\\": 2,
+                                    \\"tagName\\": \\"option\\",
+                                    \\"attributes\\": {
+                                      \\"value\\": \\"BB\\"
+                                    },
+                                    \\"childNodes\\": [
+                                      {
+                                        \\"type\\": 3,
+                                        \\"textContent\\": \\"Opt. B\\",
+                                        \\"rootId\\": 11,
+                                        \\"id\\": 75
+                                      }
+                                    ],
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 74
+                                  },
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"\\\\n        \\",
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 76
+                                  }
+                                ],
+                                \\"rootId\\": 11,
+                                \\"id\\": 69
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 77
+                              }
+                            ],
+                            \\"rootId\\": 11,
+                            \\"id\\": 67
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 78
                           },
                           {
                             \\"type\\": 2,
@@ -1562,7 +1639,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
                                 \\"rootId\\": 11,
-                                \\"id\\": 70
+                                \\"id\\": 80
                               },
                               {
                                 \\"type\\": 2,
@@ -1572,23 +1649,23 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
-                                \\"id\\": 71
+                                \\"id\\": 81
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
                                 \\"rootId\\": 11,
-                                \\"id\\": 72
+                                \\"id\\": 82
                               }
                             ],
                             \\"rootId\\": 11,
-                            \\"id\\": 69
+                            \\"id\\": 79
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
                             \\"rootId\\": 11,
-                            \\"id\\": 73
+                            \\"id\\": 83
                           }
                         ],
                         \\"rootId\\": 11,
@@ -1598,7 +1675,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
                         \\"rootId\\": 11,
-                        \\"id\\": 74
+                        \\"id\\": 84
                       }
                     ],
                     \\"rootId\\": 11,
@@ -1708,7 +1785,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
       \\"id\\": 39
     }
@@ -1717,7 +1794,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"off\\",
+      \\"text\\": \\"radio-on\\",
       \\"isChecked\\": false,
       \\"id\\": 44
     }
@@ -1725,9 +1802,18 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
   {
     \\"type\\": 3,
     \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"radio-off\\",
+      \\"isChecked\\": false,
+      \\"id\\": 49
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 1,
-      \\"id\\": 49
+      \\"id\\": 54
     }
   },
   {
@@ -1743,7 +1829,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 49
+      \\"id\\": 54
     }
   },
   {
@@ -1751,7 +1837,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 0,
-      \\"id\\": 49
+      \\"id\\": 54
     }
   },
   {
@@ -1759,7 +1845,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 2,
-      \\"id\\": 49,
+      \\"id\\": 54,
       \\"pointerType\\": 0
     }
   },
@@ -1767,9 +1853,9 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"on\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": true,
-      \\"id\\": 49
+      \\"id\\": 54
     }
   },
   {
@@ -1777,7 +1863,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 6,
-      \\"id\\": 49
+      \\"id\\": 54
     }
   },
   {
@@ -1785,7 +1871,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1794,7 +1880,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"*\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1803,7 +1889,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"**\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1812,7 +1898,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"***\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1821,7 +1907,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"****\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1830,7 +1916,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"*****\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1839,7 +1925,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"******\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1848,7 +1934,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"*******\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1857,7 +1943,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"********\\",
       \\"isChecked\\": false,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1865,7 +1951,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 6,
-      \\"id\\": 71
+      \\"id\\": 81
     }
   },
   {
@@ -1873,7 +1959,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1882,7 +1968,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"t\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1891,7 +1977,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"te\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1900,7 +1986,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"tex\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1909,7 +1995,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"text\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1918,7 +2004,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"texta\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1927,7 +2013,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textar\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1936,7 +2022,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textare\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1945,7 +2031,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textarea\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1954,7 +2040,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textarea \\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1963,7 +2049,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textarea t\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1972,7 +2058,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textarea te\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1981,7 +2067,7 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textarea tes\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
@@ -1990,16 +2076,16 @@ exports[`cross origin iframes form.html should map input events correctly 1`] = 
       \\"source\\": 5,
       \\"text\\": \\"textarea test\\",
       \\"isChecked\\": false,
-      \\"id\\": 54
+      \\"id\\": 64
     }
   },
   {
     \\"type\\": 3,
     \\"data\\": {
       \\"source\\": 5,
-      \\"text\\": \\"1\\",
+      \\"text\\": \\"\\",
       \\"isChecked\\": false,
-      \\"id\\": 59
+      \\"id\\": 69
     }
   }
 ]"
@@ -2308,8 +2394,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                 \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
                                   \\"type\\": \\"radio\\",
-                                  \\"name\\": \\"toggle\\",
-                                  \\"value\\": \\"on\\"
+                                  \\"name\\": \\"toggle\\"
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
@@ -2348,7 +2433,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                 \\"attributes\\": {
                                   \\"type\\": \\"radio\\",
                                   \\"name\\": \\"toggle\\",
-                                  \\"value\\": \\"off\\",
+                                  \\"value\\": \\"radio-on\\",
                                   \\"checked\\": true
                                 },
                                 \\"childNodes\\": [],
@@ -2374,9 +2459,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           {
                             \\"type\\": 2,
                             \\"tagName\\": \\"label\\",
-                            \\"attributes\\": {
-                              \\"for\\": \\"checkbox\\"
-                            },
+                            \\"attributes\\": {},
                             \\"childNodes\\": [
                               {
                                 \\"type\\": 3,
@@ -2388,7 +2471,9 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                 \\"type\\": 2,
                                 \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
-                                  \\"type\\": \\"checkbox\\"
+                                  \\"type\\": \\"radio\\",
+                                  \\"name\\": \\"toggle\\",
+                                  \\"value\\": \\"radio-off\\"
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
@@ -2414,7 +2499,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                             \\"type\\": 2,
                             \\"tagName\\": \\"label\\",
                             \\"attributes\\": {
-                              \\"for\\": \\"textarea\\"
+                              \\"for\\": \\"checkbox\\"
                             },
                             \\"childNodes\\": [
                               {
@@ -2425,13 +2510,9 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               },
                               {
                                 \\"type\\": 2,
-                                \\"tagName\\": \\"textarea\\",
+                                \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
-                                  \\"name\\": \\"\\",
-                                  \\"id\\": \\"\\",
-                                  \\"cols\\": \\"30\\",
-                                  \\"rows\\": \\"10\\",
-                                  \\"data-unmask-example\\": \\"true\\"
+                                  \\"type\\": \\"checkbox\\"
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
@@ -2456,9 +2537,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                           {
                             \\"type\\": 2,
                             \\"tagName\\": \\"label\\",
-                            \\"attributes\\": {
-                              \\"for\\": \\"select\\"
-                            },
+                            \\"attributes\\": {},
                             \\"childNodes\\": [
                               {
                                 \\"type\\": 3,
@@ -2468,67 +2547,13 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                               },
                               {
                                 \\"type\\": 2,
-                                \\"tagName\\": \\"select\\",
+                                \\"tagName\\": \\"input\\",
                                 \\"attributes\\": {
-                                  \\"name\\": \\"\\",
-                                  \\"id\\": \\"\\",
-                                  \\"value\\": \\"1\\"
+                                  \\"type\\": \\"checkbox\\",
+                                  \\"value\\": \\"check-on\\",
+                                  \\"checked\\": true
                                 },
-                                \\"childNodes\\": [
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"\\\\n          \\",
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 60
-                                  },
-                                  {
-                                    \\"type\\": 2,
-                                    \\"tagName\\": \\"option\\",
-                                    \\"attributes\\": {
-                                      \\"value\\": \\"1\\",
-                                      \\"selected\\": true
-                                    },
-                                    \\"childNodes\\": [
-                                      {
-                                        \\"type\\": 3,
-                                        \\"textContent\\": \\"1\\",
-                                        \\"rootId\\": 11,
-                                        \\"id\\": 62
-                                      }
-                                    ],
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 61
-                                  },
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"\\\\n          \\",
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 63
-                                  },
-                                  {
-                                    \\"type\\": 2,
-                                    \\"tagName\\": \\"option\\",
-                                    \\"attributes\\": {
-                                      \\"value\\": \\"2\\"
-                                    },
-                                    \\"childNodes\\": [
-                                      {
-                                        \\"type\\": 3,
-                                        \\"textContent\\": \\"2\\",
-                                        \\"rootId\\": 11,
-                                        \\"id\\": 65
-                                      }
-                                    ],
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 64
-                                  },
-                                  {
-                                    \\"type\\": 3,
-                                    \\"textContent\\": \\"\\\\n        \\",
-                                    \\"rootId\\": 11,
-                                    \\"id\\": 66
-                                  }
-                                ],
+                                \\"childNodes\\": [],
                                 \\"rootId\\": 11,
                                 \\"id\\": 59
                               },
@@ -2536,7 +2561,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
                                 \\"rootId\\": 11,
-                                \\"id\\": 67
+                                \\"id\\": 60
                               }
                             ],
                             \\"rootId\\": 11,
@@ -2546,7 +2571,145 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n      \\",
                             \\"rootId\\": 11,
-                            \\"id\\": 68
+                            \\"id\\": 61
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"label\\",
+                            \\"attributes\\": {
+                              \\"for\\": \\"textarea\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 63
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"textarea\\",
+                                \\"attributes\\": {
+                                  \\"name\\": \\"\\",
+                                  \\"id\\": \\"\\",
+                                  \\"cols\\": \\"30\\",
+                                  \\"rows\\": \\"10\\",
+                                  \\"data-unmask-example\\": \\"true\\"
+                                },
+                                \\"childNodes\\": [],
+                                \\"rootId\\": 11,
+                                \\"id\\": 64
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 65
+                              }
+                            ],
+                            \\"rootId\\": 11,
+                            \\"id\\": 62
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 66
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"label\\",
+                            \\"attributes\\": {
+                              \\"for\\": \\"select\\"
+                            },
+                            \\"childNodes\\": [
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n        \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 68
+                              },
+                              {
+                                \\"type\\": 2,
+                                \\"tagName\\": \\"select\\",
+                                \\"attributes\\": {
+                                  \\"name\\": \\"\\",
+                                  \\"id\\": \\"\\",
+                                  \\"value\\": \\"AA\\"
+                                },
+                                \\"childNodes\\": [
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 70
+                                  },
+                                  {
+                                    \\"type\\": 2,
+                                    \\"tagName\\": \\"option\\",
+                                    \\"attributes\\": {
+                                      \\"value\\": \\"AA\\",
+                                      \\"selected\\": true
+                                    },
+                                    \\"childNodes\\": [
+                                      {
+                                        \\"type\\": 3,
+                                        \\"textContent\\": \\"Option A\\",
+                                        \\"rootId\\": 11,
+                                        \\"id\\": 72
+                                      }
+                                    ],
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 71
+                                  },
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"\\\\n          \\",
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 73
+                                  },
+                                  {
+                                    \\"type\\": 2,
+                                    \\"tagName\\": \\"option\\",
+                                    \\"attributes\\": {
+                                      \\"value\\": \\"BB\\"
+                                    },
+                                    \\"childNodes\\": [
+                                      {
+                                        \\"type\\": 3,
+                                        \\"textContent\\": \\"Opt. B\\",
+                                        \\"rootId\\": 11,
+                                        \\"id\\": 75
+                                      }
+                                    ],
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 74
+                                  },
+                                  {
+                                    \\"type\\": 3,
+                                    \\"textContent\\": \\"\\\\n        \\",
+                                    \\"rootId\\": 11,
+                                    \\"id\\": 76
+                                  }
+                                ],
+                                \\"rootId\\": 11,
+                                \\"id\\": 69
+                              },
+                              {
+                                \\"type\\": 3,
+                                \\"textContent\\": \\"\\\\n      \\",
+                                \\"rootId\\": 11,
+                                \\"id\\": 77
+                              }
+                            ],
+                            \\"rootId\\": 11,
+                            \\"id\\": 67
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n      \\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 78
                           },
                           {
                             \\"type\\": 2,
@@ -2559,7 +2722,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n        \\",
                                 \\"rootId\\": 11,
-                                \\"id\\": 70
+                                \\"id\\": 80
                               },
                               {
                                 \\"type\\": 2,
@@ -2569,23 +2732,23 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                                 },
                                 \\"childNodes\\": [],
                                 \\"rootId\\": 11,
-                                \\"id\\": 71
+                                \\"id\\": 81
                               },
                               {
                                 \\"type\\": 3,
                                 \\"textContent\\": \\"\\\\n      \\",
                                 \\"rootId\\": 11,
-                                \\"id\\": 72
+                                \\"id\\": 82
                               }
                             ],
                             \\"rootId\\": 11,
-                            \\"id\\": 69
+                            \\"id\\": 79
                           },
                           {
                             \\"type\\": 3,
                             \\"textContent\\": \\"\\\\n    \\",
                             \\"rootId\\": 11,
-                            \\"id\\": 73
+                            \\"id\\": 83
                           }
                         ],
                         \\"rootId\\": 11,
@@ -2595,7 +2758,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
                         \\"rootId\\": 11,
-                        \\"id\\": 74
+                        \\"id\\": 84
                       }
                     ],
                     \\"rootId\\": 11,


### PR DESCRIPTION
This PR improves masking via `maskAllInputs` for:

* `<option>` elements as part of `<select>`
* `<input type="checkbox">`
* `<input type="radio">`

## What is masked

For radio/checkbox, we only mask the `value="xxx"` attribute. So for example:

```html
<input type="radio" value="my-val">
```

becomes 

```html
<input type="radio" value="******">
```

If no value is specified, nothing is added.

For `option` tags, we mask both the `value` attribute on them (so they also match the value of the `select`), as well as the content of the option - this is IMHO more in line with text input masking than to leave the displayed text.

```html
<select value="val1">
  <option value="val1">Value 1</option>
  <option value="val2">Value 2</option>
</select>
```

becomes

```html
<select value="****">
  <option value="****">*******</option>
  <option value="****">*******</option>
</select>
```