### PR TITLE
fix: Cannot set property attributeName of #<MutationRecord> which has only a getter

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1199,7 +1199,7 @@ function snapshot(
     maskAllInputs?: boolean | MaskInputOptions;
     maskTextFn?: MaskTextFn;
     maskInputFn?: MaskTextFn;
-    slimDOM?: boolean | SlimDOMOptions;
+    slimDOM?: 'all' | boolean | SlimDOMOptions;
     dataURLOptions?: DataURLOptions;
     inlineImages?: boolean;
     recordCanvas?: boolean;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -509,15 +509,9 @@ export default class MutationBuffer {
         if (
           target.tagName === 'IFRAME' &&
           m.attributeName === 'src' &&
-          !this.keepIframeSrcFn(value as string)
+          (target as HTMLIFrameElement).contentDocument
         ) {
-          if (!(target as HTMLIFrameElement).contentDocument) {
-            // we can't record it directly as we can't see into it
-            // preserve the src attribute so a decision can be taken at replay time
-            m.attributeName = 'rr_src';
-          } else {
-            return;
-          }
+          return;
         }
         if (!item) {
           item = {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -265,14 +265,14 @@ export type hooksParam = {
 };
 
 // https://dom.spec.whatwg.org/#interface-mutationrecord
-export type mutationRecord = {
+export type mutationRecord = Readonly<{
   type: string;
   target: Node;
   oldValue: string | null;
   addedNodes: NodeList;
   removedNodes: NodeList;
   attributeName: string | null;
-};
+}>;
 
 export type textCursor = {
   node: Node;


### PR DESCRIPTION
1. fix MutationRecord type error: [Properties in MutationRecord are all ReadOnly](https://dom.spec.whatwg.org/#interface-mutationrecord) which will throw a runtime type error
2. fix slimDOM type error in `rrweb-snapshot`