### PR TITLE
fix: worker_thread warning

### DIFF
--- a/.changeset/fast-chefs-smell.md
+++ b/.changeset/fast-chefs-smell.md
@@ -1,5 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 fix: worker_thread warning

--- a/.changeset/fast-chefs-smell.md
+++ b/.changeset/fast-chefs-smell.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+fix: worker_thread warning

--- a/.changeset/fast-chefs-smell.md
+++ b/.changeset/fast-chefs-smell.md
@@ -2,4 +2,4 @@
 'rrweb': patch
 ---
 
-fix: worker_thread warning
+Fix: [#1178](https://github.com/rrweb-io/rrweb/issues/1178) remove warning related to worker_threads while building

--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -144,7 +144,7 @@ for (const c of baseConfigs) {
     resolve({ browser: true }),
 
     // supports bundling `web-worker:..filename`
-    webWorkerLoader(),
+    webWorkerLoader({ targetPlatform: 'browser' }),
 
     typescript(),
   ];


### PR DESCRIPTION
fix: https://github.com/rrweb-io/rrweb/issues/1178

this issue is known in：https://github.com/darionco/rollup-plugin-web-worker-loader/issues/20

The same issue was fixed in:
1. use-cannon: https://github.com/pmndrs/use-cannon/pull/353
2. use-p2: https://github.com/pmndrs/use-p2/pull/8