### PR TITLE
fix: Ensure attributes are lowercased when checking

### DIFF
--- a/.changeset/lovely-students-boil.md
+++ b/.changeset/lovely-students-boil.md
@@ -1,0 +1,6 @@
+---
+'rrweb-snapshot': patch
+'rrweb': patch
+---
+
+fix: Ensure attributes are lowercased when checking

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -21,6 +21,7 @@ import {
   isNativeShadowDom,
   getCssRulesString,
   getInputType,
+  toLowerCase,
 } from './utils';
 
 let _id = 1;
@@ -37,9 +38,7 @@ function getValidTagName(element: HTMLElement): Lowercase<string> {
     return 'form';
   }
 
-  const processedTagName = element.tagName
-    .toLowerCase()
-    .trim() as Lowercase<string>;
+  const processedTagName = toLowerCase(element.tagName);
 
   if (tagNameRegex.test(processedTagName)) {
     // if the tag name is odd and we cannot extract
@@ -640,7 +639,7 @@ function serializeElementNode(
       attributes[attr.name] = transformAttribute(
         doc,
         tagName,
-        attr.name.toLowerCase() as Lowercase<string>,
+        toLowerCase(attr.name),
         attr.value,
       );
     }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -32,12 +32,14 @@ export function genId(): number {
   return _id++;
 }
 
-function getValidTagName(element: HTMLElement): string {
+function getValidTagName(element: HTMLElement): Lowercase<string> {
   if (element instanceof HTMLFormElement) {
     return 'form';
   }
 
-  const processedTagName = element.tagName.toLowerCase().trim();
+  const processedTagName = element.tagName
+    .toLowerCase()
+    .trim() as Lowercase<string>;
 
   if (tagNameRegex.test(processedTagName)) {
     // if the tag name is odd and we cannot extract
@@ -222,8 +224,8 @@ function getHref() {
 
 export function transformAttribute(
   doc: Document,
-  tagName: string,
-  name: string,
+  tagName: Lowercase<string>,
+  name: Lowercase<string>,
   value: string | null,
 ): string | null {
   if (!value) {
@@ -638,7 +640,7 @@ function serializeElementNode(
       attributes[attr.name] = transformAttribute(
         doc,
         tagName,
-        attr.name,
+        attr.name.toLowerCase() as Lowercase<string>,
         attr.value,
       );
     }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -186,7 +186,7 @@ export function maskInputValue({
 
 export function toLowerCase<T extends string>(str: T): Lowercase<T> {
   return str.toLowerCase() as unknown as Lowercase<T>;
-} 
+}
 
 const ORIGINAL_ATTRIBUTE_NAME = '__rrweb_original__';
 type PatchedGetImageData = {
@@ -269,6 +269,6 @@ export function getInputType(element: HTMLElement): Lowercase<string> | null {
     ? 'password'
     : type
     ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    toLowerCase(type)
+      toLowerCase(type)
     : null;
 }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -169,7 +169,7 @@ export function maskInputValue({
   maskInputFn?: MaskInputFn;
 }): string {
   let text = value || '';
-  const actualType = type && type.toLowerCase();
+  const actualType = type && toLowerCase(type);
 
   if (
     maskInputOptions[tagName.toLowerCase() as keyof MaskInputOptions] ||
@@ -183,6 +183,10 @@ export function maskInputValue({
   }
   return text;
 }
+
+export function toLowerCase<T extends string>(str: T): Lowercase<T> {
+  return str.toLowerCase() as unknown as Lowercase<T>;
+} 
 
 const ORIGINAL_ATTRIBUTE_NAME = '__rrweb_original__';
 type PatchedGetImageData = {
@@ -265,6 +269,6 @@ export function getInputType(element: HTMLElement): Lowercase<string> | null {
     ? 'password'
     : type
     ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      (type.toLowerCase() as Lowercase<string>)
+    toLowerCase(type)
     : null;
 }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -9,6 +9,7 @@ import {
   Mirror,
   isNativeShadowDom,
   getInputType,
+  toLowerCase,
 } from 'rrweb-snapshot';
 import type { observerParam, MutationBufferParam } from '../types';
 import type {
@@ -579,8 +580,8 @@ export default class MutationBuffer {
           // overwrite attribute if the mutations was triggered in same time
           item.attributes[attributeName] = transformAttribute(
             this.doc,
-            target.tagName.toLowerCase() as Lowercase<string>,
-            attributeName.toLowerCase() as Lowercase<string>,
+            toLowerCase(target.tagName),
+            toLowerCase(attributeName),
             value,
           );
         }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -579,8 +579,8 @@ export default class MutationBuffer {
           // overwrite attribute if the mutations was triggered in same time
           item.attributes[attributeName] = transformAttribute(
             this.doc,
-            target.tagName,
-            attributeName,
+            target.tagName.toLowerCase() as Lowercase<string>,
+            attributeName.toLowerCase() as Lowercase<string>,
             value,
           );
         }

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -3,6 +3,7 @@ import {
   maskInputValue,
   Mirror,
   getInputType,
+  toLowerCase,
 } from 'rrweb-snapshot';
 import type { FontFaceSet } from 'css-font-loading-module';
 import {
@@ -309,13 +310,13 @@ function initMouseInteractionObserver({
         disableMap[key] !== false,
     )
     .forEach((eventKey: keyof typeof MouseInteractions) => {
-      let eventName = eventKey.toLowerCase();
+      let eventName = toLowerCase(eventKey);
       const handler = getHandler(eventKey);
       if (window.PointerEvent) {
         switch (MouseInteractions[eventKey]) {
           case MouseInteractions.MouseDown:
           case MouseInteractions.MouseUp:
-            eventName = eventName.replace('mouse', 'pointer');
+            eventName = eventName.replace('mouse', 'pointer') as unknown as typeof eventName;
             break;
           case MouseInteractions.TouchStart:
           case MouseInteractions.TouchEnd:

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -316,7 +316,10 @@ function initMouseInteractionObserver({
         switch (MouseInteractions[eventKey]) {
           case MouseInteractions.MouseDown:
           case MouseInteractions.MouseUp:
-            eventName = eventName.replace('mouse', 'pointer') as unknown as typeof eventName;
+            eventName = eventName.replace(
+              'mouse',
+              'pointer',
+            ) as unknown as typeof eventName;
             break;
           case MouseInteractions.TouchStart:
           case MouseInteractions.TouchEnd:

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -8,6 +8,7 @@ import {
   createMirror,
   attributes,
   serializedElementNodeWithId,
+  toLowerCase,
 } from 'rrweb-snapshot';
 import {
   RRDocument,
@@ -1120,7 +1121,7 @@ export class Replayer {
         if (d.id === -1) {
           break;
         }
-        const event = new Event(MouseInteractions[d.type].toLowerCase());
+        const event = new Event(toLowerCase(MouseInteractions[d.type]));
         const target = this.mirror.getNode(d.id);
         if (!target) {
           return this.debugNodeNotFound(d, d.id);


### PR DESCRIPTION
This is currently not enforced, and could lead to bugs.

I tried to add a test but it seems that `absoluteToDoc()` always returns `''` in the tests (for whatever reason), making this rather hard to test. Happy about any pointers how to test this nicely!