### PR TITLE
Perf: optimize the performance of processMutations

### DIFF
--- a/.changeset/flat-foxes-juggle.md
+++ b/.changeset/flat-foxes-juggle.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Optimize performance of the processMutations


### PR DESCRIPTION
`processMutations` contains two phases:

1. **processMutation**
2. **emit**

and they have bad performance in some cases.

## processMutation

### case

In the case below: (reproduce link: https://github.com/wfk007/test-processMutation)

we create 1000 ElementNode and insert them into `#target`, each Node is the parent of the following Node

```html
<html>
    <body>
        <button id="add-nodes">Add multi nodes</button>

        <div id="target"></div>

        <script src="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/record/rrweb-record.min.js"></script>
        <script>
            const addNodes = document.querySelector('#add-nodes');
            const target = document.querySelector('#target');

            addNodes.addEventListener('click', () => {
                const total = 1000;
                let parent = target;
                for (let i = 0; i < total; i++) {
                    const el = document.createElement('div');
                    el.textContent = `el-${i + 1}`;
                    parent.append(el);
                    parent = el;
                }
            });
            rrwebRecord({
                sampling: {
                    mouseInteraction: false,
                    mousemove: false,
                    scroll: 300,
                    input: 'last',
                },
                slimDOMOptions: true,
                emit(event) {
                    console.log(event);
                },
            });
        </script>
    </body>
</html>
```

### performance

WITHOUT `record`, it takes about **50ms** to render

![image](https://user-images.githubusercontent.com/22289445/227211614-619a4d8d-17cc-4dcf-9c0c-378cb530cc59.png)

---

WITH `record` it takes **655ms** and processMutation takes **604ms**

![image](https://user-images.githubusercontent.com/22289445/227212017-da10e3d0-f405-4621-9512-74da5211a8d3.png)

### reason

The dom structure below can be created in many ways:
```
body
    E1
       E2
```

Approach 1:
1. create E1
2. create E2
3. E1 append E2
4. body append E1

Browser Mutation observer callback result:
```
[
    {
        target: body,
        addedNodes: [E1],
        type: "childList",
    },
]
```

approach 2:
1. create E1
2. body append E1
3. create E2
4. E1 append E2

Browser Mutation observer callback result:
```
[
    {
        target: body,
        addedNodes: [E1],
        type: "childList",
    },
    {
        target: E1,
        addedNodes: [E2],
        type: "childList",
    },
]
```

In order to cover different Mutation observer callback results and track adds/removes Nodes, RRweb loops all mutations and its' `addedNodes`.
Each Node in `addedNodes` will still travel all its' childNodes.

Considering approach2 result:
1. loop array index 0:
travel E1
travel E2(which is the childNode of E1) 
2. loop array index 1:
travel E2(no need to travel E2 and its' childNodes again)

### solution

In `genAdds`, if the node is added to `addedSet` or `movedSet`, there is no need to travel it and its' children again

after optimizing, it takes **160ms** and processMutation takes **77ms**

![image](https://user-images.githubusercontent.com/22289445/227213279-129b8e5c-0fe7-450b-aa31-f8ace10ca7b6.png)

## emit

### case
(case is on the way)

### performance

when the size of addedSet is huge(2w+ Nodes), the for-loop is very slow with time complexity O(n^2) to find a valid Node

<img width="987" alt="image" src="https://user-images.githubusercontent.com/22289445/227772648-76bd8b64-2ae8-4664-ba0f-5cd890cb567b.png">


### reason

![image](https://user-images.githubusercontent.com/22289445/227772281-c12cff8d-0bd9-4f73-9fb0-9a4e76ea1918.png)
There are 20000 nodes in addList, and index 900 is the first valid Node from right to left, but its' previous is not a valid Node. we loop from right to left to find the first valid Node

1. addList.get(19999): O(N) time complexity and it is very slow
2. addList.get(19998): O(N) time complexity and it is slow too
3. ...
4. addList(900): find valid Node
5. 899 is selected as candidate Node
6. 899 is invalid
7. so we loop from right to left
8. repeat 1/2/3...

It is very very slow(takes about 16s).

### solution

I create a linkedNodeList based on DoubleLinkedList to accelerate node query with array index, and query time complexity decrease from O(n) to O(1) with a huge performance boost

![image](https://user-images.githubusercontent.com/22289445/227773158-090fd727-65a2-4d20-9e13-00e49fbab973.png)

<img width="727" alt="image" src="https://user-images.githubusercontent.com/22289445/228466290-3f9f806e-2f93-4f26-b36c-700ab593b312.png">




 