### PR TITLE
Guard against redefinition of Date.now

### DIFF
--- a/.changeset/date-now-guard.md
+++ b/.changeset/date-now-guard.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Guard against presence of older 3rd party javascript libraries which redefine Date.now()

--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -2,4 +2,4 @@
 'rrweb': patch
 ---
 
-Guard against redefinition of Date.now by third party libraries which are also present on a page alongside rrweb 
+Guard against redefinition of Date.now by third party libraries which are also present on a page alongside rrweb

--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -1,6 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 Guard against redefinition of Date.now by third party libraries which are also present on a page alongside rrweb
-

--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -2,4 +2,4 @@
 'rrweb': patch
 ---
 
-Guard against redefinition of Date.now by third party libraries which are also present on a page alongside rrweb
+Guard against redefinition of Date.now by third party libraries which are also present on a page alongside rrweb 

--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -1,0 +1,6 @@
+---
+"rrweb": patch
+---
+
+Guard against redefinition of Date.now by third party libraries which are also present on a page alongside rrweb
+

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -14,6 +14,7 @@ import {
   hasShadowRoot,
   isSerializedIframe,
   isSerializedStylesheet,
+  nowTimestamp,
 } from '../utils';
 import type { recordOptions } from '../types';
 import {
@@ -42,7 +43,7 @@ import {
 function wrapEvent(e: event): eventWithTime {
   return {
     ...e,
-    timestamp: Date.now(),
+    timestamp: nowTimestamp(),
   };
 }
 

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -30,6 +30,7 @@ import {
   isSerializedStylesheet,
   inDom,
   getShadowHost,
+  nowTimestamp,
 } from '../utils';
 
 type DoubleLinkedListNode = {

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -30,7 +30,6 @@ import {
   isSerializedStylesheet,
   inDom,
   getShadowHost,
-  nowTimestamp,
 } from '../utils';
 
 type DoubleLinkedListNode = {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -16,6 +16,7 @@ import {
   legacy_isTouchEvent,
   patch,
   StyleSheetMirror,
+  nowTimestamp,
 } from '../utils';
 import type { observerParam, MutationBufferParam } from '../types';
 import {
@@ -180,13 +181,13 @@ function initMoveObserver({
           ? evt.changedTouches[0]
           : evt;
         if (!timeBaseline) {
-          timeBaseline = Date.now();
+          timeBaseline = nowTimestamp();
         }
         positions.push({
           x: clientX,
           y: clientY,
           id: mirror.getId(target as Node),
-          timeOffset: Date.now() - timeBaseline,
+          timeOffset: nowTimestamp() - timeBaseline,
         });
         // it is possible DragEvent is undefined even on devices
         // that support event 'drag'

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -171,7 +171,7 @@ export function patch(
 // guard against old third party libraries which redefine Date.now
 let nowTimestamp = Date.now;
 
-if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now()))) {
+if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now().toString()))) {
   // they have already redefined it! use a fallback
   nowTimestamp = () => new Date().getTime();
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -172,7 +172,7 @@ export function patch(
 let nowTimestamp = Date.now;
 if (!/[1-9][0-9]{12}/.test(Date.now())) {
   // they have already redefined it! use a fallback
-  nowTimestamp = () => (new Date()).getTime();
+  nowTimestamp = () => new Date().getTime();
 }
 export { nowTimestamp };
 

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -170,7 +170,8 @@ export function patch(
 
 // guard against old third party libraries which redefine Date.now
 let nowTimestamp = Date.now;
-if (!/[1-9][0-9]{12}/.test(Date.now())) {
+
+if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now()))) {
   // they have already redefined it! use a fallback
   nowTimestamp = () => new Date().getTime();
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -168,6 +168,14 @@ export function patch(
   }
 }
 
+// guard against old third party libraries which redefine Date.now
+let nowTimestamp = Date.now;
+if (!/[1-9][0-9]{12}/.test(Date.now())) {
+  // they have already redefined it! use a fallback
+  nowTimestamp = () => (new Date()).getTime();
+}
+export { nowTimestamp };
+
 export function getWindowScroll(win: Window) {
   const doc = win.document;
   return {


### PR DESCRIPTION
Guard against presence of likely older third party libraries which (re)define Date.now, e.g. https://github.com/datejs/Datejs/issues/92