### PR TITLE
fix: Set finished=false in goto instead of handleProgressClick

### DIFF
--- a/.changeset/controller-finish-flag.md
+++ b/.changeset/controller-finish-flag.md
@@ -1,0 +1,6 @@
+---
+"rrweb-player": patch
+"rrweb": patch
+---
+
+Reset the finished flag in Controller `goto` instead of `handleProgressClick` so that it is properly handled if `goto` is called directly.

--- a/.changeset/controller-finish-flag.md
+++ b/.changeset/controller-finish-flag.md
@@ -1,6 +1,6 @@
 ---
-"rrweb-player": patch
-"rrweb": patch
+'rrweb-player': patch
+'rrweb': patch
 ---
 
 Reset the finished flag in Controller `goto` instead of `handleProgressClick` so that it is properly handled if `goto` is called directly.

--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -208,6 +208,7 @@
   export const goto = (timeOffset: number, play?: boolean) => {
     currentTime = timeOffset;
     pauseAt = false;
+    finished = false;
     const resumePlaying =
       typeof play === 'boolean' ? play : playerState === 'playing';
     if (resumePlaying) {
@@ -250,7 +251,6 @@
       percent = 1;
     }
     const timeOffset = meta.totalTime * percent;
-    finished = false;
     goto(timeOffset);
   };
 


### PR DESCRIPTION
If the player finishes a replaying a video the Controller's `finished` boolean is set to true. This allows the video to be restarted at the beginning if the controller is toggled to play. If a user clicks on the progress bar the `finished` boolean is reset so when `toggle` is called it starts at the right place. If a user programatically calls `goto`, which is the underlying API for handling the progress bar click, the next invocation of `toggle` will start the video at the beginning instead of the proper location.