### PR TITLE
perf: record processMutation

### DIFF
--- a/.changeset/mean-tips-impress.md
+++ b/.changeset/mean-tips-impress.md
@@ -1,5 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 perf: optimize the performance of record in processMutation phase

--- a/.changeset/mean-tips-impress.md
+++ b/.changeset/mean-tips-impress.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+perf: optimize the performance of record in processMutation phase

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -656,6 +656,9 @@ export default class MutationBuffer {
     // this node was already recorded in other buffer, ignore it
     if (this.processedNodeManager.inOtherBuffer(n, this)) return;
 
+    // if n is added to set, there is no need to travel it and its' children again
+    if (this.addedSet.has(n) || this.movedSet.has(n)) return;
+
     if (this.mirror.hasNode(n)) {
       if (isIgnored(n, this.mirror)) {
         return;

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -30,6 +30,12 @@ const suites: Array<
     eval: 'window.workload()',
     times: 10,
   },
+  {
+    title: 'create 1000 DOM nodes and append into its previous looped node',
+    html: 'benchmark-dom-mutation-multiple-descendant-add.html',
+    eval: 'window.workload()',
+    times: 5,
+  },
 ];
 
 function avg(v: number[]): number {

--- a/packages/rrweb/test/html/benchmark-dom-mutation-multiple-descendant-add.html
+++ b/packages/rrweb/test/html/benchmark-dom-mutation-multiple-descendant-add.html
@@ -1,0 +1,18 @@
+<html>
+  <body></body>
+  <script>
+    function addMultiNodes() {
+      const total = 1000;
+      let parent = document.body;
+      for (let i = 0; i < total; i++) {
+        const el = document.createElement('div');
+        el.textContent = `el-${i + 1}`;
+        parent.append(el);
+        parent = el;
+      }
+    }
+    window.workload = () => {
+      addMultiNodes();
+    };
+  </script>
+</html>


### PR DESCRIPTION
Before:

```
┌─────────┬──────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬───────────────────────────┐
    │ (index) │                              title                               │                         html                          │        eval         │ times │ duration │         durations         │
    ├─────────┼──────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼───────────────────────────┤
    │    0    │ 'create 1000 DOM nodes and append into its previous looped node' │ 'benchmark-dom-mutation-multiple-descendant-add.html' │ 'window.workload()' │   5   │  628.2   │ '622, 628, 640, 627, 624' │
    └─────────┴──────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴───────────────────────────┘
```

After：

```
┌─────────┬──────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────┐
    │ (index) │                              title                               │                         html                          │        eval         │ times │ duration │      durations       │
    ├─────────┼──────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────┤
    │    0    │ 'create 1000 DOM nodes and append into its previous looped node' │ 'benchmark-dom-mutation-multiple-descendant-add.html' │ 'window.workload()' │   5   │   64.4   │ '57, 61, 73, 69, 62' │
    └─────────┴──────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────┘
```

decreased about 89.74%