### PR TITLE
Fix rrdom bugs

### DIFF
--- a/.changeset/cold-eyes-hunt.md
+++ b/.changeset/cold-eyes-hunt.md
@@ -1,0 +1,8 @@
+---
+'rrdom': patch
+---
+
+Fix: rrdom bugs
+
+1. Fix a bug in the diff algorithm.
+2. Omit the 'srcdoc' attribute of iframes to avoid overwriting content.

--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -116,8 +116,8 @@ export function diff(
     rrnodeMirror,
   );
 
-  let oldChildren = oldTree.childNodes;
-  let newChildren = newTree.childNodes;
+  const oldChildren = oldTree.childNodes;
+  const newChildren = newTree.childNodes;
   if (oldChildren.length > 0 || newChildren.length > 0) {
     // This function doesn't update props of children.
     diffChildren(
@@ -129,12 +129,12 @@ export function diff(
     );
 
     // Recursively diff the children of the old tree and the new tree with their props and deeper structures.
-    oldChildren = oldTree.childNodes;
-    newChildren = newTree.childNodes;
-    for (let i = 0; i < newChildren.length; i++) {
-      const oldChild = oldChildren[i];
-      const newChild = newChildren[i];
+    let oldChild = oldTree.firstChild;
+    let newChild = newTree.firstChild;
+    while (oldChild !== null && newChild !== null) {
       diff(oldChild, newChild, replayer, rrnodeMirror);
+      oldChild = oldChild.nextSibling;
+      newChild = newChild.nextSibling;
     }
   }
 


### PR DESCRIPTION
### Changes
1. Fix a bug in the diff algorithm 
2. Omit the 'srcdoc' attribute of iframes to avoid overwriting content.
3. Add test cases

### Bug description
<img width="361" alt="image" src="https://github.com/rrweb-io/rrweb/assets/27533910/c4d038fa-86d1-4f8e-b075-69fe52b0880c">

The error happened at this place in rrdom:

<img width="1325" alt="image" src="https://github.com/rrweb-io/rrweb/assets/27533910/6db3d8ba-2283-46a1-95a6-086febf10a97">
I've constructed a test case that can reproduce the bug. The simple explanation for this is: A child is appended to another parent node during the process of diffChildren().
