### PR TITLE
fix: Rrror parser throw

### DIFF
--- a/packages/rrweb/src/plugins/console/record/error-stack-parser.ts
+++ b/packages/rrweb/src/plugins/console/record/error-stack-parser.ts
@@ -71,8 +71,11 @@ export const ErrorStackParser = {
     } else if (error.stack) {
       return this.parseFFOrSafari(error as { stack: string });
     } else {
-      console.warn("[console-record-plugin]: Failed to parse error object:", error)
-      return []
+      console.warn(
+        '[console-record-plugin]: Failed to parse error object:',
+        error,
+      );
+      return [];
     }
   },
   // Separate line and column numbers from a string of the form: (URI:Line:Column)

--- a/packages/rrweb/src/plugins/console/record/error-stack-parser.ts
+++ b/packages/rrweb/src/plugins/console/record/error-stack-parser.ts
@@ -71,7 +71,7 @@ export const ErrorStackParser = {
     } else if (error.stack) {
       return this.parseFFOrSafari(error as { stack: string });
     } else {
-      console.warn("[console-record-plugin]: Failed to parse error object")
+      console.warn("[console-record-plugin]: Failed to parse error object:", error)
       return []
     }
   },

--- a/packages/rrweb/src/plugins/console/record/error-stack-parser.ts
+++ b/packages/rrweb/src/plugins/console/record/error-stack-parser.ts
@@ -71,7 +71,8 @@ export const ErrorStackParser = {
     } else if (error.stack) {
       return this.parseFFOrSafari(error as { stack: string });
     } else {
-      throw new Error('Cannot parse given Error object');
+      console.warn("[console-record-plugin]: Failed to parse error object")
+      return []
     }
   },
   // Separate line and column numbers from a string of the form: (URI:Line:Column)


### PR DESCRIPTION
The error parser can throw if it fails to parse the error which is very meta. This ends up being logged / caught in Sentry which is unnecessary. 

## Changes
Rather than wrapping all of the places it is used, simply changes the function to return cleanly with a warning