### PR TITLE
Shorthand inline CSS properties not saved correctly in the styleObj

### DIFF
--- a/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -363,6 +363,12 @@ exports[`integration tests [html file]: picture-in-frame.html 1`] = `
   </body></html>"
 `;
 
+exports[`integration tests [html file]: picture-with-inline-onload.html 1`] = `
+"<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><head></head><body>
+    <img src=\\"http://localhost:3030/images/robot.png\\" alt=\\"This is a robot\\" style=\\"opacity: 1;\\" _onload=\\"this.style.opacity=1\\" />
+  </body></html>"
+`;
+
 exports[`integration tests [html file]: preload.html 1`] = `
 "<!DOCTYPE html><html lang=\\"en\\"><head>
     <meta charset=\\"UTF-8\\" />

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -32,7 +32,7 @@ import {
   inDom,
   getShadowHost,
   getInlineCSSProperties,
-} from '../utils'
+} from '../utils';
 
 type DoubleLinkedListNode = {
   previous: DoubleLinkedListNode | null;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -31,7 +31,8 @@ import {
   isSerializedStylesheet,
   inDom,
   getShadowHost,
-} from '../utils';
+  getCSSProperties,
+} from '../utils'
 
 type DoubleLinkedListNode = {
   previous: DoubleLinkedListNode | null;
@@ -574,7 +575,10 @@ export default class MutationBuffer {
             item.attributes.style = {};
           }
           const styleObj = item.attributes.style as styleAttributeValue;
-          for (const pname of Array.from(target.style)) {
+          const targetStyle = target.getAttribute('style');
+          const oldStyle = old.getAttribute('style');
+
+          for (const pname of getCSSProperties(targetStyle)) {
             const newValue = target.style.getPropertyValue(pname);
             const newPriority = target.style.getPropertyPriority(pname);
             if (
@@ -588,7 +592,7 @@ export default class MutationBuffer {
               }
             }
           }
-          for (const pname of Array.from(old.style)) {
+          for (const pname of getCSSProperties(oldStyle)) {
             if (target.style.getPropertyValue(pname) === '') {
               // "if not set, returns the empty string"
               styleObj[pname] = false; // delete

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -31,7 +31,7 @@ import {
   isSerializedStylesheet,
   inDom,
   getShadowHost,
-  getCSSProperties,
+  getInlineCSSProperties,
 } from '../utils'
 
 type DoubleLinkedListNode = {
@@ -578,7 +578,7 @@ export default class MutationBuffer {
           const targetStyle = target.getAttribute('style');
           const oldStyle = old.getAttribute('style');
 
-          for (const pname of getCSSProperties(targetStyle)) {
+          for (const pname of getInlineCSSProperties(targetStyle)) {
             const newValue = target.style.getPropertyValue(pname);
             const newPriority = target.style.getPropertyPriority(pname);
             if (
@@ -592,7 +592,7 @@ export default class MutationBuffer {
               }
             }
           }
-          for (const pname of getCSSProperties(oldStyle)) {
+          for (const pname of getInlineCSSProperties(oldStyle)) {
             if (target.style.getPropertyValue(pname) === '') {
               // "if not set, returns the empty string"
               styleObj[pname] = false; // delete

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -574,7 +574,7 @@ export function inDom(n: Node): boolean {
   return doc.contains(n) || shadowHostInDom(n);
 }
 
-export function getCSSProperties(value: string | null): string[] {
+export function getInlineCSSProperties(value: string | null): string[] {
   if (!value) {
     return [];
   }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -12,6 +12,7 @@ import type {
 import type { IMirror, Mirror } from 'rrweb-snapshot';
 import { isShadowRoot, IGNORED_NODE, classMatchesRegex } from 'rrweb-snapshot';
 import type { RRNode, RRIFrameElement } from 'rrdom';
+import * as cssom from "cssom"
 
 export function on(
   type: string,
@@ -571,4 +572,13 @@ export function inDom(n: Node): boolean {
   const doc = n.ownerDocument;
   if (!doc) return false;
   return doc.contains(n) || shadowHostInDom(n);
+}
+
+export function getCSSProperties(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  return value.split(';').map(declaration =>
+    declaration.split(':')[0].trim()
+  ).filter(declaration => !!declaration);
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -577,7 +577,8 @@ export function getInlineCSSProperties(value: string | null): string[] {
   if (!value) {
     return [];
   }
-  return value.split(';').map(declaration =>
-    declaration.split(':')[0].trim()
-  ).filter(declaration => !!declaration);
+  return value
+    .split(';')
+    .map((declaration) => declaration.split(':')[0].trim())
+    .filter((declaration) => !!declaration);
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -12,7 +12,6 @@ import type {
 import type { IMirror, Mirror } from 'rrweb-snapshot';
 import { isShadowRoot, IGNORED_NODE, classMatchesRegex } from 'rrweb-snapshot';
 import type { RRNode, RRIFrameElement } from 'rrdom';
-import * as cssom from "cssom"
 
 export function on(
   type: string,

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -1843,6 +1843,166 @@ exports[`record captures nested stylesheet rules 1`] = `
 ]"
 `;
 
+exports[`record captures shorthand style properties 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"input\\",
+                    \\"attributes\\": {
+                      \\"type\\": \\"text\\",
+                      \\"size\\": \\"40\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\\\n      \\\\n    \\",
+                    \\"id\\": 8
+                  }
+                ],
+                \\"id\\": 5
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 4,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"style\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"id\\": 9
+          }
+        },
+        {
+          \\"parentId\\": 9,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\":root { --bg-orange: #FF3300; }\\",
+            \\"isStyle\\": true,
+            \\"id\\": 10
+          }
+        },
+        {
+          \\"parentId\\": 5,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"div\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [],
+            \\"id\\": 11
+          }
+        }
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 11,
+          \\"attributes\\": {
+            \\"style\\": {
+              \\"background\\": \\"var(--bg-orange)\\"
+            }
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 11,
+          \\"attributes\\": {
+            \\"style\\": {
+              \\"background-color\\": \\"rgb(0, 0, 0)\\",
+              \\"background\\": false
+            }
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  }
+]"
+`;
+
 exports[`record captures style property changes 1`] = `
 "[
   {

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -12,7 +12,7 @@ import {
   selectionData,
   styleAttributeValue,
   mutationData,
-} from '@rrweb/types'
+} from '@rrweb/types';
 import {
   assertSnapshot,
   getServerURL,
@@ -298,11 +298,11 @@ describe('record', function (this: ISuite) {
 
       setTimeout(() => {
         div.setAttribute('style', 'background: var(--bg-orange)');
-      }, 5)
+      }, 5);
 
       setTimeout(() => {
         div.setAttribute('style', 'background-color: #000000');
-      }, 10)
+      }, 10);
     });
 
     await ctx.page.waitForTimeout(50);
@@ -311,19 +311,23 @@ describe('record', function (this: ISuite) {
       (e) =>
         e.type === EventType.IncrementalSnapshot &&
         e.data.source === IncrementalSource.Mutation &&
-        e.data.attributes.length
+        e.data.attributes.length,
     );
 
-    const expectedShorthandBackground =
-      ((attributeMutationEvents[0].data as mutationData)?.attributes[0]?.attributes.style as styleAttributeValue)?.['background'];
-    const expectedLonghandBackground =
-      ((attributeMutationEvents[1].data as mutationData)?.attributes[0]?.attributes.style as styleAttributeValue)?.['background'];
+    const expectedShorthandBackground = (
+      (attributeMutationEvents[0].data as mutationData)?.attributes[0]
+        ?.attributes.style as styleAttributeValue
+    )?.['background'];
+    const expectedLonghandBackground = (
+      (attributeMutationEvents[1].data as mutationData)?.attributes[0]
+        ?.attributes.style as styleAttributeValue
+    )?.['background'];
 
     expect(attributeMutationEvents.length).toEqual(2);
     expect(expectedShorthandBackground).toEqual('var(--bg-orange)');
     expect(expectedLonghandBackground).toEqual(false);
     assertSnapshot(ctx.events);
-  })
+  });
 
   it('captures stylesheet rules', async () => {
     await ctx.page.evaluate(() => {


### PR DESCRIPTION
### Description of the issue

Noticed that inline CSS properties that were defined as a shorthand and use CSS variables don't get included in the array created by `Array.from(target.style)` and therefor they are not iterated through. 
What gets included is their attempt to convert them to longhand properties, which wrongly assigns the value of a CSS declaration.

So, for example, if a element looks like this `<div style="background: var(--bg-white)"/>` the `styleObj` it creates has only the property `background-color` with an empty value (it should be `background: var(--bg-white)`).

Instead of taking the result of `target.style` which will **NOT** include shorthand properties if not specifically asked for with `target.style.getPropertyValue()`, I wrote a little helper function to split the style attribute and get just the declarations that are actually there, using them as an iterator and keeping the rest of the functionality the same.

This way, if a shorthand was defined it will be specifically requested with `target.style.getPropertyValue()` and it's value captured in the `styleObj`

### Tests

> 3. Ensure the test suite passes or ask for help as to why tests are failing

There is one test that fails when running `yarn test` outside of packages/rrweb, but it was failing even before my changes so I think that's fine.

**I'm having weird thing happen with `test/integration.test.ts` and can't figure out what's wrong with it. Sometimes it passes and sometimes it fails like this. I don't think my changes are affecting this, but thought it's better to ask you guys**

<img width="1039" alt="image" src="https://github.com/rrweb-io/rrweb/assets/33005827/fb27a7af-dcd8-4df3-8dec-1672aadec182">
