### PR TITLE
Fix types in rrwebPlayer

### DIFF
--- a/.changeset/smooth-poems-bake.md
+++ b/.changeset/smooth-poems-bake.md
@@ -1,0 +1,5 @@
+---
+"rrweb-player": patch
+---
+
+Fix `player.getMirror` and `player.playRange` types in rrwebPlayer

--- a/.changeset/smooth-poems-bake.md
+++ b/.changeset/smooth-poems-bake.md
@@ -1,5 +1,5 @@
 ---
-"rrweb-player": patch
+'rrweb-player': patch
 ---
 
 Fix `player.getMirror` and `player.playRange` types in rrwebPlayer

--- a/.changeset/smooth-poems-bake.md
+++ b/.changeset/smooth-poems-bake.md
@@ -2,4 +2,4 @@
 'rrweb-player': patch
 ---
 
-Fix `player.getMirror` and `player.playRange` types in rrwebPlayer
+Fix `player.getMirror`, `player.playRange`, `player.$set` types in rrwebPlayer

--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -81,7 +81,7 @@ export default class rrwebPlayer extends SvelteComponent {
   playRange: (
     timeOffset: number,
     endTimeOffset: number,
-    startLooping: boolean,
-    afterHook: undefined | (() => void),
+    startLooping?: boolean,
+    afterHook?: undefined | (() => void),
   ) => void;
 }

--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -74,10 +74,7 @@ export default class rrwebPlayer extends SvelteComponent {
   setSpeed: (speed: number) => void;
   toggleSkipInactive: () => void;
   triggerResize: () => void;
-  $set: (options: {
-    width: number;
-    height: number;
-  }) => void;
+  $set: (options: { width: number; height: number }) => void;
   play: () => void;
   pause: () => void;
   goto: (timeOffset: number, play?: boolean) => void;

--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -77,4 +77,10 @@ export default class rrwebPlayer extends SvelteComponent {
   play: () => void;
   pause: () => void;
   goto: (timeOffset: number, play?: boolean) => void;
+  playRange: (
+    timeOffset: number,
+    endTimeOffset: number,
+    startLooping: boolean,
+    afterHook: undefined | (() => void),
+  ) => void;
 }

--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -74,6 +74,10 @@ export default class rrwebPlayer extends SvelteComponent {
   setSpeed: (speed: number) => void;
   toggleSkipInactive: () => void;
   triggerResize: () => void;
+  $set: (options: {
+    width: number;
+    height: number;
+  }) => void;
   play: () => void;
   pause: () => void;
   goto: (timeOffset: number, play?: boolean) => void;

--- a/packages/rrweb-player/typings/index.d.ts
+++ b/packages/rrweb-player/typings/index.d.ts
@@ -1,6 +1,7 @@
 import { playerConfig } from 'rrweb/typings/types';
 import { eventWithTime } from '@rrweb/types';
-import { Replayer, mirror } from 'rrweb';
+import { Replayer } from 'rrweb';
+import { Mirror } from 'rrweb-snapshot';
 import { SvelteComponent } from 'svelte';
 
 export type RRwebPlayerOptions = {
@@ -67,7 +68,7 @@ export default class rrwebPlayer extends SvelteComponent {
   addEvent(event: eventWithTime): void;
   getMetaData: Replayer['getMetaData'];
   getReplayer: () => Replayer;
-  getMirror: () => typeof mirror;
+  getMirror: () => Mirror;
 
   toggle: () => void;
   setSpeed: (speed: number) => void;


### PR DESCRIPTION
Was using DeprecatedMirror in its types, that shouldn't be used anymore.
Also `playRange` wasn't being defined but was documented.