### PR TITLE
fix: Handle case where `event` is null/undefined

### DIFF
--- a/.changeset/tiny-buckets-love.md
+++ b/.changeset/tiny-buckets-love.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Handle case where `event` is null/undefined

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -76,10 +76,11 @@ function getEventTarget(event: Event | NonStandardEvent): EventTarget | null {
     } else if ('path' in event && event.path.length) {
       return event.path[0];
     }
-    return event.target;
   } catch {
-    return event.target;
+    // fallback to `event.target` below
   }
+
+  return event && event.target;
 }
 
 export function initMutationObserver(


### PR DESCRIPTION
We got one or two bugs that failed due to event not being defined. So we guard against this here.

ref https://github.com/getsentry/rrweb/pull/32