### PR TITLE
feat: Pass parent element or node to `maskTextFn`

### DIFF
--- a/.changeset/wet-snails-rhyme.md
+++ b/.changeset/wet-snails-rhyme.md
@@ -1,0 +1,6 @@
+---
+'rrweb-snapshot': patch
+'rrweb': patch
+---
+
+Pass parent element/node to `maskTextFn` callback, similar to `maskInputFn`

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -586,7 +586,7 @@ function serializeTextNode(
     needMaskingText(n, maskTextClass, maskTextSelector)
   ) {
     textContent = maskTextFn
-      ? maskTextFn(textContent)
+      ? maskTextFn(textContent, n.parentNode as HTMLElement)
       : textContent.replace(/[\S]/g, '*');
   }
 

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -153,7 +153,7 @@ export type DataURLOptions = Partial<{
   quality: number;
 }>;
 
-export type MaskTextFn = (text: string) => string;
+export type MaskTextFn = (text: string, element?: HTMLElement | Node) => string;
 export type MaskInputFn = (text: string, element: HTMLElement) => string;
 
 export type KeepIframeSrcFn = (src: string) => boolean;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -496,7 +496,7 @@ export default class MutationBuffer {
                 this.maskTextSelector,
               ) && value
                 ? this.maskTextFn
-                  ? this.maskTextFn(value)
+                  ? this.maskTextFn(value, m.target)
                   : value.replace(/[\S]/g, '*')
                 : value,
             node: m.target,


### PR DESCRIPTION
Allows `maskTextFn` to access to parent element or node so that it can make masking decisions based on the element. This brings the interface to be similar to `maskInputFn`.