### PR TITLE
Compact style mutation fixes and improvements

### DIFF
--- a/.changeset/clean-plants-play.md
+++ b/.changeset/clean-plants-play.md
@@ -1,0 +1,8 @@
+---
+"rrweb": patch
+"@rrweb/types": patch
+---
+
+Compact style mutation fixes and improvements
+ - fixes when style updates contain a 'var()' on a shorthand property #1246
+ - further ensures that style mutations are compact by reverting to string method if it is shorter

--- a/.changeset/clean-plants-play.md
+++ b/.changeset/clean-plants-play.md
@@ -1,8 +1,9 @@
 ---
-"rrweb": patch
-"@rrweb/types": patch
+'rrweb': patch
+'@rrweb/types': patch
 ---
 
 Compact style mutation fixes and improvements
- - fixes when style updates contain a 'var()' on a shorthand property #1246
- - further ensures that style mutations are compact by reverting to string method if it is shorter
+
+- fixes when style updates contain a 'var()' on a shorthand property #1246
+- further ensures that style mutations are compact by reverting to string method if it is shorter

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -562,7 +562,10 @@ export default class MutationBuffer {
           target.setAttribute('data-rr-is-password', 'true');
         }
 
-        if (attributeName === 'style') {
+        if (attributeName === 'style' &&
+            (value as string).indexOf('var(') === -1 &&
+            typeof item.attributes.style !== 'string'
+           ) {
           const old = unattachedDoc.createElement('span');
           if (m.oldValue) {
             old.setAttribute('style', m.oldValue);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -439,7 +439,7 @@ export default class MutationBuffer {
         .filter((text) => this.mirror.has(text.id)),
       attributes: this.attributes
         .map((attribute) => {
-          const attributes = attribute.attributes;
+          const { attributes } = attribute;
           if (typeof attributes.style === 'string') {
             const somAsStr = JSON.stringify(attribute.styleOM);
             const unchangedAsStr = JSON.stringify(attribute.styleOMUnchanged);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -443,7 +443,7 @@ export default class MutationBuffer {
             const diffAsStr = JSON.stringify(attribute.styleDiff);
             const unchangedAsStr = JSON.stringify(attribute._unchangedStyles);
             // check if the style diff is actually shorter than the regular string based mutation
-            // (which was the whole point of #464 'compact style mutation')
+            // (which was the whole point of #464 'compact style mutation').
             if (diffAsStr.length < attributes.style.length) {
               // also: CSSOM fails badly when var() is present on shorthand properties, so only proceed with
               // the compact style mutation if these have all been accounted for

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -443,13 +443,15 @@ export default class MutationBuffer {
           if (typeof attributes.style === 'string') {
             const somAsStr = JSON.stringify(attribute.styleOM);
             const unchangedAsStr = JSON.stringify(attribute.styleOMUnchanged);
+            // check if compact style mutation is actually shorter than string style mutation
+            // CSSOM fails badly when var() is present on shorthand properties, so ensure that there are the
+            // same number of variable strings present as compared with the style version before allowing it's use
             if (
               somAsStr.length < attributes.style.length &&
               (somAsStr + unchangedAsStr).split('var(').length ===
                 attributes.style.split('var(').length
             ) {
               // use the compact style mutation format #464
-              // (CSSOM fails badly when var() is present on shorthand properties)
               attributes.style = attribute.styleOM;
             }
           }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -447,9 +447,10 @@ export default class MutationBuffer {
             if (diffAsStr.length < attributes.style.length) {
               // also: CSSOM fails badly when var() is present on shorthand properties, so only proceed with
               // the compact style mutation if these have all been accounted for
-              if ((diffAsStr + unchangedAsStr).split('var(').length ===
-                  attributes.style.split('var(').length
-                 ) {
+              if (
+                (diffAsStr + unchangedAsStr).split('var(').length ===
+                attributes.style.split('var(').length
+              ) {
                 attributes.style = attribute.styleDiff;
               }
             }

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -2933,24 +2933,14 @@ exports[`record integration tests can record node mutations 1`] = `
           \\"id\\": 36,
           \\"attributes\\": {
             \\"id\\": \\"select2-drop\\",
-            \\"style\\": {
-              \\"left\\": \\"Npx\\",
-              \\"width\\": \\"Npx\\",
-              \\"top\\": \\"Npx\\",
-              \\"bottom\\": \\"auto\\",
-              \\"display\\": \\"block\\",
-              \\"position\\": false,
-              \\"visibility\\": false
-            },
+            \\"style\\": \\"left: Npx; width: Npx; top: Npx; bottom: auto; display: block;\\",
             \\"class\\": \\"select2-drop select2-display-none select2-with-searchbox select2-drop-active\\"
           }
         },
         {
           \\"id\\": 70,
           \\"attributes\\": {
-            \\"style\\": {
-              \\"display\\": false
-            }
+            \\"style\\": \\"\\"
           }
         },
         {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -3497,17 +3497,115 @@ exports[`record integration tests can record style changes compactly and preserv
         {
           \\"id\\": 4,
           \\"attributes\\": {
+            \\"style\\": \\"background: var(--mystery); background-color: black\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": \\"\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": \\"display:block\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
             \\"style\\": {
-              \\"background-color\\": \\"black\\",
-              \\"background-image\\": false,
-              \\"background-position-x\\": false,
-              \\"background-position-y\\": false,
-              \\"background-size\\": false,
-              \\"background-repeat-x\\": false,
-              \\"background-repeat-y\\": false,
-              \\"background-attachment\\": false,
-              \\"background-origin\\": false,
-              \\"background-clip\\": false
+              \\"color\\": \\"var(--mystery-color)\\"
+            }
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": \\"color:var(--mystery-color);display:block;margin:10px\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": {
+              \\"margin-left\\": \\"Npx\\"
+            }
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": {
+              \\"margin-top\\": \\"Npx\\",
+              \\"color\\": false
             }
           }
         }

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -3391,6 +3391,134 @@ exports[`record integration tests can record node mutations 1`] = `
 ]"
 `;
 
+exports[`record integration tests can record style changes compactly and preserve css var() functions 1`] = `
+"[
+  {
+    \\"type\\": 0,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 1,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [],
+                \\"id\\": 3
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 7
+                      }
+                    ],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
+                    \\"id\\": 8
+                  }
+                ],
+                \\"id\\": 4
+              }
+            ],
+            \\"id\\": 2
+          }
+        ],
+        \\"compatMode\\": \\"BackCompat\\",
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": \\"background: var(--mystery)\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 4,
+          \\"attributes\\": {
+            \\"style\\": {
+              \\"background-color\\": \\"black\\",
+              \\"background-image\\": false,
+              \\"background-position-x\\": false,
+              \\"background-position-y\\": false,
+              \\"background-size\\": false,
+              \\"background-repeat-x\\": false,
+              \\"background-repeat-y\\": false,
+              \\"background-attachment\\": false,
+              \\"background-origin\\": false,
+              \\"background-clip\\": false
+            }
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  }
+]"
+`;
+
 exports[`record integration tests can use maskInputOptions to configure which type of inputs should be masked 1`] = `
 "[
   {

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -220,7 +220,7 @@ describe('record integration tests', function (this: ISuite) {
     await page.evaluate(
       'document.body.setAttribute("style", "background: var(--mystery)")',
     );
-    await page.waitForTimeout(10);
+    await waitForRAF(page);
     // and in this change we can't use the shorter styleObj format either
     await page.evaluate(
       'document.body.setAttribute("style", "background: var(--mystery); background-color: black")',
@@ -228,25 +228,25 @@ describe('record integration tests', function (this: ISuite) {
 
     // reset is always shorter to be recorded as a sting rather than a styleObj
     await page.evaluate('document.body.setAttribute("style", "")');
-    await page.waitForTimeout(10);
+    await waitForRAF(page);
 
     await page.evaluate('document.body.setAttribute("style", "display:block")');
-    await page.waitForTimeout(10);
+    await waitForRAF(page);
     // following should be recorded as an update of `{ color: 'var(--mystery-color)' }` without needing to include the display
     await page.evaluate(
       'document.body.setAttribute("style", "color:var(--mystery-color);display:block")',
     );
-    await page.waitForTimeout(10);
+    await waitForRAF(page);
     // whereas this case, it's shorter to record the entire string than the longhands for margin
     await page.evaluate(
       'document.body.setAttribute("style", "color:var(--mystery-color);display:block;margin:10px")',
     );
-    await page.waitForTimeout(10);
+    await waitForRAF(page);
     // and in this case, it's shorter to record just the change to the longhand margin-left;
     await page.evaluate(
       'document.body.setAttribute("style", "color:var(--mystery-color);display:block;margin:10px 10px 10px 0px;")',
     );
-    await page.waitForTimeout(10);
+    await waitForRAF(page);
     // see what happens when we manipulate the style object directly (expecting a compact mutation with just these two changes)
     await page.evaluate(
       'document.body.style.marginTop = 0; document.body.style.color = null',

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -209,6 +209,29 @@ describe('record integration tests', function (this: ISuite) {
     assertSnapshot(snapshots);
   });
 
+  it('can record style changes compactly and preserve css var() functions', async () => {
+    const page: puppeteer.Page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.setContent(getHtml.call(this, 'blank.html'), {
+      waitUntil: 'networkidle0',
+    });
+
+    // goal here is to ensure var(--mystery) ends up in the mutations
+    await page.evaluate(
+      'document.body.setAttribute("style", "background: var(--mystery)")',
+    );
+    await page.waitForTimeout(50);
+    // and here that we can revert to { background: false, background-color: 'black' } format (assuming we've used string format for above)
+    await page.evaluate(
+      'document.body.setAttribute("style", "background-color: black")',
+    );
+
+    const snapshots = (await page.evaluate(
+      'window.snapshots',
+    )) as eventWithTime[];
+    assertSnapshot(snapshots);
+  });
+
   it('can freeze mutations', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -251,6 +251,7 @@ describe('record integration tests', function (this: ISuite) {
     await page.evaluate(
       'document.body.style.marginTop = 0; document.body.style.color = null',
     );
+    await waitForRAF(page);
 
     const snapshots = (await page.evaluate(
       'window.snapshots',

--- a/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
+++ b/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
@@ -2625,10 +2625,7 @@ exports[`cross origin iframes form.html should map scroll events correctly 1`] =
         {
           \\"id\\": 9,
           \\"attributes\\": {
-            \\"style\\": {
-              \\"width\\": \\"Npx\\",
-              \\"height\\": \\"Npx\\"
-            }
+            \\"style\\": \\"width: Npx; height: Npx;\\"
           }
         }
       ],

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -133,23 +133,26 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
           s.data.source === IncrementalSource.Mutation
         ) {
           s.data.attributes.forEach((a) => {
-            if (
-              'style' in a.attributes &&
-              a.attributes.style &&
-              typeof a.attributes.style === 'object'
-            ) {
-              for (const [k, v] of Object.entries(a.attributes.style)) {
-                if (Array.isArray(v)) {
-                  if (coordinatesReg.test(k + ': ' + v[0])) {
-                    // TODO: could round the number here instead depending on what's coming out of various test envs
-                    a.attributes.style[k] = ['Npx', v[1]];
+            if ('style' in a.attributes && a.attributes.style) {
+              if (typeof a.attributes.style === 'object') {
+                for (const [k, v] of Object.entries(a.attributes.style)) {
+                  if (Array.isArray(v)) {
+                    if (coordinatesReg.test(k + ': ' + v[0])) {
+                      // TODO: could round the number here instead depending on what's coming out of various test envs
+                      a.attributes.style[k] = ['Npx', v[1]];
+                    }
+                  } else if (typeof v === 'string') {
+                    if (coordinatesReg.test(k + ': ' + v)) {
+                      a.attributes.style[k] = 'Npx';
+                    }
                   }
-                } else if (typeof v === 'string') {
-                  if (coordinatesReg.test(k + ': ' + v)) {
-                    a.attributes.style[k] = 'Npx';
-                  }
+                  coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
                 }
-                coordinatesReg.lastIndex = 0; // wow, a real wart in ECMAScript
+              } else if (coordinatesReg.test(a.attributes.style)) {
+                a.attributes.style = a.attributes.style.replace(
+                  coordinatesReg,
+                  '$1: Npx',
+                );
               }
             }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -294,8 +294,8 @@ export type attributeCursor = {
   attributes: {
     [key: string]: string | styleOMValue | null;
   };
-  styleOM: styleOMValue;
-  styleOMUnchanged: styleOMValue;
+  styleDiff: styleOMValue;
+  _unchangedStyles: styleOMValue;
 };
 export type attributeMutation = {
   id: number;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -283,7 +283,7 @@ export type textMutation = {
   value: string | null;
 };
 
-export type styleAttributeValue = {
+export type styleOMValue = {
   [key: string]: styleValueWithPriority | string | false;
 };
 
@@ -292,13 +292,15 @@ export type styleValueWithPriority = [string, string];
 export type attributeCursor = {
   node: Node;
   attributes: {
-    [key: string]: string | styleAttributeValue | null;
+    [key: string]: string | styleOMValue | null;
   };
+  styleOM: styleOMValue;
+  styleOMUnchanged: styleOMValue;
 };
 export type attributeMutation = {
   id: number;
   attributes: {
-    [key: string]: string | styleAttributeValue | null;
+    [key: string]: string | styleOMValue | null;
   };
 };
 


### PR DESCRIPTION
**1)**: CSSOM was failing badly with shorthand + variables as reported in #1246 e.g. in

```
elem.style = "background: var(--my-bg);"
```
the resultant mutation had no record of the variable.  This is a deficiency in the spec for CSSOM as evidenced here:
https://bugs.chromium.org/p/chromium/issues/detail?id=1218159#c_ts1631714802

In this case we can fallback to the regular method before style attributes were special cased in #464, and which is still supported in replay.

**2)**: I realized we can switch between the #464 method and the regular attribute method for a given mutation depending on which is longer.  This prevents us converting the following:

```
elem.style = "background:black;"
```
to the much more verbose:

```
'style': {
        'background-color': 'black',
        'background-image': false,
        'background-position-x': false,
        'background-position-y': false,
        'background-size': false,
        'background-repeat-x': false,
        'background-repeat-y': false,
        'background-attachment': false,
        'background-origin': false,
        'background-clip': false
    }
```

Whilst still preserving those cases where the #464 method is more terse.  We achieve this by executing both methods and comparing string lengths of the two methods.
Comparison of the two methods upon emission is also the way we verify that the variable functions are being preserved.
