### PR TITLE
ref(test): Filter out scroll and viewport resize from snapshots

### DIFF
--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -109,8 +109,7 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
       .filter((s) => {
         if (
           s.type === EventType.IncrementalSnapshot &&
-          (s.data.source === IncrementalSource.MouseMove ||
-            s.data.source === IncrementalSource.ViewportResize)
+          [IncrementalSource.MouseMove, IncrementalSource.Scroll, IncrementalSource.ViewportResize].includes(s.data.source)
         ) {
           return false;
         }

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -109,8 +109,11 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
       .filter((s) => {
         if (
           s.type === EventType.IncrementalSnapshot &&
-          (s.data.source === IncrementalSource.MouseMove ||
-            s.data.source === IncrementalSource.ViewportResize)
+          [
+            IncrementalSource.MouseMove,
+            IncrementalSource.Scroll,
+            IncrementalSource.ViewportResize,
+          ].includes(s.data.source)
         ) {
           return false;
         }

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -109,11 +109,8 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
       .filter((s) => {
         if (
           s.type === EventType.IncrementalSnapshot &&
-          [
-            IncrementalSource.MouseMove,
-            IncrementalSource.Scroll,
-            IncrementalSource.ViewportResize,
-          ].includes(s.data.source)
+          (s.data.source === IncrementalSource.MouseMove ||
+            s.data.source === IncrementalSource.ViewportResize)
         ) {
           return false;
         }

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -109,7 +109,11 @@ function stringifySnapshots(snapshots: eventWithTime[]): string {
       .filter((s) => {
         if (
           s.type === EventType.IncrementalSnapshot &&
-          [IncrementalSource.MouseMove, IncrementalSource.Scroll, IncrementalSource.ViewportResize].includes(s.data.source)
+          [
+            IncrementalSource.MouseMove,
+            IncrementalSource.Scroll,
+            IncrementalSource.ViewportResize,
+          ].includes(s.data.source)
         ) {
           return false;
         }


### PR DESCRIPTION
In addition to mouse move events, filter out scroll and viewport resize events from snapshots. These seem to flake a lot locally.