### PR TITLE
perf(genAdds): refactor recursive procedure to iterative

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -20,6 +20,7 @@
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build",
     "lint": "yarn eslint src",
+    "benchmark-dom-mutation": "vitest run --maxConcurrency 1 --no-file-parallelism -t 'deeply nested children' test/benchmark/dom-mutation"
     "benchmark": "vitest run --maxConcurrency 1 --no-file-parallelism test/benchmark"
   },
   "type": "module",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -20,7 +20,7 @@
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build",
     "lint": "yarn eslint src",
-    "benchmark-dom-mutation": "vitest run --maxConcurrency 1 --no-file-parallelism -t 'deeply nested children' test/benchmark/dom-mutation"
+    "benchmark-dom-mutation": "vitest run --maxConcurrency 1 --no-file-parallelism -t 'deeply nested children' test/benchmark/dom-mutation",
     "benchmark": "vitest run --maxConcurrency 1 --no-file-parallelism test/benchmark"
   },
   "type": "module",

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -683,7 +683,9 @@ export default class MutationBuffer {
         const genAddsQueue: [Node, Node | undefined][] = new Array<
           [Node, Node | undefined]
         >();
-        m.addedNodes.forEach((n) => {
+
+        for(let i = m.addedNodes.length-1; i >= 0; i--) {
+          const n = m.addedNodes[i];
           genAddsQueue.push([n, m.target]);
 
           // iterate breadth first over new nodes (non recursive for performance)
@@ -723,23 +725,26 @@ export default class MutationBuffer {
               // but we have to ignore it's children otherwise they will be added as placeholders too
               continue;
             }
-            n.childNodes.forEach((childN) => {
+
+            for(let j = n.childNodes.length-1; j >= 0; j--) {
+              const childN = n.childNodes[j];
               if (this.movedSet.has(childN) || this.addedSet.has(childN))
                 return;
 
               genAddsQueue.push([childN, undefined]);
-            });
+            };
             if (hasShadowRoot(n)) {
-              n.shadowRoot.childNodes.forEach((childN) => {
+              for(let j = n.shadowRoot.childNodes.length-1; j >= 0; j--) {
+                const childN = n.shadowRoot.childNodes[j];
                 if (this.movedSet.has(childN) || this.addedSet.has(childN))
                   return;
 
                 this.processedNodeManager.add(childN, this);
                 genAddsQueue.push([childN, n]);
-              });
+              };
             }
           }
-        });
+        };
 
         m.removedNodes.forEach((n) => {
           const nodeId = this.mirror.getId(n);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -680,7 +680,64 @@ export default class MutationBuffer {
           return; // any removedNodes won't have been in mirror either
         }
 
-        m.addedNodes.forEach((n) => this.genAdds(n, m.target));
+        const genAddsQueue: [Node, Node | undefined][] = new Array<
+          [Node, Node | undefined]
+        >(1000);
+        m.addedNodes.forEach((n) => {
+          let rp = -1;
+          let wp = -1;
+          genAddsQueue[++wp] = [n, m.target];
+
+          // iterate breadth first over new nodes (non recursive for performance)
+          while (rp < wp) {
+            const next = genAddsQueue[++rp];
+            if (!next) {
+              throw new Error(
+                'Add queue is corrupt, there is no next item to process',
+              );
+            }
+            const [n, target] = next;
+
+            // this node was already recorded in other buffer, ignore it
+            if (this.processedNodeManager.inOtherBuffer(n, this)) continue;
+
+            // if n is added to set, there is no need to travel it and its' children again
+            if (this.addedSet.has(n) || this.movedSet.has(n)) continue;
+
+            if (this.mirror.hasNode(n)) {
+              if (isIgnored(n, this.mirror, this.slimDOMOptions)) {
+                continue;
+              }
+              this.movedSet.add(n);
+              let targetId: number | null = null;
+              if (target && this.mirror.hasNode(target)) {
+                targetId = this.mirror.getId(target);
+              }
+              if (targetId && targetId !== -1) {
+                this.movedMap[moveKey(this.mirror.getId(n), targetId)] = true;
+              }
+            } else {
+              this.addedSet.add(n);
+              this.droppedSet.delete(n);
+            }
+
+            if (isBlocked(n, this.blockClass, this.blockSelector, false)) {
+              // if this node is blocked `serializeNode` will turn it into a placeholder element
+              // but we have to ignore it's children otherwise they will be added as placeholders too
+              continue;
+            }
+            n.childNodes.forEach((childN) => {
+              genAddsQueue[++wp] = [childN, undefined];
+            });
+            if (hasShadowRoot(n)) {
+              n.shadowRoot.childNodes.forEach((childN) => {
+                this.processedNodeManager.add(childN, this);
+                genAddsQueue[++wp] = [childN, n];
+              });
+            }
+          }
+        });
+
         m.removedNodes.forEach((n) => {
           const nodeId = this.mirror.getId(n);
           const parentId = isShadowRoot(m.target)
@@ -733,66 +790,6 @@ export default class MutationBuffer {
       }
       default:
         break;
-    }
-  };
-
-  /**
-   * Make sure you check if `n`'s parent is blocked before calling this function
-   * */
-  private genAddsQueue: [Node, Node | undefined][] = new Array<
-    [Node, Node | undefined]
-  >(1000);
-  private genAdds = (node: Node, t?: Node) => {
-    let rp = -1;
-    let wp = -1;
-    this.genAddsQueue[++wp] = [node, t];
-
-    while (rp < wp) {
-      const next = this.genAddsQueue[++rp];
-      if (!next) {
-        throw new Error(
-          'Add queue is corrupt, there is no next item to process',
-        );
-      }
-      const [n, target] = next;
-
-      // this node was already recorded in other buffer, ignore it
-      if (this.processedNodeManager.inOtherBuffer(n, this)) continue;
-
-      // if n is added to set, there is no need to travel it and its' children again
-      if (this.addedSet.has(n) || this.movedSet.has(n)) continue;
-
-      if (this.mirror.hasNode(n)) {
-        if (isIgnored(n, this.mirror, this.slimDOMOptions)) {
-          continue;
-        }
-        this.movedSet.add(n);
-        let targetId: number | null = null;
-        if (target && this.mirror.hasNode(target)) {
-          targetId = this.mirror.getId(target);
-        }
-        if (targetId && targetId !== -1) {
-          this.movedMap[moveKey(this.mirror.getId(n), targetId)] = true;
-        }
-      } else {
-        this.addedSet.add(n);
-        this.droppedSet.delete(n);
-      }
-
-      if (isBlocked(n, this.blockClass, this.blockSelector, false)) {
-        continue;
-      }
-      // if this node is blocked `serializeNode` will turn it into a placeholder element
-      // but we have to remove it's children otherwise they will be added as placeholders too
-      n.childNodes.forEach((childN) => {
-        this.genAddsQueue[++wp] = [childN, undefined];
-      });
-      if (hasShadowRoot(n)) {
-        n.shadowRoot.childNodes.forEach((childN) => {
-          this.processedNodeManager.add(childN, this);
-          this.genAddsQueue[++wp] = [childN, n];
-        });
-      }
     }
   };
 }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -690,12 +690,7 @@ export default class MutationBuffer {
 
           // iterate breadth first over new nodes (non recursive for performance)
           while (genAddsQueue.length) {
-            const next = genAddsQueue.pop()!;
-
-            // Since this is an extremely hot path, do not destructure next
-            // in order to avoid invoking the iterator protocol
-            const n = next[0];
-            const target = next[1];
+            const [n, target] = genAddsQueue.pop()!;
 
             // this node was already recorded in other buffer, ignore it
             if (this.processedNodeManager.inOtherBuffer(n, this)) continue;
@@ -728,17 +723,11 @@ export default class MutationBuffer {
 
             for (let j = n.childNodes.length - 1; j >= 0; j--) {
               const childN = n.childNodes[j];
-              if (this.movedSet.has(childN) || this.addedSet.has(childN))
-                return;
-
               genAddsQueue.push([childN, undefined]);
             }
             if (hasShadowRoot(n)) {
               for (let j = n.shadowRoot.childNodes.length - 1; j >= 0; j--) {
                 const childN = n.shadowRoot.childNodes[j];
-                if (this.movedSet.has(childN) || this.addedSet.has(childN))
-                  return;
-
                 this.processedNodeManager.add(childN, this);
                 genAddsQueue.push([childN, n]);
               }
@@ -746,7 +735,8 @@ export default class MutationBuffer {
           }
         }
 
-        m.removedNodes.forEach((n) => {
+        for(let i = 0; i < m.removedNodes.length; i++) {
+          const n = m.removedNodes[i];
           const nodeId = this.mirror.getId(n);
           const parentId = isShadowRoot(m.target)
             ? this.mirror.getId(m.target.host)
@@ -793,7 +783,7 @@ export default class MutationBuffer {
             });
           }
           this.mapRemoves.push(n);
-        });
+        };
         break;
       }
       default:

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -688,12 +688,7 @@ export default class MutationBuffer {
 
           // iterate breadth first over new nodes (non recursive for performance)
           while (genAddsQueue.length) {
-            const next = genAddsQueue.pop();
-            if (!next) {
-              throw new Error(
-                'Add queue is corrupt, there is no next item to process',
-              );
-            }
+            const next = genAddsQueue.pop()!;
 
             // Since this is an extremely hot path, do not destructure next
             // in order to avoid invoking the iterator protocol
@@ -729,10 +724,16 @@ export default class MutationBuffer {
               continue;
             }
             n.childNodes.forEach((childN) => {
+              if (this.movedSet.has(childN) || this.addedSet.has(childN))
+                return;
+
               genAddsQueue.push([childN, undefined]);
             });
             if (hasShadowRoot(n)) {
               n.shadowRoot.childNodes.forEach((childN) => {
+                if (this.movedSet.has(childN) || this.addedSet.has(childN))
+                  return;
+
                 this.processedNodeManager.add(childN, this);
                 genAddsQueue.push([childN, n]);
               });

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -684,7 +684,7 @@ export default class MutationBuffer {
           [Node, Node | undefined]
         >();
 
-        for(let i = m.addedNodes.length-1; i >= 0; i--) {
+        for (let i = m.addedNodes.length - 1; i >= 0; i--) {
           const n = m.addedNodes[i];
           genAddsQueue.push([n, m.target]);
 
@@ -726,25 +726,25 @@ export default class MutationBuffer {
               continue;
             }
 
-            for(let j = n.childNodes.length-1; j >= 0; j--) {
+            for (let j = n.childNodes.length - 1; j >= 0; j--) {
               const childN = n.childNodes[j];
               if (this.movedSet.has(childN) || this.addedSet.has(childN))
                 return;
 
               genAddsQueue.push([childN, undefined]);
-            };
+            }
             if (hasShadowRoot(n)) {
-              for(let j = n.shadowRoot.childNodes.length-1; j >= 0; j--) {
+              for (let j = n.shadowRoot.childNodes.length - 1; j >= 0; j--) {
                 const childN = n.shadowRoot.childNodes[j];
                 if (this.movedSet.has(childN) || this.addedSet.has(childN))
                   return;
 
                 this.processedNodeManager.add(childN, this);
                 genAddsQueue.push([childN, n]);
-              };
+              }
             }
           }
-        };
+        }
 
         m.removedNodes.forEach((n) => {
           const nodeId = this.mirror.getId(n);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -779,14 +779,8 @@ export default class MutationBuffer {
         this.droppedSet.delete(n);
       }
 
-      const isNodeBlocked = isBlocked(
-        n,
-        this.blockClass,
-        this.blockSelector,
-        false,
-      );
-      if (isNodeBlocked) {
-        return;
+      if (isBlocked(n, this.blockClass, this.blockSelector, false)) {
+        continue;
       }
       // if this node is blocked `serializeNode` will turn it into a placeholder element
       // but we have to remove it's children otherwise they will be added as placeholders too

--- a/packages/rrweb/src/record/processed-node-manager.ts
+++ b/packages/rrweb/src/record/processed-node-manager.ts
@@ -5,14 +5,11 @@ import type MutationBuffer from './mutation';
  */
 export default class ProcessedNodeManager {
   private nodeMap: WeakMap<Node, Set<MutationBuffer>> = new WeakMap();
-
   private active = false;
 
   public inOtherBuffer(node: Node, thisBuffer: MutationBuffer) {
     const buffers = this.nodeMap.get(node);
-    return (
-      buffers && Array.from(buffers).some((buffer) => buffer !== thisBuffer)
-    );
+    return buffers?.has(thisBuffer)
   }
 
   public add(node: Node, buffer: MutationBuffer) {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -3218,11 +3218,51 @@ exports[`record integration tests > can record node mutations 1`] = `
         },
         {
           \\"parentId\\": 26,
-          \\"nextId\\": 28,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"span\\",
+            \\"attributes\\": {
+              \\"class\\": \\"select2-arrow\\",
+              \\"role\\": \\"presentation\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 32
+          }
+        },
+        {
+          \\"parentId\\": 32,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"b\\",
+            \\"attributes\\": {
+              \\"role\\": \\"presentation\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 33
+          }
+        },
+        {
+          \\"parentId\\": 26,
+          \\"nextId\\": 32,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"   \\",
-            \\"id\\": 27
+            \\"id\\": 31
+          }
+        },
+        {
+          \\"parentId\\": 26,
+          \\"nextId\\": 31,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"abbr\\",
+            \\"attributes\\": {
+              \\"class\\": \\"select2-search-choice-close\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 30
           }
         },
         {
@@ -3250,51 +3290,11 @@ exports[`record integration tests > can record node mutations 1`] = `
         },
         {
           \\"parentId\\": 26,
-          \\"nextId\\": 31,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"abbr\\",
-            \\"attributes\\": {
-              \\"class\\": \\"select2-search-choice-close\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 30
-          }
-        },
-        {
-          \\"parentId\\": 26,
-          \\"nextId\\": 32,
+          \\"nextId\\": 28,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"   \\",
-            \\"id\\": 31
-          }
-        },
-        {
-          \\"parentId\\": 26,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"span\\",
-            \\"attributes\\": {
-              \\"class\\": \\"select2-arrow\\",
-              \\"role\\": \\"presentation\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 32
-          }
-        },
-        {
-          \\"parentId\\": 32,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"b\\",
-            \\"attributes\\": {
-              \\"role\\": \\"presentation\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 33
+            \\"id\\": 27
           }
         },
         {
@@ -3314,11 +3314,26 @@ exports[`record integration tests > can record node mutations 1`] = `
         },
         {
           \\"parentId\\": 36,
-          \\"nextId\\": 38,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"ul\\",
+            \\"attributes\\": {
+              \\"class\\": \\"select2-results\\",
+              \\"role\\": \\"listbox\\",
+              \\"id\\": \\"select2-results-1\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 45
+          }
+        },
+        {
+          \\"parentId\\": 36,
+          \\"nextId\\": 45,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"   \\",
-            \\"id\\": 37
+            \\"id\\": 44
           }
         },
         {
@@ -3336,34 +3351,11 @@ exports[`record integration tests > can record node mutations 1`] = `
         },
         {
           \\"parentId\\": 38,
-          \\"nextId\\": 40,
+          \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"       \\",
-            \\"id\\": 39
-          }
-        },
-        {
-          \\"parentId\\": 38,
-          \\"nextId\\": 41,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"label\\",
-            \\"attributes\\": {
-              \\"for\\": \\"s2id_autogen1_search\\",
-              \\"class\\": \\"select2-offscreen\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 40
-          }
-        },
-        {
-          \\"parentId\\": 38,
-          \\"nextId\\": 42,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"       \\",
-            \\"id\\": 41
+            \\"textContent\\": \\"   \\",
+            \\"id\\": 43
           }
         },
         {
@@ -3393,35 +3385,43 @@ exports[`record integration tests > can record node mutations 1`] = `
         },
         {
           \\"parentId\\": 38,
-          \\"nextId\\": null,
+          \\"nextId\\": 42,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"   \\",
-            \\"id\\": 43
+            \\"textContent\\": \\"       \\",
+            \\"id\\": 41
           }
         },
         {
-          \\"parentId\\": 36,
-          \\"nextId\\": 45,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"   \\",
-            \\"id\\": 44
-          }
-        },
-        {
-          \\"parentId\\": 36,
-          \\"nextId\\": null,
+          \\"parentId\\": 38,
+          \\"nextId\\": 41,
           \\"node\\": {
             \\"type\\": 2,
-            \\"tagName\\": \\"ul\\",
+            \\"tagName\\": \\"label\\",
             \\"attributes\\": {
-              \\"class\\": \\"select2-results\\",
-              \\"role\\": \\"listbox\\",
-              \\"id\\": \\"select2-results-1\\"
+              \\"for\\": \\"s2id_autogen1_search\\",
+              \\"class\\": \\"select2-offscreen\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 45
+            \\"id\\": 40
+          }
+        },
+        {
+          \\"parentId\\": 38,
+          \\"nextId\\": 40,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"       \\",
+            \\"id\\": 39
+          }
+        },
+        {
+          \\"parentId\\": 36,
+          \\"nextId\\": 38,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"   \\",
+            \\"id\\": 37
           }
         },
         {
@@ -3463,27 +3463,16 @@ exports[`record integration tests > can record node mutations 1`] = `
           }
         },
         {
-          \\"parentId\\": 18,
-          \\"nextId\\": 36,
+          \\"parentId\\": 68,
+          \\"nextId\\": 69,
           \\"node\\": {
             \\"type\\": 2,
-            \\"tagName\\": \\"div\\",
+            \\"tagName\\": \\"span\\",
             \\"attributes\\": {
-              \\"id\\": \\"select2-drop-mask\\",
-              \\"class\\": \\"select2-drop-mask\\",
-              \\"style\\": \\"\\"
+              \\"class\\": \\"select2-match\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 70
-          }
-        },
-        {
-          \\"parentId\\": 62,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"2 results are available, use up and down arrow keys to navigate.\\",
-            \\"id\\": 71
           }
         },
         {
@@ -3497,11 +3486,11 @@ exports[`record integration tests > can record node mutations 1`] = `
               \\"role\\": \\"presentation\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 72
+            \\"id\\": 71
           }
         },
         {
-          \\"parentId\\": 72,
+          \\"parentId\\": 71,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 2,
@@ -3512,41 +3501,52 @@ exports[`record integration tests > can record node mutations 1`] = `
               \\"role\\": \\"option\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 73
+            \\"id\\": 72
           }
         },
         {
-          \\"parentId\\": 73,
+          \\"parentId\\": 72,
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"A\\",
-            \\"id\\": 74
+            \\"id\\": 73
           }
         },
         {
-          \\"parentId\\": 73,
-          \\"nextId\\": 74,
+          \\"parentId\\": 72,
+          \\"nextId\\": 73,
           \\"node\\": {
             \\"type\\": 2,
             \\"tagName\\": \\"span\\",
             \\"attributes\\": {
               \\"class\\": \\"select2-match\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 74
+          }
+        },
+        {
+          \\"parentId\\": 18,
+          \\"nextId\\": 36,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"div\\",
+            \\"attributes\\": {
+              \\"id\\": \\"select2-drop-mask\\",
+              \\"class\\": \\"select2-drop-mask\\",
+              \\"style\\": \\"\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 75
           }
         },
         {
-          \\"parentId\\": 68,
-          \\"nextId\\": 69,
+          \\"parentId\\": 62,
+          \\"nextId\\": null,
           \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"span\\",
-            \\"attributes\\": {
-              \\"class\\": \\"select2-match\\"
-            },
-            \\"childNodes\\": [],
+            \\"type\\": 3,
+            \\"textContent\\": \\"2 results are available, use up and down arrow keys to navigate.\\",
             \\"id\\": 76
           }
         }
@@ -3576,7 +3576,7 @@ exports[`record integration tests > can record node mutations 1`] = `
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 0,
-      \\"id\\": 70
+      \\"id\\": 75
     }
   },
   {
@@ -9588,6 +9588,15 @@ exports[`record integration tests > should not record input values if dynamicall
   {
     \\"type\\": 3,
     \\"data\\": {
+      \\"source\\": 3,
+      \\"id\\": 21,
+      \\"x\\": 2,
+      \\"y\\": 0
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
       \\"id\\": 21
@@ -10689,11 +10698,11 @@ exports[`record integration tests > should record DOM node movement 1 1`] = `
         },
         {
           \\"parentId\\": 12,
-          \\"nextId\\": 14,
+          \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n      \\",
-            \\"id\\": 13
+            \\"textContent\\": \\"\\\\n    \\",
+            \\"id\\": 19
           }
         },
         {
@@ -10709,11 +10718,11 @@ exports[`record integration tests > should record DOM node movement 1 1`] = `
         },
         {
           \\"parentId\\": 14,
-          \\"nextId\\": 16,
+          \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n        \\",
-            \\"id\\": 15
+            \\"textContent\\": \\"\\\\n      \\",
+            \\"id\\": 18
           }
         },
         {
@@ -10738,20 +10747,20 @@ exports[`record integration tests > should record DOM node movement 1 1`] = `
         },
         {
           \\"parentId\\": 14,
-          \\"nextId\\": null,
+          \\"nextId\\": 16,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n      \\",
-            \\"id\\": 18
+            \\"textContent\\": \\"\\\\n        \\",
+            \\"id\\": 15
           }
         },
         {
           \\"parentId\\": 12,
-          \\"nextId\\": null,
+          \\"nextId\\": 14,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n    \\",
-            \\"id\\": 19
+            \\"textContent\\": \\"\\\\n      \\",
+            \\"id\\": 13
           }
         }
       ]
@@ -10945,11 +10954,11 @@ exports[`record integration tests > should record DOM node movement 2 1`] = `
       \\"adds\\": [
         {
           \\"parentId\\": 12,
-          \\"nextId\\": 14,
+          \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n      \\",
-            \\"id\\": 13
+            \\"textContent\\": \\"\\\\n    \\",
+            \\"id\\": 19
           }
         },
         {
@@ -10965,11 +10974,11 @@ exports[`record integration tests > should record DOM node movement 2 1`] = `
         },
         {
           \\"parentId\\": 14,
-          \\"nextId\\": 16,
+          \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n        \\",
-            \\"id\\": 15
+            \\"textContent\\": \\"\\\\n      \\",
+            \\"id\\": 18
           }
         },
         {
@@ -10994,20 +11003,20 @@ exports[`record integration tests > should record DOM node movement 2 1`] = `
         },
         {
           \\"parentId\\": 14,
-          \\"nextId\\": null,
+          \\"nextId\\": 16,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n      \\",
-            \\"id\\": 18
+            \\"textContent\\": \\"\\\\n        \\",
+            \\"id\\": 15
           }
         },
         {
           \\"parentId\\": 12,
-          \\"nextId\\": null,
+          \\"nextId\\": 14,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"\\\\n    \\",
-            \\"id\\": 19
+            \\"textContent\\": \\"\\\\n      \\",
+            \\"id\\": 13
           }
         },
         {

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -89,17 +89,6 @@ describe('benchmark: mutation observer', () => {
     return fs.readFileSync(filePath, 'utf8');
   };
 
-  const addRecordingScript = async (page: Page) => {
-    // const scriptUrl = `${getServerURL(server)}/rrweb-1.1.3.js`;
-    const scriptUrl = `${getServerURL(server)}/rrweb.umd.cjs`;
-    await page.evaluate((url) => {
-      const scriptEl = document.createElement('script');
-      scriptEl.src = url;
-      document.head.append(scriptEl);
-    }, scriptUrl);
-    await page.waitForFunction('window.rrweb');
-  };
-
   for (const suite of suites) {
     it(suite.title, async () => {
       page = await browser.newPage();
@@ -110,12 +99,17 @@ describe('benchmark: mutation observer', () => {
       const loadPage = async () => {
         if ('html' in suite) {
           await page.goto('about:blank');
+          const code = fs.readFileSync(path.resolve(__dirname, '../../dist/rrweb.umd.cjs')).toString()
+          await page.setContent(`<html>
+            <script>
+            ${code.toString()}
+            </script>
+            </html>`);
+
           await page.setContent(getHtml.call(this, suite.html));
         } else {
           await page.goto(suite.url);
         }
-
-        await addRecordingScript(page);
       };
 
       const getDuration = async (): Promise<number> => {

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -99,7 +99,9 @@ describe('benchmark: mutation observer', () => {
       const loadPage = async () => {
         if ('html' in suite) {
           await page.goto('about:blank');
-          const code = fs.readFileSync(path.resolve(__dirname, '../../dist/rrweb.umd.cjs')).toString()
+          const code = fs
+            .readFileSync(path.resolve(__dirname, '../../dist/rrweb.umd.cjs'))
+            .toString();
           await page.setContent(`<html>
             <script>
             ${code.toString()}

--- a/packages/rrweb/test/html/benchmark-dom-mutation-deep-nested.html
+++ b/packages/rrweb/test/html/benchmark-dom-mutation-deep-nested.html
@@ -2,7 +2,7 @@
   <body></body>
   <script>
     function init() {
-      const count = 100;
+      const count = 100;  // originally 1000 in #1277
 
       let roots = [];
       for (let i = 0; i < count; ++i) {
@@ -11,7 +11,7 @@
         roots.push(div);
       }
 
-      let tree_depth = 256;
+      let tree_depth = 256; // originally 64 in #1277
       let children = [...roots];
       while (tree_depth > 0) {
         for (let i = 0; i < children.length; i++) {


### PR DESCRIPTION
Not sure how representative the benchmark is, so I'm adding the screenshot of the profile (deep DOM tree benchmark). Looking at timings, it seems to take ~18ms before and 13ms after my change, or about ~30% gain. Feel free to do more extensive benchmarking and take those timings with a grain of salt as I just ran the benchmarks once

Before
<img width="698" alt="CleanShot 2023-08-08 at 10 11 25@2x" src="https://github.com/rrweb-io/rrweb/assets/9317857/0176935f-ea61-4e9f-b981-fb3c91d96528">

After
<img width="549" alt="CleanShot 2023-08-08 at 10 11 36@2x" src="https://github.com/rrweb-io/rrweb/assets/9317857/b34baec9-ecde-4871-8fc2-d7e106d608f1">

We can see the stack is shallower as expected (and uses less memory, sadly no metrics on that).
A small benefit is that we also remove the overhead of calling into the polymorphic genAdds fn.

The queue has a magic default size of 1000 - feel free to tweak that to some better value, I'm not sure what a sensible default could be here