### PR TITLE
Extend to run fixBrowserCompatibilityIssuesInCSS over inline stylesheets

### DIFF
--- a/.changeset/curvy-apples-lay.md
+++ b/.changeset/curvy-apples-lay.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Extend to run fixBrowserCompatibilityIssuesInCSS over inline stylesheets

--- a/.changeset/curvy-apples-lay.md
+++ b/.changeset/curvy-apples-lay.md
@@ -1,6 +1,6 @@
 ---
-"rrweb-snapshot": patch
-"rrweb": patch
+'rrweb-snapshot': patch
+'rrweb': patch
 ---
 
 Extend to run fixBrowserCompatibilityIssuesInCSS over inline stylesheets

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -51,16 +51,6 @@ function getValidTagName(element: HTMLElement): Lowercase<string> {
   return processedTagName;
 }
 
-function stringifyStyleSheet(sheet: CSSStyleSheet): string {
-  return sheet.cssRules
-    ? Array.from(sheet.cssRules)
-        .map((rule) =>
-          rule.cssText ? validateStringifiedCssRule(rule.cssText) : '',
-        )
-        .join('')
-    : '';
-}
-
 function extractOrigin(url: string): string {
   let origin = '';
   if (url.indexOf('//') > -1) {
@@ -564,7 +554,7 @@ function serializeTextNode(
         // to _only_ include the current rule(s) added by the text node.
         // So we'll be conservative and keep textContent as-is.
       } else if ((n.parentNode as HTMLStyleElement).sheet?.cssRules) {
-        textContent = stringifyStyleSheet(
+        textContent = getCssRulesString(
           (n.parentNode as HTMLStyleElement).sheet!,
         );
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,9 +5503,14 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-cssom@^0.4.4, cssom@^0.5.0, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
+cssom@^0.4.4, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
   version "0.6.0"
   resolved "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
+
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
 
 cssom@~0.3.6:
   version "0.3.8"


### PR DESCRIPTION
@Juice10 a small PR assuming it's correct to also run inline <style> elements over the `fixBrowserCompatibilityIssuesInCSS` function that was added in #1047 

This is a starting point for fixing #1249 