### PR TITLE
[rrvideo] feat:  support config chrome launch options

### DIFF
--- a/packages/rrvideo/rrvideo.config.example.json
+++ b/packages/rrvideo/rrvideo.config.example.json
@@ -6,5 +6,6 @@
   "mouseTail": {
     "strokeStyle": "green",
     "lineWidth": 2
-  }
+  },
+  "launchOptions": {}
 }

--- a/packages/rrvideo/src/index.ts
+++ b/packages/rrvideo/src/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { chromium } from 'playwright';
 import { EventType, eventWithTime } from '@rrweb/types';
 import type { RRwebPlayerOptions } from 'rrweb-player';
+import type { LaunchOptions } from "playwright";
 
 const rrwebScriptPath = path.resolve(
   require.resolve('rrweb-player'),
@@ -18,6 +19,7 @@ type RRvideoConfig = {
   input: string;
   output?: string;
   headless?: boolean;
+  launchOptions?: LaunchOptions;
   // A number between 0 and 1. The higher the value, the better the quality of the video.
   resolutionRatio?: number;
   // A callback function that will be called when the progress of the replay is updated.
@@ -29,6 +31,7 @@ const defaultConfig: Required<RRvideoConfig> = {
   input: '',
   output: 'rrvideo-output.webm',
   headless: true,
+  launchOptions: {},
   // A good trade-off value between quality and file size.
   resolutionRatio: 0.8,
   onProgressUpdate: () => {
@@ -126,6 +129,7 @@ export async function transformToVideo(options: RRvideoConfig) {
   Object.assign(config.rrwebPlayer, scaledViewport);
   const browser = await chromium.launch({
     headless: config.headless,
+    ...config.launchOptions
   });
   const context = await browser.newContext({
     viewport: scaledViewport,

--- a/packages/rrvideo/src/index.ts
+++ b/packages/rrvideo/src/index.ts
@@ -102,6 +102,14 @@ export async function transformToVideo(options: RRvideoConfig) {
   if (!options.input) throw new Error('input is required');
   // If the output is not specified or undefined, use the default value.
   if (!options.output) delete options.output;
+  // rrvideo config file support set 'headless', if the headless is not boolean, use the default value.
+  if (
+    options.launchOptions &&
+    typeof options.launchOptions.headless === 'boolean'
+  ) {
+    config.headless = options.launchOptions.headless;
+    delete options.launchOptions.headless;
+  }
   Object.assign(config, options);
   if (config.resolutionRatio > 1) config.resolutionRatio = 1; // The max value is 1.
 
@@ -129,7 +137,7 @@ export async function transformToVideo(options: RRvideoConfig) {
   Object.assign(config.rrwebPlayer, scaledViewport);
   const browser = await chromium.launch({
     headless: config.headless,
-    ...config.launchOptions
+    ...config.launchOptions,
   });
   const context = await browser.newContext({
     viewport: scaledViewport,

--- a/packages/rrvideo/src/index.ts
+++ b/packages/rrvideo/src/index.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { chromium } from 'playwright';
 import { EventType, eventWithTime } from '@rrweb/types';
 import type { RRwebPlayerOptions } from 'rrweb-player';
-import type { LaunchOptions } from "playwright";
+import type { LaunchOptions } from 'playwright';
 
 const rrwebScriptPath = path.resolve(
   require.resolve('rrweb-player'),


### PR DESCRIPTION
https://github.com/rrweb-io/rrvideo/issues/28 
#1289 
```
// rrvideo.config.json
{
  "width": 1400,
  "height": 900,
  "speed": 4,
  "skipInactive": true,
  "mouseTail": {
    "strokeStyle": "green",
    "lineWidth": 2
  },
// can set chrome launch options in this, such as 'args: ['--no-sandbox', '--disable-setuid-sandbox']', include 'headless'
  "launchOptions": {}
}
```