### PR TITLE
perf: only call createHTMLDocument when it is needed

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -497,14 +497,6 @@ export default class MutationBuffer {
     if (isIgnored(m.target, this.mirror)) {
       return;
     }
-    let unattachedDoc;
-    try {
-      // avoid upsetting original document from a Content Security point of view
-      unattachedDoc = document.implementation.createHTMLDocument();
-    } catch (e) {
-      // fallback to more direct method
-      unattachedDoc = this.doc;
-    }
     switch (m.type) {
       case 'characterData': {
         const value = m.target.textContent;
@@ -597,6 +589,14 @@ export default class MutationBuffer {
             value,
           );
           if (attributeName === 'style') {
+            let unattachedDoc;
+            try {
+              // avoid upsetting original document from a Content Security point of view
+              unattachedDoc = document.implementation.createHTMLDocument();
+            } catch (e) {
+              // fallback to more direct method
+              unattachedDoc = this.doc;
+            }
             const old = unattachedDoc.createElement('span');
             if (m.oldValue) {
               old.setAttribute('style', m.oldValue);


### PR DESCRIPTION
I noticed on a very large mutation that createHTMLDocument was a significant portion of the processing time. It appears that `unnattachedDoc` is only used in one specific branch, so rather than create it every time `processMutation` is called, I moved it so that it is only created in the branch where it is used.

This improves a couple of the benchmarks, while the others appear to be unaffected either way:

Before:
<img width="1103" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/cd467596-0573-42d0-beff-275913dd6cf3">
<img width="1230" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/69765180-3c8d-4b1a-ae5d-0a8543607473">

After:
<img width="1104" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/ba36c7e8-3f24-4666-970f-64d08d40907f">
<img width="1230" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/ebe866cc-29e1-4139-8cb1-defaa33e6d2b">

