### PR TITLE
Return early for child same origin frames

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -114,6 +114,9 @@ function record<T = eventWithTime>(
   if (inEmittingFrame && !emit) {
     throw new Error('emit function is required');
   }
+  if (!inEmittingFrame && !passEmitsToParent) {
+    return () => {  /* no-op since in this case we don't need to record anything from this frame in particular */ };
+  }
   // move departed options to new options
   if (mousemoveWait !== undefined && sampling.mousemove === undefined) {
     sampling.mousemove = mousemoveWait;


### PR DESCRIPTION
If we have cross origin record turned on but we are in a child frame that has the same origin as its parent we end up in sort of an inefficient state. We will start the recording, record mutations, but then never actually emit them anywhere since inEmittingFrame and passEmitsToParent are both false. This is a waste of resources and we might as well just never start the recording.

Brought this up in slack: https://rrweb.slack.com/archives/C01BYDC5C93/p1692810269238919