### PR TITLE
fix(perf): benchmark processMutations/addList worst case performance

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -287,8 +287,8 @@ export default class MutationBuffer {
     const getParentId = (n: Node): number | null => {
       if (!n.parentNode) return null;
       return isShadowRoot(n.parentNode)
-          ? this.mirror.getId(getShadowHost(n))
-          : this.mirror.getId(n.parentNode);
+        ? this.mirror.getId(getShadowHost(n))
+        : this.mirror.getId(n.parentNode);
     };
     const pushAdd = (n: Node) => {
       if (!n.parentNode || !inDom(n)) {
@@ -385,7 +385,7 @@ export default class MutationBuffer {
           adds.push({
             parentId,
             nextId: getNextId(addedNode),
-            node: sn
+            node: sn,
           });
           addedIds.add(sn.id);
         }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1508,7 +1508,7 @@ export class Replayer {
           // is newly added document, maybe the document node of an iframe
           return this.newDocumentQueue.push(mutation);
         }
-        return allowQueue ? addToQueue(mutation) : false
+        return allowQueue ? addToQueue(mutation) : false;
       }
 
       if (mutation.node.isShadow) {
@@ -1528,7 +1528,7 @@ export class Replayer {
         next = mirror.getNode(mutation.nextId);
       }
       if (nextNotInDOM(mutation)) {
-        return allowQueue ? addToQueue(mutation) : false
+        return allowQueue ? addToQueue(mutation) : false;
       }
 
       if (mutation.node.rootId && !mirror.getNode(mutation.node.rootId)) {
@@ -1687,7 +1687,11 @@ export class Replayer {
       appendNode(mutation);
     });
 
-    const iterateResolveTree = (tree: ResolveTree, mirror: RRDOMMirror | Mirror, cb: (mutation: addedNodeMutation) => unknown) => {
+    const iterateResolveTree = (
+      tree: ResolveTree,
+      mirror: RRDOMMirror | Mirror,
+      cb: (mutation: addedNodeMutation) => unknown,
+    ) => {
       if (tree.value) {
         cb(tree.value);
       }
@@ -1701,9 +1705,11 @@ export class Replayer {
       }
       while (nextChild) {
         iterateResolveTree(nextChild, mirror, cb);
-        nextChild = nextChild.value ? tree.children.get(nextChild.value.node.id) : undefined;
+        nextChild = nextChild.value
+          ? tree.children.get(nextChild.value.node.id)
+          : undefined;
       }
-    }
+    };
     const startTime = Date.now();
     for (const tree of queue) {
       iterateResolveTree(tree, mirror, (mutation: addedNodeMutation) => {

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -342,7 +342,7 @@ export function polyfill(win = window) {
 }
 
 export type ResolveTree = {
-  id: number,
+  id: number;
   value: addedNodeMutation | null;
   children: Map<number | null, ResolveTree>;
 };

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -341,70 +341,11 @@ export function polyfill(win = window) {
   }
 }
 
-type ResolveTree = {
-  value: addedNodeMutation;
-  children: ResolveTree[];
-  parent: ResolveTree | null;
+export type ResolveTree = {
+  id: number,
+  value: addedNodeMutation | null;
+  children: Map<number | null, ResolveTree>;
 };
-
-export function queueToResolveTrees(queue: addedNodeMutation[]): ResolveTree[] {
-  const queueNodeMap: Record<number, ResolveTree> = {};
-  const putIntoMap = (
-    m: addedNodeMutation,
-    parent: ResolveTree | null,
-  ): ResolveTree => {
-    const nodeInTree: ResolveTree = {
-      value: m,
-      parent,
-      children: [],
-    };
-    queueNodeMap[m.node.id] = nodeInTree;
-    return nodeInTree;
-  };
-
-  const queueNodeTrees: ResolveTree[] = [];
-  for (const mutation of queue) {
-    const { nextId, parentId } = mutation;
-    if (nextId && nextId in queueNodeMap) {
-      const nextInTree = queueNodeMap[nextId];
-      if (nextInTree.parent) {
-        const idx = nextInTree.parent.children.indexOf(nextInTree);
-        nextInTree.parent.children.splice(
-          idx,
-          0,
-          putIntoMap(mutation, nextInTree.parent),
-        );
-      } else {
-        const idx = queueNodeTrees.indexOf(nextInTree);
-        queueNodeTrees.splice(idx, 0, putIntoMap(mutation, null));
-      }
-      continue;
-    }
-    if (parentId in queueNodeMap) {
-      const parentInTree = queueNodeMap[parentId];
-      parentInTree.children.push(putIntoMap(mutation, parentInTree));
-      continue;
-    }
-    queueNodeTrees.push(putIntoMap(mutation, null));
-  }
-
-  return queueNodeTrees;
-}
-
-export function iterateResolveTree(
-  tree: ResolveTree,
-  cb: (mutation: addedNodeMutation) => unknown,
-) {
-  cb(tree.value);
-  /**
-   * The resolve tree was designed to reflect the DOM layout,
-   * but we need append next sibling first, so we do a reverse
-   * loop here.
-   */
-  for (let i = tree.children.length - 1; i >= 0; i--) {
-    iterateResolveTree(tree.children[i], cb);
-  }
-}
 
 export type AppendedIframe = {
   mutationInQueue: addedNodeMutation;

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -54,6 +54,12 @@ const suites: Array<
     eval: 'window.workload()',
     times: 5,
   },
+  {
+    title: 'add 5x2000 DOM nodes in random order',
+    html: 'benchmark-dom-mutation-random-add.html',
+    eval: 'window.workload()',
+    times: 5,
+  },
 ];
 
 function avg(v: number[]): number {

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -48,6 +48,12 @@ const suites: Array<
     eval: 'window.workload()',
     times: 10,
   },
+  {
+    title: 'add and reorder 10000 DOM nodes',
+    html: 'benchmark-dom-mutation-add-reorder.html',
+    eval: 'window.workload()',
+    times: 5,
+  },
 ];
 
 function avg(v: number[]): number {

--- a/packages/rrweb/test/html/benchmark-dom-mutation-add-reorder.html
+++ b/packages/rrweb/test/html/benchmark-dom-mutation-add-reorder.html
@@ -1,0 +1,33 @@
+<html>
+  <body>
+    <select id="select"></select>
+  </body>
+  <script>
+    window.workload = () => {
+      const optionCount = 10000;
+      const options = [];
+      for (let i = 0; i < optionCount; ++i) {
+        const value = `${i}`;
+        options.push({ value, label: value });
+      }
+      const frag = document.createDocumentFragment();
+      const select = document.getElementById('select');
+      const parent = select.parentNode;
+      parent.removeChild(select);
+      for (let o of options) {
+        const option = document.createElement('option');
+        option.value = o.value;
+        option.textContent = o.label;
+        o.optionElement = option;
+        frag.appendChild(option);
+      }
+      select.appendChild(frag);
+      parent.appendChild(select);
+      // re-shuffle the options
+      options.sort(() => Math.random() - 0.5);
+      for (var o of options) {
+        o.optionElement.parentNode.appendChild(o.optionElement);
+      }
+    };
+  </script>
+</html>

--- a/packages/rrweb/test/html/benchmark-dom-mutation-random-add.html
+++ b/packages/rrweb/test/html/benchmark-dom-mutation-random-add.html
@@ -1,0 +1,25 @@
+<html>
+    <body>
+        <ul id="list"></ul>
+    </body>
+    <script>
+        const itemCount = 5;
+        const nodesPerItem = 2000;
+        window.workload = () => {
+            const list = document.getElementById('list');
+            for (let i = 0; i < itemCount; ++i) {
+                const li = document.createElement('li');
+                list.appendChild(li);
+            }
+            for (i = 0; i < itemCount; ++i) {
+                for (let j = 0; j < nodesPerItem; ++j) {
+                    const index = Math.floor(Math.random() * nodesPerItem);
+                    const span = document.createElement('span');
+                    const li = list.children[i];
+                    li.insertBefore(span, li.children[index + 1]);
+                    span.textContent = `node ${j}`;
+                }
+            }
+        };
+    </script>
+</html>


### PR DESCRIPTION
In reference to this slack thread: https://rrweb.slack.com/archives/C01BYDC5C93/p1693333759752269

This is meant as a starting point for discussion, not necessarily merge-ready code. I added a benchmark demonstrating the "bad" behavior, and a naive attempt at a fix.

Before fix:
<img width="1161" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/a9249475-9979-45d1-8752-2b269f53c206">

After fix:
<img width="1130" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/8625afab-86f2-436f-bda2-03d4f9182cca">

The issue with the fix as-is, is that it makes performance _slightly worse_ in the average case, so the extra pass through `addList` to re-order the list nodes probably needs to be done conditionally, or maybe there's some way to build the list more efficiently to avoid this altogether.

So let me know what you'd like to see from here. I could change this PR to only include the benchmark, and open an issue to address fixing the performance in this case, for example.