### PR TITLE
Enable preserveSource of rollup-plugin-web-worker-loader

### DIFF
--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -125,6 +125,7 @@ function getPlugins(options = {}) {
     webWorkerLoader({
       targetPlatform: 'browser',
       inline: true,
+      preserveSource: true,
       sourceMap,
     }),
     esbuild({
@@ -144,7 +145,11 @@ for (const c of baseConfigs) {
     resolve({ browser: true }),
 
     // supports bundling `web-worker:..filename`
-    webWorkerLoader({ targetPlatform: 'browser' }),
+    webWorkerLoader({
+      targetPlatform: 'browser',
+      inline: true,
+      preserveSource: true,
+    }),
 
     typescript(),
   ];


### PR DESCRIPTION
Ref: https://github.com/rrweb-io/rrweb/issues/1308

This change modifies the build output `` as detailed below:

### Before 

```
var WorkerFactory = createBase64WorkerFactory('Lyogcm9sbHVwLXBsdWdpbi13Z...', null, false);
```

### After

```
var WorkerFactory = createInlineWorkerFactory(/* rollup-plugin-web-worker-loader */function () {
(function () {
    '__worker_loader_strict__';

   --- SOURCE CODE HERE ---

})();
}, null);
```