### PR TITLE
Pref: export eventWithTime

### DIFF
--- a/.changeset/lemon-lamps-switch.md
+++ b/.changeset/lemon-lamps-switch.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+export eventWithTime for consumption by typescript code

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -8,6 +8,7 @@ export {
   IncrementalSource,
   MouseInteractions,
   ReplayerEvents,
+  type eventWithTime
 } from '@rrweb/types';
 
 export type { recordOptions } from './types';


### PR DESCRIPTION
When using emit, you do not know the type of event and can only write it as any[], which is not very elegant. rrweb should provide the type directly
