### PR TITLE
fix: Fix checking for `patchTarget` in `initAdoptedStyleSheetObserver`

### DIFF
--- a/.changeset/calm-oranges-sin.md
+++ b/.changeset/calm-oranges-sin.md
@@ -1,5 +1,5 @@
 ---
-"rrweb": patch
+'rrweb': patch
 ---
 
 fix: Fix checking for `patchTarget` in `initAdoptedStyleSheetObserver`

--- a/.changeset/calm-oranges-sin.md
+++ b/.changeset/calm-oranges-sin.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+fix: Fix checking for `patchTarget` in `initAdoptedStyleSheetObserver`

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -900,10 +900,12 @@ export function initAdoptedStyleSheetObserver(
     host.nodeName === '#document'
       ? (host as Document).defaultView?.Document
       : host.ownerDocument?.defaultView?.ShadowRoot;
-  const originalPropertyDescriptor = Object.getOwnPropertyDescriptor(
-    patchTarget?.prototype,
-    'adoptedStyleSheets',
-  );
+  const originalPropertyDescriptor = patchTarget?.prototype
+    ? Object.getOwnPropertyDescriptor(
+        patchTarget?.prototype,
+        'adoptedStyleSheets',
+      )
+    : undefined;
   if (
     hostId === null ||
     hostId === -1 ||


### PR DESCRIPTION
Calling `Object.getOwnPropertyDescriptor(undefined, 'xx')` actually errors out, so let's guard there. The types for this are bad, because it takes `any` but actually fails on nullish objects 😬 