### PR TITLE
🐞 fix(web-extension): beforeunload logic

### DIFF
--- a/.changeset/witty-kids-talk.md
+++ b/.changeset/witty-kids-talk.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/web-extension": patch
+---
+
+🐞 fix(web-extension): beforeunload logic

--- a/.changeset/witty-kids-talk.md
+++ b/.changeset/witty-kids-talk.md
@@ -1,5 +1,5 @@
 ---
-"@rrweb/web-extension": patch
+'@rrweb/web-extension': patch
 ---
 
 🐞 fix(web-extension): beforeunload logic

--- a/packages/web-extension/src/content/index.ts
+++ b/packages/web-extension/src/content/index.ts
@@ -155,8 +155,8 @@ async function initMainPage() {
 
   // Before unload pages, cache the new events in the local storage.
   window.addEventListener('beforeunload', (event) => {
+    if (!newEvents.length) return;
     event.preventDefault();
-    if (newEvents.length === 0) return;
     void Browser.storage.local.set({
       [LocalDataKey.bufferedEvents]: bufferedEvents.concat(newEvents),
     });


### PR DESCRIPTION
check `newEvents` before `event.preventDefault`

see the video, Chrome show the dialog but I didn't  record, this is unexpected: 


https://drive.google.com/file/d/1sJ316mWbbRGkVfiG6C1EslAahrw3zMyE/view?usp=share_link


