### PR TITLE
fix: lint errors from adding `recordDOM` option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,9 @@ module.exports = {
   plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc', 'jest', 'compat'],
   rules: {
     'tsdoc/syntax': 'warn',
+    '@typescript-eslint/no-unused-vars': ['warn', {
+      varsIgnorePattern: '^_',
+      argsIgnorePattern: '^_',
+    }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc', 'jest', 'compat'],
   rules: {
     'tsdoc/syntax': 'warn',
-    '@typescript-eslint/no-unused-vars': ['warn', {
+    '@typescript-eslint/no-unused-vars': ['error', {
       varsIgnorePattern: '^_',
       argsIgnorePattern: '^_',
     }],

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -5,7 +5,6 @@ import {
   tagMap,
   elementNode,
   BuildCache,
-  attributes,
   legacyAttributes,
 } from './types';
 import { isElement, Mirror, isNodeMetaEqual } from './utils';
@@ -478,13 +477,16 @@ export function buildNodeWithSN(
 }
 
 function visit(mirror: Mirror, onVisit: (node: Node) => void) {
-  function walk(node: Node) {
+  function walk(node: Node|null) {
+    if (!node) {
+      return;
+    }
     onVisit(node);
   }
 
   for (const id of mirror.getIds()) {
     if (mirror.has(id)) {
-      walk(mirror.getNode(id)!);
+      walk(mirror.getNode(id));
     }
   }
 }

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -477,7 +477,7 @@ export function buildNodeWithSN(
 }
 
 function visit(mirror: Mirror, onVisit: (node: Node) => void) {
-  function walk(node: Node|null) {
+  function walk(node: Node | null) {
     if (!node) {
       return;
     }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -252,7 +252,6 @@ export function transformAttribute(
 export function ignoreAttribute(
   tagName: string,
   name: string,
-  _value: unknown,
 ): boolean {
   return (tagName === 'video' || tagName === 'audio') && name === 'autoplay';
 }
@@ -383,11 +382,6 @@ function onceIframeLoaded(
   }
   // use default listener
   iframeEl.addEventListener('load', listener);
-}
-
-function isStylesheetLoaded(link: HTMLLinkElement) {
-  if (!link.getAttribute('href')) return true; // nothing to load
-  return link.sheet !== null;
 }
 
 function onceStylesheetLoaded(

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -249,7 +249,11 @@ export function transformAttribute(
   return value;
 }
 
-export function ignoreAttribute(tagName: string, name: string): boolean {
+export function ignoreAttribute(
+  tagName: string,
+  name: string,
+  _value: unknown,
+): boolean {
   return (tagName === 'video' || tagName === 'audio') && name === 'autoplay';
 }
 

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -249,10 +249,7 @@ export function transformAttribute(
   return value;
 }
 
-export function ignoreAttribute(
-  tagName: string,
-  name: string,
-): boolean {
+export function ignoreAttribute(tagName: string, name: string): boolean {
   return (tagName === 'video' || tagName === 'audio') && name === 'autoplay';
 }
 

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -71,7 +71,7 @@ declare interface CSSImportRule extends CSSRule {
  * Browsers sometimes incorrectly escape `@import` on `.cssText` statements.
  * This function tries to correct the escaping.
  * more info: https://bugs.chromium.org/p/chromium/issues/detail?id=1472259
- * @param cssImportRule
+ * @param cssImportRule - A CSSImportRule
  * @returns `cssText` with browser inconsistencies fixed, or null if not applicable.
  */
 export function escapeImportStatement(rule: CSSImportRule): string {

--- a/packages/rrweb/src/plugins/console/replay/index.ts
+++ b/packages/rrweb/src/plugins/console/replay/index.ts
@@ -5,7 +5,7 @@ import type { ReplayPlugin } from '../../../types';
 
 /**
  * define an interface to replay log records
- * (data: logData) => void> function to display the log data
+ * (data: logData) => void - function to display the log data
  */
 type ReplayLogger = Partial<Record<LogLevel, (data: LogData) => void>>;
 

--- a/packages/rrweb/src/plugins/console/replay/index.ts
+++ b/packages/rrweb/src/plugins/console/replay/index.ts
@@ -5,7 +5,7 @@ import type { ReplayPlugin } from '../../../types';
 
 /**
  * define an interface to replay log records
- * (data: logData) => void - function to display the log data
+ * (data: logData) =\> void - function to display the log data
  */
 type ReplayLogger = Partial<Record<LogLevel, (data: LogData) => void>>;
 

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -1297,10 +1297,18 @@ export function initObservers(
   const inputHandler = initInputObserver(o);
   const mediaInteractionHandler = initMediaInteractionObserver(o);
 
-  let styleSheetObserver = () => { /* noop if !recordDOM */ };
-  let adoptedStyleSheetObserver = () => { /* noop if !recordDOM */ };
-  let styleDeclarationObserver = () => { /* noop if !recordDOM */ };
-  let fontObserver = () => { /* noop if !recordDOM */ };
+  let styleSheetObserver = () => {
+    /* noop if !recordDOM */
+  };
+  let adoptedStyleSheetObserver = () => {
+    /* noop if !recordDOM */
+  };
+  let styleDeclarationObserver = () => {
+    /* noop if !recordDOM */
+  };
+  let fontObserver = () => {
+    /* noop if !recordDOM */
+  };
   if (o.recordDOM) {
     styleSheetObserver = initStyleSheetObserver(o, { win: currentWindow });
     adoptedStyleSheetObserver = initAdoptedStyleSheetObserver(o, o.doc);

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -1297,10 +1297,10 @@ export function initObservers(
   const inputHandler = initInputObserver(o);
   const mediaInteractionHandler = initMediaInteractionObserver(o);
 
-  let styleSheetObserver = () => {};
-  let adoptedStyleSheetObserver = () => {};
-  let styleDeclarationObserver = () => {};
-  let fontObserver = () => {};
+  let styleSheetObserver = () => { /* noop if !recordDOM */ };
+  let adoptedStyleSheetObserver = () => { /* noop if !recordDOM */ };
+  let styleDeclarationObserver = () => { /* noop if !recordDOM */ };
+  let fontObserver = () => { /* noop if !recordDOM */ };
   if (o.recordDOM) {
     styleSheetObserver = initStyleSheetObserver(o, { win: currentWindow });
     adoptedStyleSheetObserver = initAdoptedStyleSheetObserver(o, o.doc);

--- a/packages/rrweb/src/record/observers/canvas/2d.ts
+++ b/packages/rrweb/src/record/observers/canvas/2d.ts
@@ -1,4 +1,3 @@
-import type { Mirror } from 'rrweb-snapshot';
 import {
   blockClass,
   CanvasContext,

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -280,7 +280,7 @@ export class CanvasManager {
 
   flushPendingCanvasMutations() {
     this.pendingCanvasMutations.forEach(
-      (values: canvasMutationCommand[], canvas: HTMLCanvasElement) => {
+      (_values: canvasMutationCommand[], canvas: HTMLCanvasElement) => {
         const id = this.mirror.getId(canvas);
         this.flushPendingCanvasMutationFor(canvas, id);
       },
@@ -297,7 +297,7 @@ export class CanvasManager {
     if (!valuesWithType || id === -1) return;
 
     const values = valuesWithType.map((value) => {
-      const { type, ...rest } = value;
+      const { type: _type, ...rest } = value;
       return rest;
     });
     const { type } = valuesWithType[0];

--- a/packages/rrweb/src/record/observers/canvas/webgl.ts
+++ b/packages/rrweb/src/record/observers/canvas/webgl.ts
@@ -16,7 +16,7 @@ function patchGLPrototype(
   cb: canvasManagerMutationCallback,
   blockClass: blockClass,
   blockSelector: string | null,
-  mirror: Mirror,
+  _mirror: Mirror,
   win: IWindow,
 ): listenerHandler[] {
   const handlers: listenerHandler[] = [];

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -81,7 +81,7 @@ export class StylesheetManager {
   }
 
   // TODO: take snapshot on stylesheet reload by applying event listener
-  private trackStylesheetInLinkElement(linkEl: HTMLLinkElement) {
+  private trackStylesheetInLinkElement(_linkEl: HTMLLinkElement) {
     // linkEl.addEventListener('load', () => {
     //   // re-loaded, maybe take another snapshot?
     // });

--- a/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
@@ -30,6 +30,7 @@ async function getTransparentBlobFor(
 ): Promise<string> {
   const id = `${width}-${height}`;
   if ('OffscreenCanvas' in globalThis) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (transparentBlobMap.has(id)) return transparentBlobMap.get(id)!;
     const offscreen = new OffscreenCanvas(width, height);
     offscreen.getContext('2d'); // creates rendering context for `converToBlob`
@@ -58,9 +59,9 @@ worker.onmessage = async function (e) {
     );
 
     const offscreen = new OffscreenCanvas(width, height);
-    const ctx = offscreen.getContext('2d')!;
+    const ctx = offscreen.getContext('2d');
 
-    ctx.drawImage(bitmap, 0, 0);
+    ctx && ctx.drawImage(bitmap, 0, 0);
     bitmap.close();
     const blob = await offscreen.convertToBlob(dataURLOptions); // takes a while
     const type = blob.type;

--- a/packages/rrweb/src/replay/canvas/webgl.ts
+++ b/packages/rrweb/src/replay/canvas/webgl.ts
@@ -10,7 +10,6 @@ function getContext(
   // if `preserveDrawingBuffer` is set to true,
   // you might have to do `ctx.flush()` before every webgl canvas event
   try {
-    const foo = target.getContext('webgl');
     if (type === CanvasContext.WebGL) {
       return (
         target.getContext('webgl') ||

--- a/packages/rrweb/src/replay/canvas/webgl.ts
+++ b/packages/rrweb/src/replay/canvas/webgl.ts
@@ -10,12 +10,14 @@ function getContext(
   // if `preserveDrawingBuffer` is set to true,
   // you might have to do `ctx.flush()` before every webgl canvas event
   try {
+    const foo = target.getContext('webgl');
     if (type === CanvasContext.WebGL) {
       return (
-        target.getContext('webgl')! || target.getContext('experimental-webgl')
+        target.getContext('webgl') ||
+        (target.getContext('experimental-webgl') as WebGLRenderingContext)
       );
     }
-    return target.getContext('webgl2')!;
+    return target.getContext('webgl2');
   } catch (e) {
     return null;
   }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1001,9 +1001,10 @@ export class Replayer {
    * pause when there are some canvas drawImage args need to be loaded
    */
   private async preloadAllImages(): Promise<void[]> {
-    let beforeLoadState = this.service.state;
+    // TODO `_beforeLoadState` here does not seem to be used?
+    let _beforeLoadState = this.service.state;
     const stateHandler = () => {
-      beforeLoadState = this.service.state;
+      _beforeLoadState = this.service.state;
     };
     this.emitter.on(ReplayerEvents.Start, stateHandler);
     this.emitter.on(ReplayerEvents.Pause, stateHandler);
@@ -1035,8 +1036,9 @@ export class Replayer {
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
       const imgd = ctx?.createImageData(canvas.width, canvas.height);
-      let d = imgd?.data;
-      d = JSON.parse(data.args[0]) as Uint8ClampedArray;
+      // TODO: `_d` is not being used, unless there are some side-effects
+      let _d = imgd?.data;
+      _d = JSON.parse(data.args[0]) as Uint8ClampedArray;
       imgd && ctx?.putImageData(imgd, 0, 0);
     }
   }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -30,7 +30,7 @@ const DEPARTED_MIRROR_ACCESS_WARNING =
   'now you can use replayer.getMirror() to access the mirror instance of a replayer,' +
   '\r\n' +
   'or you can use record.mirror to access the mirror instance during recording.';
-/** @deprecated */
+/** @deprecated Use `replayer.getMirror()` or `record.mirror` to access mirror instance in their respective environments */
 export let _mirror: DeprecatedMirror = {
   map: {},
   getId() {
@@ -114,7 +114,7 @@ export function hookSetter<T>(
           set(value) {
             // put hooked setter into event loop to avoid of set latency
             setTimeout(() => {
-              d.set!.call(this, value);
+              d.set && d.set.call(this, value);
             }, 0);
             if (original && original.set) {
               original.set.call(this, value);


### PR DESCRIPTION
- fixes lint errors from https://github.com/rrweb-io/rrweb/pull/1311
- cleans up some unused var warnings (+ suppresses some)
- make `no-unused-vars` error instead of warn, ignores vars/args that start with underscore ("_")
- removes some null assertion operators