### PR TITLE
Enable control of compression level

### DIFF
--- a/packages/rrweb/src/packer/base.ts
+++ b/packages/rrweb/src/packer/base.ts
@@ -1,6 +1,7 @@
 import type { eventWithTime } from '@rrweb/types';
+import type { ZlibOptions } from 'fflate';
 
-export type PackFn = (event: eventWithTime) => string;
+export type PackFn = (event: eventWithTime, options?: ZlibOptions) => string;
 export type UnpackFn = (raw: string) => eventWithTime;
 
 export type eventWithTimeAndPacker = eventWithTime & {

--- a/packages/rrweb/src/packer/pack.ts
+++ b/packages/rrweb/src/packer/pack.ts
@@ -1,10 +1,10 @@
-import { strFromU8, strToU8, zlibSync } from 'fflate';
+import { ZlibOptions, strFromU8, strToU8, zlibSync } from 'fflate';
 import { PackFn, MARK, eventWithTimeAndPacker } from './base';
 
-export const pack: PackFn = (event) => {
+export const pack: PackFn = (event, options?: ZlibOptions) => {
   const _e: eventWithTimeAndPacker = {
     ...event,
     v: MARK,
   };
-  return strFromU8(zlibSync(strToU8(JSON.stringify(_e))), true);
+  return strFromU8(zlibSync(strToU8(JSON.stringify(_e)), options), true);
 };

--- a/packages/rrweb/test/packer.test.ts
+++ b/packages/rrweb/test/packer.test.ts
@@ -16,16 +16,14 @@ describe('pack', () => {
   it('can pack with default options', () => {
     const packedData = pack(event);
     const unpackedData = unpack(packedData);
-    expect(unpackedData)
-      .toEqual(expect.objectContaining(event));
+    expect(unpackedData).toEqual(expect.objectContaining(event));
   });
   it('can pack with different compression levels', () => {
     for (let i = 0; i <= 9; i++) {
       const packedData = pack(event, { level: i as any });
       const unpackedData = unpack(packedData);
-      expect(unpackedData)
-        .toEqual(expect.objectContaining(event));
-      }
+      expect(unpackedData).toEqual(expect.objectContaining(event));
+    }
   });
 });
 

--- a/packages/rrweb/test/packer.test.ts
+++ b/packages/rrweb/test/packer.test.ts
@@ -13,6 +13,20 @@ describe('pack', () => {
     const packedData = pack(event);
     expect(packedData).toMatchSnapshot();
   });
+  it('can pack with default options', () => {
+    const packedData = pack(event);
+    const unpackedData = unpack(packedData);
+    expect(unpackedData)
+      .toEqual(expect.objectContaining(event));
+  });
+  it('can pack with different compression levels', () => {
+    for (let i = 0; i <= 9; i++) {
+      const packedData = pack(event, { level: i as any });
+      const unpackedData = unpack(packedData);
+      expect(unpackedData)
+        .toEqual(expect.objectContaining(event));
+      }
+  });
 });
 
 describe('unpack', () => {


### PR DESCRIPTION
Implementation for https://github.com/rrweb-io/rrweb/issues/1335
Here I extend `PackFn` with an optional parameter to be able to control of compression level.