### PR TITLE
ref: Avoid cloning events to add `timestamp`

### DIFF
--- a/.changeset/fast-colts-itch.md
+++ b/.changeset/fast-colts-itch.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+ref: Avoid cloning events to add `timestamp`

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -41,10 +41,9 @@ import {
 } from './error-handler';
 
 function wrapEvent(e: event): eventWithTime {
-  return {
-    ...e,
-    timestamp: nowTimestamp(),
-  };
+  const eWithTime = e as eventWithTime;
+  eWithTime.timestamp = nowTimestamp();
+  return eWithTime;
 }
 
 let wrappedEmit!: (e: eventWithTime, isCheckout?: boolean) => void;


### PR DESCRIPTION
We are always passing in fresh objects to this method, so instead of cloning this into a new object, we can just put the `timestamp` on the given object directly and return it, saving a bit of processing cost.