### PR TITLE
perf(rrweb): attribute mutation optimization

### DIFF
--- a/.changeset/moody-dots-refuse.md
+++ b/.changeset/moody-dots-refuse.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+use WeakMap for faster attributeCursor lookup while processing attribute mutations

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -142,6 +142,7 @@ export default class MutationBuffer {
 
   private texts: textCursor[] = [];
   private attributes: attributeCursor[] = [];
+  private attributeMap = new WeakMap<Node, attributeCursor>();
   private removes: removedNodeMutation[] = [];
   private mapRemoves: Node[] = [];
 
@@ -485,6 +486,7 @@ export default class MutationBuffer {
     // reset
     this.texts = [];
     this.attributes = [];
+    this.attributeMap = new WeakMap<Node, attributeCursor>();
     this.removes = [];
     this.addedSet = new Set<Node>();
     this.movedSet = new Set<Node>();
@@ -554,9 +556,7 @@ export default class MutationBuffer {
           return;
         }
 
-        let item: attributeCursor | undefined = this.attributes.find(
-          (a) => a.node === m.target,
-        );
+        let item = this.attributeMap.get(m.target);
         if (
           target.tagName === 'IFRAME' &&
           attributeName === 'src' &&
@@ -578,6 +578,7 @@ export default class MutationBuffer {
             _unchangedStyles: {},
           };
           this.attributes.push(item);
+          this.attributeMap.set(m.target, item);
         }
 
         // Keep this property on inputs that used to be password inputs

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -42,6 +42,12 @@ const suites: Array<
     eval: 'window.workload()',
     times: 5,
   },
+  {
+    title: 'modify attributes on 10000 DOM nodes',
+    html: 'benchmark-dom-mutation-attributes.html',
+    eval: 'window.workload()',
+    times: 10,
+  },
 ];
 
 function avg(v: number[]): number {

--- a/packages/rrweb/test/html/benchmark-dom-mutation-attributes.html
+++ b/packages/rrweb/test/html/benchmark-dom-mutation-attributes.html
@@ -1,0 +1,21 @@
+<html>
+  <body></body>
+  <script>
+    function init() {
+      const count = 10000;
+      for (let i = 0; i < count; ++i) {
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+      }
+    }
+
+    init();
+
+    window.workload = () => {
+      const divs = document.getElementsByTagName('div');
+      for (let div of divs) {
+        div.classList.add('foo');
+      }
+    };
+  </script>
+</html>


### PR DESCRIPTION
Large lists of attribute modifications can bog down on the `attributes.find` in `processMutation`. Added a benchmark to demonstrate.

Before:
![image](https://github.com/rrweb-io/rrweb/assets/541814/6243da2e-a988-449e-8e01-cb38bb556ac2)


After:
![image](https://github.com/rrweb-io/rrweb/assets/541814/54ad0367-ef33-4505-ac9f-70f3f2287b55)
