### PR TITLE
fix: scrolling can be incorrect when fast-forwarding

### DIFF
--- a/.changeset/spotty-bees-destroy.md
+++ b/.changeset/spotty-bees-destroy.md
@@ -1,0 +1,5 @@
+---
+'rrdom': patch
+---
+
+fix: scrolling may not be applied when fast-forwarding

--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -118,7 +118,7 @@ export function diff(
 
   diffChildren(oldTree, newTree, replayer, rrnodeMirror);
 
-  diffAfterUpdatingChildren(oldTree, newTree, replayer, rrnodeMirror);
+  diffAfterUpdatingChildren(oldTree, newTree, replayer);
 }
 
 /**
@@ -195,8 +195,8 @@ function diffBeforeUpdatingChildren(
         );
       }
       /**
-       * Edge case where `applyScroll` may fail in `diffAfterUpdatingChildren`:
-       * the height of a node when `applyScroll` is called may be incorrect if
+       * Attributes and styles of the old element need to be updated before updating its children because of an edge case:
+       * `applyScroll` may fail in `diffAfterUpdatingChildren` when the height of a node when `applyScroll` is called may be incorrect if
        * 1. its parent node contains styles that affects the targeted node's height
        * 2. the CSS selector is targeting an attribute of the parent node
        * by running `diffProps` on the parent node before `diffChildren` is called,
@@ -216,7 +216,6 @@ function diffAfterUpdatingChildren(
   oldTree: Node,
   newTree: IRRNode,
   replayer: ReplayerHandler,
-  rrnodeMirror: Mirror,
 ) {
   switch (newTree.RRNodeType) {
     case RRNodeType.Document: {
@@ -227,7 +226,6 @@ function diffAfterUpdatingChildren(
     case RRNodeType.Element: {
       const oldElement = oldTree as HTMLElement;
       const newRRElement = newTree as RRElement;
-      diffProps(oldElement, newRRElement, rrnodeMirror);
       newRRElement.scrollData &&
         replayer.applyScroll(newRRElement.scrollData, true);
       /**

--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -194,6 +194,15 @@ function diffBeforeUpdatingChildren(
           rrnodeMirror,
         );
       }
+      /**
+       * Edge case where `applyScroll` may fail in `diffAfterUpdatingChildren`:
+       * the height of a node when `applyScroll` is called may be incorrect if
+       * 1. its parent node contains styles that affects the targeted node's height
+       * 2. the CSS selector is targeting an attribute of the parent node
+       * by running `diffProps` on the parent node before `diffChildren` is called,
+       * we can ensure that the correct attributes (and therefore styles) have applied to parent nodes
+       */
+      diffProps(oldElement, newRRElement, rrnodeMirror);
       break;
     }
   }

--- a/packages/rrweb/test/events/scroll-with-parent-styles.ts
+++ b/packages/rrweb/test/events/scroll-with-parent-styles.ts
@@ -1,0 +1,326 @@
+import { EventType, IncrementalSource } from '@rrweb/types';
+import type { eventWithTime } from '@rrweb/types';
+
+const now = Date.now();
+const events: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1200,
+      height: 500,
+    },
+    timestamp: now + 100,
+  },
+  // full snapshot:
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          {
+            type: 1,
+            name: 'html',
+            publicId: '',
+            systemId: '',
+            id: 2,
+          },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: {
+              lang: 'en',
+            },
+            childNodes: [
+              {
+                id: 4,
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 5,
+                    type: 2,
+                    tagName: 'style',
+                    attributes: {
+                      type: 'text/css',
+                    },
+                    childNodes: [
+                      {
+                        id: 6,
+                        type: 3,
+                        textContent:
+                          'main[data-v-7231068e] { position: fixed; top: 0px; right: 0px; height: calc(100% - 0px); overflow: auto; left: 0px; }.container[data-v-7231068e] { overflow: auto; overscroll-behavior-y: contain; position: relative; height: 100%; }.container .card[data-v-7231068e] { min-height: 170px; height: 100%; }',
+                        isStyle: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 7,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: {},
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'ul',
+                        attributes: {},
+                        childNodes: [
+                          {
+                            type: 2,
+                            tagName: 'li',
+                            attributes: {},
+                            childNodes: [
+                              {
+                                type: 2,
+                                tagName: 'a',
+                                attributes: {
+                                  href: 'https://localhost/page1',
+                                },
+                                childNodes: [
+                                  {
+                                    type: 3,
+                                    textContent: '\nGo to page 1\n',
+                                    id: 12,
+                                  },
+                                ],
+                                id: 11,
+                              },
+                            ],
+                            id: 10,
+                          },
+                          {
+                            type: 2,
+                            tagName: 'li',
+                            attributes: {},
+                            childNodes: [
+                              {
+                                type: 2,
+                                tagName: 'a',
+                                attributes: {
+                                  href: 'https://localhost/page2',
+                                },
+                                childNodes: [
+                                  {
+                                    type: 3,
+                                    textContent: '\nGo to page 2\n',
+                                    id: 15,
+                                  },
+                                ],
+                                id: 14,
+                              },
+                            ],
+                            id: 13,
+                          },
+                        ],
+                        id: 9,
+                      },
+                    ],
+                    id: 8,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: {
+        left: 0,
+        top: 0,
+      },
+    },
+    timestamp: now + 100,
+  },
+  // mutation that adds all of the new parent/child elements
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [],
+      adds: [
+        {
+          parentId: 8,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'main',
+            attributes: {
+              'data-v-7231068e': '',
+            },
+            childNodes: [],
+            id: 16,
+          },
+        },
+        {
+          parentId: 16,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'div',
+            attributes: {
+              'data-v-7231068e': '',
+              class: 'container',
+            },
+            childNodes: [],
+            id: 17,
+          },
+        },
+        {
+          parentId: 17,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'div',
+            attributes: {
+              'data-v-7231068e': '',
+              class: 'card',
+            },
+            childNodes: [],
+            id: 18,
+          },
+        },
+        {
+          parentId: 18,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'button',
+            attributes: {
+              'data-v-7231068e': '',
+            },
+            childNodes: [],
+            id: 19,
+          },
+        },
+        {
+          parentId: 19,
+          nextId: null,
+          node: {
+            type: 3,
+            textContent: '1',
+            id: 20,
+          },
+        },
+        {
+          parentId: 17,
+          nextId: 18,
+          node: {
+            type: 2,
+            tagName: 'div',
+            attributes: {
+              'data-v-7231068e': '',
+              class: 'card',
+            },
+            childNodes: [],
+            id: 21,
+          },
+        },
+        {
+          parentId: 21,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'button',
+            attributes: {
+              'data-v-7231068e': '',
+            },
+            childNodes: [],
+            id: 22,
+          },
+        },
+        {
+          parentId: 22,
+          nextId: null,
+          node: {
+            type: 3,
+            textContent: '2',
+            id: 23,
+          },
+        },
+        {
+          parentId: 17,
+          nextId: 21,
+          node: {
+            type: 2,
+            tagName: 'div',
+            attributes: {
+              'data-v-7231068e': '',
+              class: 'card',
+            },
+            childNodes: [],
+            id: 24,
+          },
+        },
+        {
+          parentId: 24,
+          nextId: null,
+          node: {
+            type: 2,
+            tagName: 'button',
+            attributes: {
+              'data-v-7231068e': '',
+            },
+            childNodes: [],
+            id: 25,
+          },
+        },
+        {
+          parentId: 25,
+          nextId: null,
+          node: {
+            type: 3,
+            textContent: '3',
+            id: 26,
+          },
+        },
+      ],
+    },
+    timestamp: now + 500,
+  },
+  // scroll event on the '.container' div
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Scroll,
+      id: 17,
+      x: 0,
+      y: 800,
+    },
+    timestamp: now + 1000,
+  },
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [{ parentId: 16, id: 17 }],
+      adds: [],
+    },
+    timestamp: now + 2000,
+  },
+];
+
+export default events;


### PR DESCRIPTION
👋 hello! i'm seeing an issue where the scrolling position of the dom can end up being incorrect after skipping when using the virtual dom. here is an example replay to visualize the issue:

https://rrwebdebug.com/play/index.html?url=https%3A%2F%2Fgist.githubusercontent.com%2Fjuliecheng%2F6f264bae8fa3bcfc56b3011d4bf3b737%2Fraw%2F84f6ddc329abb88b6b8d26a76306b4f10a33028a%2Fbroken-scrolling.json&version=2.0.0-alpha.8&virtual-dom=on&play=on

if you let it play regularly, you'll see that about 2 seconds in I scroll down so the number 7 + "click" button is now visible for the remainder of the replay. if you skip all the way back to the beginning of the replay + pause immediately (so that you still see "Test Page"), then skip to some spot in the middle of the replay, the scrolling position is incorrect (it didn't scroll) compared to the regular playback.

if the node we're trying to call `applyScroll` on has its height affected by the styles of its parent node, and the parent node is missing attributes that prevent the CSS selector rules from matching at the time `applyScroll` is called, we run into an issue w/ scrolling. the node's `clientHeight` can equal `scrollHeight` w/o the parent styles which means `scrollTo` won't actually do anything. here is an example css:
```
parent[data-v-12345] { <--- isn't applied yet because it's missing the data attribute at the time applyScroll is called
  position: fixed;
  height: calc(100% - 0px);
}

targetElement[data-v-12345] {
  overflow: auto;
  height: 100%;
}
```

not sure if there is a more elegant solution in mind for this but my thought process was to run `diffProps` inside `diffBeforeUpdatingChildren` so that newly created nodes that are missing attributes will now have them added (and therefore styles applied). then when `diffChildren` runs and `applyScroll` is called on one of its child nodes all of the styling and height calculations should be correct