### PR TITLE
use native setTimeout when zone.js is present

### DIFF
--- a/.changeset/fair-seahorses-care.md
+++ b/.changeset/fair-seahorses-care.md
@@ -1,0 +1,6 @@
+---
+'rrweb': patch
+---
+
+Use native setTimeout when zone.js is present
+Use native add/removeEventListener when zone.js is present

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -25,6 +25,7 @@ import {
   getInputType,
   toLowerCase,
   extractFileExtension,
+  nativeSetTimeout,
 } from './utils';
 
 let _id = 1;
@@ -363,7 +364,7 @@ function onceIframeLoaded(
     return;
   }
   if (readyState !== 'complete') {
-    const timer = setTimeout(() => {
+    const timer = nativeSetTimeout(() => {
       if (!fired) {
         listener();
         fired = true;
@@ -385,7 +386,7 @@ function onceIframeLoaded(
   ) {
     // iframe was already loaded, make sure we wait to trigger the listener
     // till _after_ the mutation that found this iframe has had time to process
-    setTimeout(listener, 0);
+    nativeSetTimeout(listener, 0);
 
     return iframeEl.addEventListener('load', listener); // keep listing for future loads
   }
@@ -413,7 +414,7 @@ function onceStylesheetLoaded(
 
   if (styleSheetLoaded) return;
 
-  const timer = setTimeout(() => {
+  const timer = nativeSetTimeout(() => {
     if (!fired) {
       listener();
       fired = true;

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -184,3 +184,5 @@ export type KeepIframeSrcFn = (src: string) => boolean;
 export type BuildCache = {
   stylesWithHoverClass: Map<string, string>;
 };
+
+export type IWindow = Window & typeof globalThis;

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -56,7 +56,9 @@ export function getNative<T>(
 
 export const nativeSetTimeout =
   typeof window !== 'undefined'
-    ? getNative<typeof window.setTimeout>('setTimeout')
+    ? (getNative<typeof window.setTimeout>('setTimeout').bind(
+        window,
+      ) as typeof window.setTimeout)
     : global.setTimeout;
 
 /**

--- a/packages/rrweb/src/record/observers/canvas/2d.ts
+++ b/packages/rrweb/src/record/observers/canvas/2d.ts
@@ -1,4 +1,5 @@
 import type { Mirror } from 'rrweb-snapshot';
+import { nativeSetTimeout } from 'rrweb-snapshot';
 import {
   blockClass,
   CanvasContext,
@@ -44,7 +45,7 @@ export default function initCanvas2DMutationObserver(
             if (!isBlocked(this.canvas, blockClass, blockSelector, true)) {
               // Using setTimeout as toDataURL can be heavy
               // and we'd rather not block the main thread
-              setTimeout(() => {
+              nativeSetTimeout(() => {
                 const recordArgs = serializeArgs(args, win, this);
                 cb(this.canvas, {
                   type: CanvasContext['2D'],

--- a/packages/rrweb/src/record/processed-node-manager.ts
+++ b/packages/rrweb/src/record/processed-node-manager.ts
@@ -1,4 +1,5 @@
 import type MutationBuffer from './mutation';
+import { getNative } from 'rrweb-snapshot';
 
 /**
  * Keeps a log of nodes that could show up in multiple mutation buffer but shouldn't be handled twice.
@@ -7,13 +8,17 @@ export default class ProcessedNodeManager {
   private nodeMap: WeakMap<Node, Set<MutationBuffer>> = new WeakMap();
   // Whether to continue RAF loop.
   private loop = true;
+  private nativeRAF;
 
   constructor() {
+    this.nativeRAF = getNative<typeof requestAnimationFrame>(
+      'requestAnimationFrame',
+    ).bind(window);
     this.periodicallyClear();
   }
 
   private periodicallyClear() {
-    requestAnimationFrame(() => {
+    this.nativeRAF(() => {
       this.clear();
       if (this.loop) this.periodicallyClear();
     });

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -11,7 +11,7 @@ import {
 } from './observer';
 import { patch, inDom } from '../utils';
 import type { Mirror } from 'rrweb-snapshot';
-import { isNativeShadowDom } from 'rrweb-snapshot';
+import { isNativeShadowDom, nativeSetTimeout } from 'rrweb-snapshot';
 
 type BypassOptions = Omit<
   MutationBufferParam,
@@ -74,7 +74,7 @@ export class ShadowDomManager {
       }),
     );
     // Defer this to avoid adoptedStyleSheet events being created before the full snapshot is created or attachShadow action is recorded.
-    setTimeout(() => {
+    nativeSetTimeout(() => {
       if (
         shadowRoot.adoptedStyleSheets &&
         shadowRoot.adoptedStyleSheets.length > 0

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ import type {
   Mirror,
   INode,
   DataURLOptions,
+  IWindow,
 } from 'rrweb-snapshot';
 
 export enum EventType {
@@ -688,8 +689,6 @@ declare global {
   }
 }
 
-export type IWindow = Window & typeof globalThis;
-
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
 export type GetTypedKeys<Obj extends object, ValueType> = TakeTypeHelper<
@@ -704,3 +703,5 @@ export type TakeTypedKeyValues<Obj extends object, Type> = Pick<
   Obj,
   TakeTypeHelper<Obj, Type>[keyof TakeTypeHelper<Obj, Type>]
 >;
+
+export { IWindow };


### PR DESCRIPTION
This is similar to what is already done with zone.js and MutationObserver. I ran into an issue on a customer's application where the setTimeout in hookSetter was triggering angular's change detection, which caused a mutation, which led to another setTimeout, and just continued on like that forever, effectively locking up the browser at 100% CPU.