### PR TITLE
optimize isParentRemoved for large remove lists

### DIFF
--- a/.changeset/late-keys-whisper.md
+++ b/.changeset/late-keys-whisper.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Optimize isParentRemoved for large remove lists


### PR DESCRIPTION
Encountered a mutation that removes ~1400 nodes. Noticed a lot of the processing time was tied up in `isParentRemoved`, which repeatedly does an iterative search of the `removes` array. I added a map (nodeId => index in removes array) to speed up this process. See before/after images below:

Before:
<img width="547" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/320e916f-0310-4bed-a8df-12ba6b641544">

After:
<img width="556" alt="image" src="https://github.com/rrweb-io/rrweb/assets/541814/aa13cea1-a655-4ee4-b041-64eecf430ceb">

I didn't see a difference in the existing benchmarks, even though one of them involves removing a lot of nodes. The problem functionality shown in the profiles above involved scrolling through a large table that would dynamically remove/add pages of data as you scroll.
