### PR TITLE
Add "types" field to fix error when using "moduleResolution": "NodeNext"

### DIFF
--- a/.changeset/wise-spiders-jog.md
+++ b/.changeset/wise-spiders-jog.md
@@ -1,0 +1,5 @@
+---
+'@rrweb/types': patch
+---
+
+Fix type error when using `"moduleResolution": "NodeNext"`.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,6 +30,7 @@
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/types.js",
       "require": "./dist/types.umd.cjs"
     }


### PR DESCRIPTION
Hello,

In my project I am attempting to use `"moduleResolution": "NodeNext"` in my `tsconfig.json` file, and importing rrweb types like this:

```typescript
import { type eventWithTime } from '@rrweb/types';
```

But it results in this error:

> Could not find a declaration file for module '@rrweb/types'. '/Users/admin/project/node_modules/@rrweb/types/dist/types.js' implicitly has an 'any' type.
>  There are types at '/Users/admin/project/node_modules/@rrweb/types/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@rrweb/types' library may need to update its package.json or typings.

After searching online and testing a few things, making the change in this PR made the error go away.

Please let me know if you want any other changes. Thanks!
