### PR TITLE
allow passing null to maskTextClass/blockClass

### DIFF
--- a/.changeset/quick-cows-chew.md
+++ b/.changeset/quick-cows-chew.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': patch
+---
+
+allow passing null to maskTextClass/blockClass

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -270,7 +270,7 @@ export function _isBlockedElement(
       if (element.classList.contains(blockClass)) {
         return true;
       }
-    } else {
+    } else if (blockClass) {
       for (let eIndex = element.classList.length; eIndex--; ) {
         const className = element.classList[eIndex];
         if (blockClass.test(className)) {
@@ -294,6 +294,7 @@ export function classMatchesRegex(
   checkAncestors: boolean,
 ): boolean {
   if (!node) return false;
+  if (!regex) return false;
   if (node.nodeType !== node.ELEMENT_NODE) {
     if (!checkAncestors) return false;
     return classMatchesRegex(node.parentNode, regex, checkAncestors);


### PR DESCRIPTION
Allows you to disable maskTextClass and blockClass by passing `null`, which can give a little performance boost for large snapshots/mutations if you only do your masking/blocking with selectors. Regex class matching in particular seems to be a pretty big drag on performance.