### PR TITLE
Make properties x and y optional in mouseInteractionParam

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1161,8 +1161,8 @@ export class Replayer {
                 this.lastMouseDownEvent = null;
               }
               this.mousePos = {
-                x: d.x,
-                y: d.y,
+                x: d.x || 0,
+                y: d.y || 0,
                 id: d.id,
                 debugData: d,
               };
@@ -1171,7 +1171,7 @@ export class Replayer {
                 // don't draw a trail as user has lifted finger and is placing at a new point
                 this.tailPositions.length = 0;
               }
-              this.moveAndHover(d.x, d.y, d.id, isSync, d);
+              this.moveAndHover(d.x || 0, d.y || 0, d.id, isSync, d);
               if (d.type === MouseInteractions.Click) {
                 /*
                  * don't want target.click() here as could trigger an iframe navigation

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -417,8 +417,8 @@ export type CanvasArg =
 type mouseInteractionParam = {
   type: MouseInteractions;
   id: number;
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
   pointerType?: PointerTypes;
 };
 


### PR DESCRIPTION
The event representing a mouse interaction of focus an element does not include the properties `x` and `y`. Thus, they must be defined as optional.

Example of "focus" event without the `x` and `y` properties:

```
{
   "type": 3,
   "data": {
       "source": 2,
       "type": 5,
       "id": 408
    },
   "timestamp": 1702560401489
}
```