### PR TITLE
Fix maskInputFn is ignored during the creation of the full snapshot

### DIFF
--- a/.changeset/beige-olives-roll.md
+++ b/.changeset/beige-olives-roll.md
@@ -3,5 +3,4 @@
 "rrweb": patch
 ---
 
-Fix maskInputFn is ignored during the creation of the full snapshot
-Fix maskInputFn type in `snapshot`
+Fix that the optional `maskInputFn` was being accidentally ignored during the creation of the full snapshot

--- a/.changeset/beige-olives-roll.md
+++ b/.changeset/beige-olives-roll.md
@@ -1,0 +1,7 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Fix maskInputFn is ignored during the creation of the full snapshot
+Fix maskInputFn type in `snapshot`

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1235,7 +1235,7 @@ function snapshot(
     inlineStylesheet?: boolean;
     maskAllInputs?: boolean | MaskInputOptions;
     maskTextFn?: MaskTextFn;
-    maskInputFn?: MaskTextFn;
+    maskInputFn?: MaskInputFn;
     slimDOM?: 'all' | boolean | SlimDOMOptions;
     dataURLOptions?: DataURLOptions;
     inlineImages?: boolean;

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -376,6 +376,7 @@ function record<T = eventWithTime>(
       inlineStylesheet,
       maskAllInputs: maskInputOptions,
       maskTextFn,
+      maskInputFn,
       slimDOM: slimDOMOptions,
       dataURLOptions,
       recordCanvas,


### PR DESCRIPTION
Fix for https://github.com/rrweb-io/rrweb/issues/1385