### PR TITLE
perf(snapshot): avoid recreate element `a` every time

### DIFF
--- a/.changeset/hungry-dodos-taste.md
+++ b/.changeset/hungry-dodos-taste.md
@@ -1,0 +1,10 @@
+---
+'rrweb-snapshot': patch
+---
+
+Avoid recreating the same element every time, instead, we cache and we just update the element.
+
+Before: 779k ops/s
+After: 860k ops/s
+
+Benchmark: https://jsbench.me/ktlqztuf95/1

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -218,7 +218,7 @@ function getHref(doc: Document, customHref?: string) {
   if (!customHref) {
     customHref = '';
   }
-  // note: using `new URL` is slower https://jsbench.me/uqlud17rxo/1
+  // note: using `new URL` is slower. See #1434 or https://jsbench.me/uqlud17rxo/1
   a.setAttribute('href', customHref);
   return a.href;
 }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -195,23 +195,34 @@ function getAbsoluteSrcsetString(doc: Document, attributeValue: string) {
   return output.join(', ');
 }
 
+const cachedDocument = new WeakMap<Document, HTMLAnchorElement>();
+
 export function absoluteToDoc(doc: Document, attributeValue: string): string {
   if (!attributeValue || attributeValue.trim() === '') {
     return attributeValue;
   }
-  const a: HTMLAnchorElement = doc.createElement('a');
-  a.href = attributeValue;
-  return a.href;
+
+  return getHref(doc, attributeValue);
 }
 
 function isSVGElement(el: Element): boolean {
   return Boolean(el.tagName === 'svg' || (el as SVGElement).ownerSVGElement);
 }
 
-function getHref() {
-  // return a href without hash
-  const a = document.createElement('a');
-  a.href = '';
+function getHref(doc: Document, customHref?: string) {
+  let a = cachedDocument.get(doc);
+
+  if (!a) {
+    a = doc.createElement('a');
+    cachedDocument.set(doc, a);
+  }
+
+  if (!customHref) {
+    customHref = '';
+  }
+
+  a.setAttribute('href', customHref);
+
   return a.href;
 }
 
@@ -243,7 +254,7 @@ export function transformAttribute(
   } else if (name === 'srcset') {
     return getAbsoluteSrcsetString(doc, value);
   } else if (name === 'style') {
-    return absoluteToStylesheet(value, getHref());
+    return absoluteToStylesheet(value, getHref(doc));
   } else if (tagName === 'object' && name === 'data') {
     return absoluteToDoc(doc, value);
   }
@@ -505,6 +516,7 @@ function serializeNode(
       });
     case n.TEXT_NODE:
       return serializeTextNode(n as Text, {
+        doc,
         needsMask,
         maskTextFn,
         rootId,
@@ -535,6 +547,7 @@ function getRootId(doc: Document, mirror: Mirror): number | undefined {
 function serializeTextNode(
   n: Text,
   options: {
+    doc: Document;
     needsMask: boolean | undefined;
     maskTextFn: MaskTextFn | undefined;
     rootId: number | undefined;
@@ -566,7 +579,7 @@ function serializeTextNode(
         n,
       );
     }
-    textContent = absoluteToStylesheet(textContent, getHref());
+    textContent = absoluteToStylesheet(textContent, getHref(options.doc));
   }
   if (isScript) {
     textContent = 'SCRIPT_PLACEHOLDER';
@@ -660,7 +673,7 @@ function serializeElementNode(
       (n as HTMLStyleElement).sheet as CSSStyleSheet,
     );
     if (cssText) {
-      attributes._cssText = absoluteToStylesheet(cssText, getHref());
+      attributes._cssText = absoluteToStylesheet(cssText, getHref(doc));
     }
   }
   // form fields

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -218,6 +218,7 @@ function getHref(doc: Document, customHref?: string) {
   if (!customHref) {
     customHref = '';
   }
+  // note: using `new URL` is slower https://jsbench.me/uqlud17rxo/1
   a.setAttribute('href', customHref);
   return a.href;
 }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -211,18 +211,14 @@ function isSVGElement(el: Element): boolean {
 
 function getHref(doc: Document, customHref?: string) {
   let a = cachedDocument.get(doc);
-
   if (!a) {
     a = doc.createElement('a');
     cachedDocument.set(doc, a);
   }
-
   if (!customHref) {
     customHref = '';
   }
-
   a.setAttribute('href', customHref);
-
   return a.href;
 }
 


### PR DESCRIPTION
Avoid recreating the same element every time, instead, we cache and we just update the element.

Before: 779k ops/s
After: 860k ops/s

Benchmark: https://jsbench.me/ktlqztuf95/1

On Chrome:
![image](https://github.com/rrweb-io/rrweb/assets/12551007/911a6055-81ae-461b-bf1c-7ada5e11dbec)

On Firefox:
![image](https://github.com/rrweb-io/rrweb/assets/12551007/5e5eda1e-c573-45cf-9c9b-402bd69e07e0)
