### PR TITLE
Rrvideo receipe update

### DIFF
--- a/docs/recipes/export-to-video.md
+++ b/docs/recipes/export-to-video.md
@@ -4,4 +4,4 @@ The event data recorded by rrweb is a performant, easy to compress, text-based f
 
 But if you really need to convert it into a video format, there are some tools that can do this work.
 
-Use [rrvideo](https://github.com/rrweb-io/rrvideo).
+Use [rrvideo](https://github.com/rrweb-io/rrweb/blob/master/packages/rrvideo/README.md).

--- a/docs/recipes/export-to-video.zh_CN.md
+++ b/docs/recipes/export-to-video.zh_CN.md
@@ -2,4 +2,4 @@
 
 rrweb 录制的数据是一种高效、易于压缩的文本格式，可以用于像素级的回放。但如果有进一步将录制数据转换为视频的需求，同样可以通过一些工具实现。
 
-使用 [rrvideo](https://github.com/rrweb-io/rrvideo)。
+使用 [rrvideo](https://github.com/rrweb-io/rrweb/blob/master/packages/rrvideo/README.zh_CN.md)。


### PR DESCRIPTION
The file was pointing to the old Rrvideo repo
The old repository soon is going to be closed as the Rrvideo was merged on Rrweb
This change is pointing this recipe to the new and updated official doc.

Updated English and Chinese.

The old doc was pointing here:
![image](https://github.com/rrweb-io/rrweb/assets/34777258/afb4bdf1-a4aa-4f33-9f3a-5af9cec681de)
