### PR TITLE
fix: grid template is parsed incorrectly by chrome

### DIFF
--- a/.changeset/stale-llamas-divide.md
+++ b/.changeset/stale-llamas-divide.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': patch
+---
+
+adds a correction for when chrome passes an incorrect grid-template-area cssText during snapshot

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -1,16 +1,16 @@
 import {
+  documentNode,
+  documentTypeNode,
+  elementNode,
   idNodeMap,
+  IMirror,
   MaskInputFn,
   MaskInputOptions,
   nodeMetaMap,
-  IMirror,
-  serializedNodeWithId,
-  serializedNode,
   NodeType,
-  documentNode,
-  documentTypeNode,
+  serializedNode,
+  serializedNodeWithId,
   textNode,
-  elementNode,
 } from './types';
 
 export function isElement(n: Node): n is Element {
@@ -106,8 +106,48 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
   }
 }
 
+function replaceChromeGridTemplateAreas(rule: CSSStyleRule): string {
+  const hasGridTemplateInCSSText = rule.cssText.includes('grid-template:');
+  const hasGridTemplateAreaInStyleRules =
+    rule.style.getPropertyValue('grid-template-areas') !== '';
+  const hasGridTemplateAreaInCSSText = rule.cssText.includes(
+    'grid-template-areas:',
+  );
+  if (
+    isCSSStyleRule(rule) &&
+    hasGridTemplateInCSSText &&
+    hasGridTemplateAreaInStyleRules &&
+    !hasGridTemplateAreaInCSSText
+  ) {
+    // chrome does not correctly provide the grid template areas in the rules cssText
+    // e.g. https://bugs.chromium.org/p/chromium/issues/detail?id=1303968
+    // we remove the grid-template rule from the text... so everything from grid-template: to the next semicolon
+    // and then add each grid-template-x rule into the css text because Chrome isn't doing this correctly
+    const parts = rule.cssText
+      .split(';')
+      .filter((s) => !s.includes('grid-template:'))
+      .map((s) => s.trim());
+
+    const gridStyles: string[] = [];
+
+    for (let i = 0; i < rule.style.length; i++) {
+      const styleName = rule.style[i];
+      if (styleName.startsWith('grid-template')) {
+        gridStyles.push(
+          `${styleName}: ${rule.style.getPropertyValue(styleName)}`,
+        );
+      }
+    }
+    parts.splice(parts.length - 1, 0, gridStyles.join('; '));
+    return parts.join('; ');
+  }
+  return rule.cssText;
+}
+
 export function stringifyRule(rule: CSSRule): string {
   let importStringified;
+  let gridTemplateFixed;
+
   if (isCSSImportRule(rule)) {
     try {
       importStringified =
@@ -125,7 +165,11 @@ export function stringifyRule(rule: CSSRule): string {
     return fixSafariColons(rule.cssText);
   }
 
-  return importStringified || rule.cssText;
+  if (isCSSStyleRule(rule)) {
+    gridTemplateFixed = replaceChromeGridTemplateAreas(rule);
+  }
+
+  return importStringified || gridTemplateFixed || rule.cssText;
 }
 
 export function fixSafariColons(cssStringified: string): string {

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -135,7 +135,7 @@ describe('css parser', () => {
   it('fixes incorrectly parsed grid template rules', () => {
     const cssText =
       '#wrapper { display: grid; grid-template: "header header" max-content / repeat(2, 1fr); margin: 0px auto; }';
-    // to avoid using JSDom we can fake as much of the CSSStyleDeclaration as we ned
+    // to avoid using JSDom we can fake as much of the CSSStyleDeclaration as we need
     const cssStyleDeclaration: Record<string | number, any> = {
       length: 3,
       0: 'grid-template-areas',


### PR DESCRIPTION
fixes: https://github.com/rrweb-io/rrweb/issues/1395

Chrome is not correctly providing `cssText` when the style includes a `grid-template-area` rule. This PR attempts to detect and correct this...

(it's my first PR against the repo, so have opened early to get feedback and guidance :))