### PR TITLE
perf(genadds) traverse children in reverse order

### DIFF
--- a/.changeset/unlucky-flowers-remember.md
+++ b/.changeset/unlucky-flowers-remember.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+traverse childNodes in reverse order to match desired serialization order

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -728,12 +728,15 @@ export default class MutationBuffer {
     // if this node is blocked `serializeNode` will turn it into a placeholder element
     // but we have to remove it's children otherwise they will be added as placeholders too
     if (!isBlocked(n, this.blockClass, this.blockSelector, false)) {
-      n.childNodes.forEach((childN) => this.genAdds(childN));
+      for (let i = n.childNodes.length - 1; i >= 0; --i) {
+        this.genAdds(n.childNodes[i]);
+      }
       if (hasShadowRoot(n)) {
-        n.shadowRoot.childNodes.forEach((childN) => {
+        for (let j = n.shadowRoot.childNodes.length - 1; j >= 0; --j) {
+          let childN = n.shadowRoot.childNodes[j];
           this.processedNodeManager.add(childN, this);
           this.genAdds(childN, n);
-        });
+        }
       }
     }
   };


### PR DESCRIPTION
I noticed when you add a deep/complex tree as part of a mutation, a large portion of the tree ends up being added to the addList. This is because genAdds traverses the children of each node in order, but serialization in pushAdd wants each node to have a serialized parent _and_ nextSibling. Reversing the order of traversal in genAdds makes it more likely to avoid adding nodes to the addList.

I ran the benchmarks before/after and this was a pretty small improvement across the board.