### PR TITLE
Fix for test cases mentioned in #1379

### DIFF
--- a/.changeset/rich-dots-lay.md
+++ b/.changeset/rich-dots-lay.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': patch
+---
+
+Fix css parsing errors

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -431,16 +431,21 @@ export function parse(css: string, options: ParserOptions = {}) {
    */
 
   function selector() {
+    whitespace();
+    while (css[0] == '}') {
+      error('extra closing bracket');
+      css = css.slice(1);
+      whitespace();
+    }
 
-    whitespace(); while(css[0] == '}'){ error('extra closing bracket'); css = css.slice(1); whitespace(); }
-
-		const m = match(/^(("(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^{])+)/);
+    const m = match(/^(("(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^{])+)/);
     if (!m) {
       return;
     }
     /* @fix Remove all comments from selectors
      * http://ostermiller.org/findcomment.html */
-    const cleanedInput = m[0].trim()
+    const cleanedInput = m[0]
+      .trim()
       .replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '')
 
       // Handle strings by replacing commas inside them
@@ -448,47 +453,49 @@ export function parse(css: string, options: ParserOptions = {}) {
         return m.replace(/,/g, '\u200C');
       });
 
-      // Split using a custom function and restore commas in strings
-      return customSplit(cleanedInput).map(s => s.replace(/\u200C/g, ',').trim());
-    }
+    // Split using a custom function and restore commas in strings
+    return customSplit(cleanedInput).map((s) =>
+      s.replace(/\u200C/g, ',').trim(),
+    );
+  }
 
-    /**
-     * Split selector correctly, ensuring not to split on comma if inside ().
-     */
+  /**
+   * Split selector correctly, ensuring not to split on comma if inside ().
+   */
 
-    function customSplit(input: string) {
-      let result = [];
-      let currentSegment = '';
-      let depthParentheses = 0; // Track depth of parentheses
-      let depthBrackets = 0; // Track depth of square brackets
-    
-      for (let char of input) {
-        if (char === '(') {
-          depthParentheses++;
-        } else if (char === ')') {
-          depthParentheses--;
-        } else if (char === '[') {
-          depthBrackets++;
-        } else if (char === ']') {
-          depthBrackets--;
-        }
-    
-        // Split point is a comma that is not inside parentheses or square brackets
-        if (char === ',' && depthParentheses === 0 && depthBrackets === 0) {
-          result.push(currentSegment);
-          currentSegment = '';
-        } else {
-          currentSegment += char;
-        }
+  function customSplit(input: string) {
+    let result = [];
+    let currentSegment = '';
+    let depthParentheses = 0; // Track depth of parentheses
+    let depthBrackets = 0; // Track depth of square brackets
+
+    for (let char of input) {
+      if (char === '(') {
+        depthParentheses++;
+      } else if (char === ')') {
+        depthParentheses--;
+      } else if (char === '[') {
+        depthBrackets++;
+      } else if (char === ']') {
+        depthBrackets--;
       }
-    
-      // Add the last segment
-      if (currentSegment) {
+
+      // Split point is a comma that is not inside parentheses or square brackets
+      if (char === ',' && depthParentheses === 0 && depthBrackets === 0) {
         result.push(currentSegment);
+        currentSegment = '';
+      } else {
+        currentSegment += char;
       }
-    
-      return result;
     }
+
+    // Add the last segment
+    if (currentSegment) {
+      result.push(currentSegment);
+    }
+
+    return result;
+  }
 
   /**
    * Parse declaration.

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -464,12 +464,12 @@ export function parse(css: string, options: ParserOptions = {}) {
    */
 
   function customSplit(input: string) {
-    let result = [];
+    const result = [];
     let currentSegment = '';
     let depthParentheses = 0; // Track depth of parentheses
     let depthBrackets = 0; // Track depth of square brackets
 
-    for (let char of input) {
+    for (const char of input) {
       if (char === '(') {
         depthParentheses++;
       } else if (char === ')') {

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -438,6 +438,7 @@ export function parse(css: string, options: ParserOptions = {}) {
       whitespace();
     }
 
+    // Use match logic from https://github.com/NxtChg/pieces/blob/3eb39c8287a97632e9347a24f333d52d916bc816/js/css_parser/css_parse.js#L46C1-L47C1
     const m = match(/^(("(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^{])+)/);
     if (!m) {
       return;

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -78,6 +78,35 @@ describe('css parser', () => {
     expect(errors[0].filename).toEqual('foo.css');
   });
 
+  it('should parse selector with comma nested inside ()', () => {
+    const result = parse(
+      '[_nghost-ng-c4172599085]:not(.fit-content).aim-select:hover:not(:disabled, [_nghost-ng-c4172599085]:not(.fit-content).aim-select--disabled, [_nghost-ng-c4172599085]:not(.fit-content).aim-select--invalid, [_nghost-ng-c4172599085]:not(.fit-content).aim-select--active) { border-color: rgb(84, 84, 84); }',
+    );
+
+    expect(result.parent).toEqual(null);
+
+    const rules = result.stylesheet!.rules;
+    expect(rules.length).toEqual(1);
+
+    let rule = rules[0] as Rule;
+    expect(rule.parent).toEqual(result);
+    expect(rule.selectors?.length).toEqual(1);
+
+    let decl = rule.declarations![0];
+    expect(decl.parent).toEqual(rule);
+  });
+
+  it('parses { and } in attribute selectors correctly', () => {
+    const result = parse('foo[someAttr~="{someId}"] { color: red; }');
+    const rules = result.stylesheet!.rules;
+  
+    expect(rules.length).toEqual(1);
+  
+    const rule = rules[0] as Rule;
+  
+    expect(rule.selectors![0]).toEqual('foo[someAttr~="{someId}"]');
+  });
+
   it('should set parent property', () => {
     const result = parse(
       'thing { test: value; }\n' +

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -99,11 +99,11 @@ describe('css parser', () => {
   it('parses { and } in attribute selectors correctly', () => {
     const result = parse('foo[someAttr~="{someId}"] { color: red; }');
     const rules = result.stylesheet!.rules;
-  
+
     expect(rules.length).toEqual(1);
-  
+
     const rule = rules[0] as Rule;
-  
+
     expect(rule.selectors![0]).toEqual('foo[someAttr~="{someId}"]');
   });
 


### PR DESCRIPTION
Update of parsing function using selector from [here](https://github.com/NxtChg/pieces/blob/master/js/css_parser/css_parse.js) and update to logic for `,` inside `()` and associated tests to fix #1379 