### PR TITLE
fix: The needsMask check should also be ignored when the childNode array length is equal to 0

### DIFF
--- a/.changeset/lazy-bananas-peel.md
+++ b/.changeset/lazy-bananas-peel.md
@@ -1,0 +1,5 @@
+---
+"rrweb-snapshot": patch
+---
+
+fix: The needsMask check should also be ignored when the childNode array length is equal to 0

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -982,7 +982,9 @@ export function serializeNodeWithId(
 
   if (
     !needsMask &&
-    n.childNodes // we can avoid the check on leaf elements, as masking is applied to child text nodes only
+    n.childNodes?.length > 0
+    // we can avoid the check on leaf elements, as masking is applied to child text nodes only
+    // The needsMask check should also be ignored when the childNode array length is 0
   ) {
     // perf: if needsMask = true, children won't also need to check
     const checkAncestors = needsMask === undefined; // if false, we've already checked ancestors


### PR DESCRIPTION
When checking needsMask, it is not rigorous to determine whether _n.childNode_ exists, but also to determine whether the array length is greater than 0