### PR TITLE
fix: console logger can serialize bigint values

### DIFF
--- a/.changeset/breezy-mice-breathe.md
+++ b/.changeset/breezy-mice-breathe.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+safely capture BigInt values with the console log plugin"

--- a/packages/rrweb/src/plugins/console/record/stringify.ts
+++ b/packages/rrweb/src/plugins/console/record/stringify.ts
@@ -91,7 +91,7 @@ export function stringify(
   const keys: unknown[] = [];
   return JSON.stringify(
     obj,
-    function (key, value: string | object | null | undefined) {
+    function (key, value: string | bigint | object | null | undefined) {
       /**
        * forked from https://github.com/moll/json-stringify-safe/blob/master/stringify.js
        * to deCycle the object
@@ -119,6 +119,9 @@ export function stringify(
       if (value === undefined) return 'undefined';
       if (shouldIgnore(value as object)) {
         return toString(value as object);
+      }
+      if (typeof value === 'bigint') {
+        return value.toString() + 'n';
       }
       if (value instanceof Event) {
         const eventResult: Record<string, unknown> = {};
@@ -158,7 +161,7 @@ export function stringify(
       return true;
     }
 
-    // is function
+    // is function or bigint
     if (typeof _obj === 'function') {
       return true;
     }

--- a/packages/rrweb/test/plugins/console/record.test.ts
+++ b/packages/rrweb/test/plugins/console/record.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { stringify } from '../../../src/plugins/console/record/stringify';
 
 describe('console record plugin', () => {

--- a/packages/rrweb/test/plugins/console/record.test.ts
+++ b/packages/rrweb/test/plugins/console/record.test.ts
@@ -1,0 +1,7 @@
+import { stringify } from '../../../src/plugins/console/record/stringify';
+
+describe('console record plugin', () => {
+  it('can stringify bigint', () => {
+    expect(stringify(BigInt(1))).toEqual('"1n"');
+  });
+});


### PR DESCRIPTION
fixes #1209

console log record plugin already has a replacer function added to JSON.stringify call so we can add a handler for BigInt

when serializing `BigInt("1")`

before "TypeError: Do not know how to serialize a BigInt"

after '"1n"'

