### PR TITLE
Avoid the costly createElement calls during snapshot

### DIFF
--- a/.changeset/avoid-costly-createlement.md
+++ b/.changeset/avoid-costly-createlement.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': patch
+---
+
+Avoid the costly createElement calls during snapshot

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -577,7 +577,10 @@ function serializeTextNode(
         n,
       );
     }
-    textContent = absoluteToStylesheet(textContent, getHrefWithoutHash(options.doc));
+    textContent = absoluteToStylesheet(
+      textContent,
+      getHrefWithoutHash(options.doc),
+    );
   }
   if (isScript) {
     textContent = 'SCRIPT_PLACEHOLDER';
@@ -671,7 +674,10 @@ function serializeElementNode(
       (n as HTMLStyleElement).sheet as CSSStyleSheet,
     );
     if (cssText) {
-      attributes._cssText = absoluteToStylesheet(cssText, getHrefWithoutHash(doc));
+      attributes._cssText = absoluteToStylesheet(
+        cssText,
+        getHrefWithoutHash(doc),
+      );
     }
   }
   // form fields


### PR DESCRIPTION
An alternative PR to #1387

I've also renamed `getHref` to `getHrefWithoutHash` to better reflect what it is doing