### PR TITLE
Single style capture

### DIFF
--- a/.changeset/single-style-capture.md
+++ b/.changeset/single-style-capture.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Edge case: Provide support for mutations on a <style> element which (unusually) has multiple text nodes

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-compat": "^5.0.0",
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-tsdoc": "^0.2.17",
+    "happy-dom": "^14.12.0",
     "markdownlint": "^0.25.1",
     "markdownlint-cli": "^0.31.1",
     "prettier": "2.8.4",

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -46,7 +46,6 @@
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.15.0",
-    "happy-dom": "^14.12.0",
     "puppeteer": "^17.1.3",
     "typescript": "^5.4.5",
     "vite": "^5.3.1",

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -90,8 +90,8 @@ export function applyCssSplits(
   hackCss: boolean,
   cache: BuildCache,
 ): void {
-  let childTextNodes: serializedTextNodeWithId[] = [];
-  for (let scn of n.childNodes) {
+  const childTextNodes: serializedTextNodeWithId[] = [];
+  for (const scn of n.childNodes) {
     if (scn.type === NodeType.Text) {
       childTextNodes.push(scn);
     }

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -96,26 +96,24 @@ export function applyCssSplits(
       childTextNodes.push(scn);
     }
   }
+  const cssTextSplits = cssText.split('/* rr_split */');
+  while (
+    cssTextSplits.length > 1 &&
+    cssTextSplits.length > childTextNodes.length
+  ) {
+    // unexpected: remerge the last two so that we don't discard any css
+    cssTextSplits.splice(-2, 2, cssTextSplits.slice(-2).join(''));
+  }
   for (let i = 0; i < childTextNodes.length; i++) {
-    let remainder = '';
-    const scn = childTextNodes[i];
-    if (i !== childTextNodes.length - 1) {
-      const ix = cssText.indexOf('/* rr_split */');
-      if (ix !== -1) {
-        remainder = cssText.substring(ix + '/* rr_split */'.length);
-        cssText = cssText.substring(0, ix);
-      }
-    } else {
-      // todo: replaceAll after lib.es2021
-      cssText = cssText.replace(/\/\* rr_split \*\//g, '');
+    const childTextNode = childTextNodes[i];
+    const cssTextSection = cssTextSplits[i];
+    if (childTextNode && cssTextSection) {
+      // id will be assigned when these child nodes are
+      // iterated over in buildNodeWithSN
+      childTextNode.textContent = hackCss
+        ? adaptCssForReplay(cssTextSection, cache)
+        : cssTextSection;
     }
-    if (hackCss) {
-      cssText = adaptCssForReplay(cssText, cache);
-    }
-    // id will be assigned when these child nodes are
-    // iterated over in buildNodeWithSN
-    scn.textContent = cssText;
-    cssText = remainder;
   }
 }
 

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -1,6 +1,7 @@
 import { mediaSelectorPlugin, pseudoClassPlugin } from './css';
 import {
   type serializedNodeWithId,
+  type serializedElementNodeWithId,
   NodeType,
   type tagMap,
   type elementNode,
@@ -76,6 +77,70 @@ export function createCache(): BuildCache {
   return {
     stylesWithHoverClass,
   };
+}
+
+/**
+ * Normally a <style> element has a single textNode containing the rules.
+ * During serialization, we bypass this (`styleEl.sheet`) to get the rules the
+ * browser sees and serialize this to a special _cssText attribute, blanking
+ * out any text nodes. This function reverses that and also handles cases where
+ * there were no textNode children present (dynamic css/or a <link> element) as
+ * well as multiple textNodes (`cssTextSplits`), which need to be repopulated
+ * in case they are modified by subsequent mutations.
+ */
+export function buildStyleNode(
+  n: serializedElementNodeWithId,
+  styleEl: HTMLStyleElement, // a <link type="styleshet"> also gets rebuilt as a <style>
+  cssText: string,
+  options: {
+    doc: Document;
+    hackCss: boolean;
+    cache: BuildCache;
+  },
+) {
+  const { doc, hackCss, cache } = options;
+  if (n.childNodes.length) {
+    let cssTextSplits: string[] = [];
+    if (
+      n.attributes._cssTextSplits &&
+      typeof n.attributes._cssTextSplits === 'string'
+    ) {
+      cssTextSplits = n.attributes._cssTextSplits.split(' ');
+    }
+    for (let j = n.childNodes.length - 1; j >= 0; j--) {
+      const scn = n.childNodes[j];
+      let ix = 0;
+      if (cssTextSplits.length > j && j > 0) {
+        ix = parseInt(cssTextSplits[j - 1]);
+      }
+      if (scn.type === NodeType.Text) {
+        let remainder = '';
+        if (ix !== 0) {
+          remainder = cssText.substring(0, ix);
+          cssText = cssText.substring(ix);
+        } else if (j > 1) {
+          continue;
+        }
+        if (hackCss) {
+          cssText = adaptCssForReplay(cssText, cache);
+        }
+        // id will be assigned when these child nodes are
+        // iterated over in buildNodeWithSN
+        scn.textContent = cssText;
+
+        cssText = remainder;
+      }
+    }
+  } else {
+    if (hackCss) {
+      cssText = adaptCssForReplay(cssText, cache);
+    }
+    /**
+       <link> element or dynamic <style> are serialized without any child nodes
+       we create the text node without an ID or presence in mirror as it can't
+    */
+    styleEl.appendChild(doc.createTextNode(cssText));
+  }
 }
 
 function buildNode(
@@ -156,45 +221,13 @@ function buildNode(
           continue;
         }
 
-        const isTextarea = tagName === 'textarea' && name === 'value';
-        const isRemoteOrDynamicCss = tagName === 'style' && name === '_cssText';
-        if ((isTextarea || isRemoteOrDynamicCss) && typeof value === 'string') {
-          if (isRemoteOrDynamicCss && n.childNodes.length) {
-            let cssTextSplits: string[] = [];
-            if (
-              n.attributes._cssTextSplits &&
-              typeof n.attributes._cssTextSplits === 'string'
-            ) {
-              cssTextSplits = n.attributes._cssTextSplits.split(' ');
-            }
-            for (let j = n.childNodes.length - 1; j >= 0; j--) {
-              const scn = n.childNodes[j];
-              let ix = 0;
-              if (cssTextSplits.length > j && j > 0) {
-                ix = parseInt(cssTextSplits[j - 1]);
-              }
-              if (scn.type === NodeType.Text) {
-                let remainder = '';
-                if (ix !== 0) {
-                  remainder = value.substring(0, ix);
-                  value = value.substring(ix);
-                } else if (j > 1) {
-                  continue;
-                }
-                if (hackCss) {
-                  value = adaptCssForReplay(value, cache);
-                }
-                scn.textContent = value;
-                value = remainder;
-              }
-            }
-            continue;
-          } else if (hackCss && isRemoteOrDynamicCss) {
-            // <link> element or dynamic <style>
-            value = adaptCssForReplay(value, cache);
-          }
-          // https://github.com/rrweb-io/rrweb/issues/112
-          // https://github.com/rrweb-io/rrweb/pull/1351
+        if (typeof value !== 'string') {
+          // pass
+        } else if (tagName === 'style' && name === '_cssText') {
+          buildStyleNode(n, node as HTMLStyleElement, value, options);
+          continue; // no need to set _cssText as attribute
+        } else if (tagName === 'textarea' && name === 'value') {
+          // create without an ID or presence in mirror
           node.appendChild(doc.createTextNode(value));
           n.childNodes = []; // value overrides childNodes
           continue;

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -189,6 +189,9 @@ function buildNode(
               }
             }
             continue;
+          } else if (hackCss && isRemoteOrDynamicCss) {
+            // <link> element or dynamic <style>
+            value = adaptCssForReplay(value, cache);
           }
           // https://github.com/rrweb-io/rrweb/issues/112
           // https://github.com/rrweb-io/rrweb/pull/1351

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -160,6 +160,14 @@ function buildNode(
           value = adaptCssForReplay(value, cache);
         }
         if ((isTextarea || isRemoteOrDynamicCss) && typeof value === 'string') {
+          if (
+            isRemoteOrDynamicCss &&
+            n.childNodes.length &&
+            n.childNodes[0].type === NodeType.Text
+          ) {
+            n.childNodes[0].textContent = value;
+            continue;
+          }
           // https://github.com/rrweb-io/rrweb/issues/112
           // https://github.com/rrweb-io/rrweb/pull/1351
           node.appendChild(doc.createTextNode(value));
@@ -317,11 +325,11 @@ function buildNode(
       return node;
     }
     case NodeType.Text:
-      return doc.createTextNode(
-        n.isStyle && hackCss
-          ? adaptCssForReplay(n.textContent, cache)
-          : n.textContent,
-      );
+      if (n.isStyle && hackCss) {
+        // support legacy style
+        return doc.createTextNode(adaptCssForReplay(n.textContent, cache));
+      }
+      return doc.createTextNode(n.textContent);
     case NodeType.CDATA:
       return doc.createCDATASection(n.textContent);
     case NodeType.Comment:

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -152,20 +152,42 @@ function buildNode(
         if (name.startsWith('rr_')) {
           specialAttributes[name] = value;
           continue;
+        } else if (name === '_cssTextSplits') {
+          continue;
         }
 
         const isTextarea = tagName === 'textarea' && name === 'value';
         const isRemoteOrDynamicCss = tagName === 'style' && name === '_cssText';
-        if (isRemoteOrDynamicCss && hackCss && typeof value === 'string') {
-          value = adaptCssForReplay(value, cache);
-        }
         if ((isTextarea || isRemoteOrDynamicCss) && typeof value === 'string') {
-          if (
-            isRemoteOrDynamicCss &&
-            n.childNodes.length &&
-            n.childNodes[0].type === NodeType.Text
-          ) {
-            n.childNodes[0].textContent = value;
+          if (isRemoteOrDynamicCss && n.childNodes.length) {
+            let cssTextSplits: string[] = [];
+            if (
+              n.attributes._cssTextSplits &&
+              typeof n.attributes._cssTextSplits === 'string'
+            ) {
+              cssTextSplits = n.attributes._cssTextSplits.split(' ');
+            }
+            for (let j = n.childNodes.length - 1; j >= 0; j--) {
+              const scn = n.childNodes[j];
+              let ix = 0;
+              if (cssTextSplits.length > j && j > 0) {
+                ix = parseInt(cssTextSplits[j - 1]);
+              }
+              if (scn.type === NodeType.Text) {
+                let remainder = '';
+                if (ix !== 0) {
+                  remainder = value.substring(0, ix);
+                  value = value.substring(ix);
+                } else if (j > 1) {
+                  continue;
+                }
+                if (hackCss) {
+                  value = adaptCssForReplay(value, cache);
+                }
+                scn.textContent = value;
+                value = remainder;
+              }
+            }
             continue;
           }
           // https://github.com/rrweb-io/rrweb/issues/112

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -80,6 +80,49 @@ export function createCache(): BuildCache {
 }
 
 /**
+ * undo findCssTextSplits
+ * (would move to utils.ts but uses `adaptCssForReplay`)
+ */
+export function applyCssSplits(
+  n: serializedElementNodeWithId,
+  cssText: string,
+  cssTextSplits: number[],
+  hackCss: boolean,
+  cache: BuildCache,
+): void {
+  const lenCheckOk =
+    cssTextSplits.length &&
+    cssTextSplits[cssTextSplits.length - 1] === cssText.length;
+  for (let j = n.childNodes.length - 1; j >= 0; j--) {
+    const scn = n.childNodes[j];
+    let ix = 0;
+    if (cssTextSplits.length > j && j > 0) {
+      ix = cssTextSplits[j - 1];
+    }
+    if (scn.type === NodeType.Text) {
+      let remainder = '';
+      if (ix !== 0 && lenCheckOk) {
+        remainder = cssText.substring(0, ix);
+        cssText = cssText.substring(ix);
+      } else if (j > 1) {
+        continue;
+      }
+      if (hackCss) {
+        cssText = adaptCssForReplay(cssText, cache);
+      }
+      // id will be assigned when these child nodes are
+      // iterated over in buildNodeWithSN
+      scn.textContent = cssText;
+      cssText = remainder;
+    }
+  }
+  if (cssText.length) {
+    // something has gone wrong
+    console.warn('Leftover css content after applyCssSplits:', cssText);
+  }
+}
+
+/**
  * Normally a <style> element has a single textNode containing the rules.
  * During serialization, we bypass this (`styleEl.sheet`) to get the rules the
  * browser sees and serialize this to a special _cssText attribute, blanking
@@ -90,7 +133,7 @@ export function createCache(): BuildCache {
  */
 export function buildStyleNode(
   n: serializedElementNodeWithId,
-  styleEl: HTMLStyleElement, // a <link type="styleshet"> also gets rebuilt as a <style>
+  styleEl: HTMLStyleElement, // when inlined, a <link type="stylesheet"> also gets rebuilt as a <style>
   cssText: string,
   options: {
     doc: Document;
@@ -100,40 +143,13 @@ export function buildStyleNode(
 ) {
   const { doc, hackCss, cache } = options;
   if (n.childNodes.length) {
-    let cssTextSplits: string[] = [];
-    if (
-      n.attributes._cssTextSplits &&
-      typeof n.attributes._cssTextSplits === 'string'
-    ) {
-      cssTextSplits = n.attributes._cssTextSplits.split(' ');
+    let cssTextSplits: number[] = [];
+    if (n.attributes._cssTextSplits) {
+      cssTextSplits = n.attributes._cssTextSplits
+        .split(' ')
+        .map((s) => parseInt(s));
     }
-    const lenCheckOk =
-      cssTextSplits.length &&
-      parseInt(cssTextSplits[cssTextSplits.length - 1]) === cssText.length;
-    for (let j = n.childNodes.length - 1; j >= 0; j--) {
-      const scn = n.childNodes[j];
-      let ix = 0;
-      if (cssTextSplits.length >= j && j > 1) {
-        ix = parseInt(cssTextSplits[j - 2]);
-      }
-      if (scn.type === NodeType.Text) {
-        let remainder = '';
-        if (ix !== 0 && lenCheckOk) {
-          remainder = cssText.substring(0, ix);
-          cssText = cssText.substring(ix);
-        } else if (j > 1) {
-          continue;
-        }
-        if (hackCss) {
-          cssText = adaptCssForReplay(cssText, cache);
-        }
-        // id will be assigned when these child nodes are
-        // iterated over in buildNodeWithSN
-        scn.textContent = cssText;
-
-        cssText = remainder;
-      }
-    }
+    applyCssSplits(n, cssText, cssTextSplits, hackCss, cache);
   } else {
     if (hackCss) {
       cssText = adaptCssForReplay(cssText, cache);

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -117,10 +117,6 @@ export function applyCssSplits(
     scn.textContent = cssText;
     cssText = remainder;
   }
-  if (cssText.length) {
-    // something has gone wrong
-    console.warn('Leftover css content after applyCssSplits:', cssText);
-  }
 }
 
 /**

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -107,15 +107,18 @@ export function buildStyleNode(
     ) {
       cssTextSplits = n.attributes._cssTextSplits.split(' ');
     }
+    const lenCheckOk =
+      cssTextSplits.length &&
+      parseInt(cssTextSplits[cssTextSplits.length - 1]) === cssText.length;
     for (let j = n.childNodes.length - 1; j >= 0; j--) {
       const scn = n.childNodes[j];
       let ix = 0;
-      if (cssTextSplits.length > j && j > 0) {
-        ix = parseInt(cssTextSplits[j - 1]);
+      if (cssTextSplits.length >= j && j > 1) {
+        ix = parseInt(cssTextSplits[j - 2]);
       }
       if (scn.type === NodeType.Text) {
         let remainder = '';
-        if (ix !== 0) {
+        if (ix !== 0 && lenCheckOk) {
           remainder = cssText.substring(0, ix);
           cssText = cssText.substring(ix);
         } else if (j > 1) {

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -104,7 +104,7 @@ export function applyCssSplits(
       if (ix !== 0 && lenCheckOk) {
         remainder = cssText.substring(0, ix);
         cssText = cssText.substring(ix);
-      } else if (j > 1) {
+      } else if (j > 0) {
         continue;
       }
       if (hackCss) {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -27,7 +27,7 @@ import {
   toLowerCase,
   extractFileExtension,
   absolutifyURLs,
-  findCssTextSplits,
+  markCssSplits,
 } from './utils';
 import dom from '@rrweb/utils';
 
@@ -603,18 +603,14 @@ function serializeElementNode(
     }
   }
   if (tagName === 'style' && (n as HTMLStyleElement).sheet) {
-    const cssText = stringifyStylesheet(
+    let cssText = stringifyStylesheet(
       (n as HTMLStyleElement).sheet as CSSStyleSheet,
     );
     if (cssText) {
-      attributes._cssText = cssText;
       if (n.childNodes.length > 1) {
-        const splits = findCssTextSplits(
-          attributes._cssText,
-          n as HTMLStyleElement,
-        );
-        attributes._cssTextSplits = splits.join(' ');
+        cssText = markCssSplits(cssText, n as HTMLStyleElement);
       }
+      attributes._cssText = cssText;
     }
   }
   // form fields

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -404,7 +404,7 @@ function serializeNode(
      * `newlyAddedElement: true` skips scrollTop and scrollLeft check
      */
     newlyAddedElement?: boolean;
-    blankTextNodes?: boolean;
+    cssCaptured?: boolean;
   },
 ): serializedNode | false {
   const {
@@ -422,7 +422,7 @@ function serializeNode(
     recordCanvas,
     keepIframeSrcFn,
     newlyAddedElement = false,
-    blankTextNodes = false,
+    cssCaptured = false,
   } = options;
   // Only record root id when document object is not the base document
   const rootId = getRootId(doc, mirror);
@@ -469,7 +469,7 @@ function serializeNode(
         needsMask,
         maskTextFn,
         rootId,
-        blankTextNodes,
+        cssCaptured,
       });
     case n.CDATA_SECTION_NODE:
       return {
@@ -501,10 +501,10 @@ function serializeTextNode(
     needsMask: boolean;
     maskTextFn: MaskTextFn | undefined;
     rootId: number | undefined;
-    blankTextNodes?: boolean;
+    cssCaptured?: boolean;
   },
 ): serializedNode {
-  const { needsMask, maskTextFn, rootId, blankTextNodes } = options;
+  const { needsMask, maskTextFn, rootId, cssCaptured } = options;
   // The parent node may not be a html element which has a tagName attribute.
   // So just let it be undefined which is ok in this use case.
   const parent = dom.parentNode(n);
@@ -514,7 +514,7 @@ function serializeTextNode(
   const isScript = parentTagName === 'SCRIPT' ? true : undefined;
   if (isScript) {
     textContent = 'SCRIPT_PLACEHOLDER';
-  } else if (!blankTextNodes) {
+  } else if (!cssCaptured) {
     textContent = dom.textContent(n);
     if (isStyle && textContent) {
       // mutation only: we don't need to use stringifyStylesheet
@@ -928,7 +928,7 @@ export function serializeNodeWithId(
       node: serializedElementNodeWithId,
     ) => unknown;
     stylesheetLoadTimeout?: number;
-    blankTextNodes?: boolean;
+    cssCaptured?: boolean;
   },
 ): serializedNodeWithId | null {
   const {
@@ -954,7 +954,7 @@ export function serializeNodeWithId(
     stylesheetLoadTimeout = 5000,
     keepIframeSrcFn = () => false,
     newlyAddedElement = false,
-    blankTextNodes = false,
+    cssCaptured = false,
   } = options;
   let { needsMask } = options;
   let { preserveWhiteSpace = true } = options;
@@ -985,7 +985,7 @@ export function serializeNodeWithId(
     recordCanvas,
     keepIframeSrcFn,
     newlyAddedElement,
-    blankTextNodes,
+    cssCaptured,
   });
   if (!_serializedNode) {
     // TODO: dev only
@@ -1065,7 +1065,7 @@ export function serializeNodeWithId(
       onStylesheetLoad,
       stylesheetLoadTimeout,
       keepIframeSrcFn,
-      blankTextNodes: false,
+      cssCaptured: false,
     };
 
     if (
@@ -1080,7 +1080,7 @@ export function serializeNodeWithId(
         (serializedNode as elementNode).attributes._cssText !== undefined &&
         typeof serializedNode.attributes._cssText === 'string'
       ) {
-        bypassOptions.blankTextNodes = true;
+        bypassOptions.cssCaptured = true;
       }
       for (const childN of Array.from(dom.childNodes(n))) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -27,6 +27,7 @@ import {
   toLowerCase,
   extractFileExtension,
   absolutifyURLs,
+  findCssTextSplits,
 } from './utils';
 import dom from '@rrweb/utils';
 
@@ -1089,9 +1090,17 @@ export function serializeNodeWithId(
     } else {
       if (
         serializedNode.type === NodeType.Element &&
-        (serializedNode as elementNode).attributes._cssText !== undefined
+        (serializedNode as elementNode).attributes._cssText !== undefined &&
+        typeof serializedNode.attributes._cssText === 'string'
       ) {
         bypassOptions.blankTextNodes = true;
+        if (n.childNodes.length > 1) {
+          const splits = findCssTextSplits(
+            serializedNode.attributes._cssText,
+            n as HTMLStyleElement,
+          );
+          serializedNode.attributes._cssTextSplits = splits.join(' ');
+        }
       }
       for (const childN of Array.from(dom.childNodes(n))) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -540,7 +540,7 @@ function serializeTextNode(
       textContent = absolutifyURLs(textContent, getHref(options.doc));
     }
   }
-  if (!isScript && !isStyle && textContent && needsMask) {
+  if (!isStyle && !isScript && textContent && needsMask) {
     textContent = maskTextFn
       ? maskTextFn(textContent, dom.parentElement(n))
       : textContent.replace(/[\S]/g, '*');

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -517,26 +517,10 @@ function serializeTextNode(
   } else if (!blankTextNodes) {
     textContent = dom.textContent(n);
     if (isStyle && textContent) {
-      // This branch is solely for the use of mutation
-      if (n.nextSibling || n.previousSibling) {
-        // This is not the only child of the stylesheet.
-        // We can't read all of the sheet's .cssRules and expect them
-        // to _only_ include the current rule(s) added by the text node.
-        // So we'll be conservative and keep textContent as-is.
-      } else if ((parent as HTMLStyleElement).sheet?.cssRules) {
-        try {
-          textContent = stringifyStylesheet(
-            (parent as HTMLStyleElement).sheet!,
-          );
-        } catch (err) {
-          console.warn(
-            `Cannot get CSS styles from text's parentNode. Error: ${
-              err as string
-            }`,
-            n,
-          );
-        }
-      }
+      // mutation only: we don't need to use stringifyStylesheet
+      // as a <style> text node mutation obliterates any previous
+      // programmatic rule manipulation (.insertRule etc.)
+      // so the current textContent represents the most up to date state
       textContent = absolutifyURLs(textContent, getHref(options.doc));
     }
   }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -624,6 +624,13 @@ function serializeElementNode(
     );
     if (cssText) {
       attributes._cssText = cssText;
+      if (n.childNodes.length > 1) {
+        const splits = findCssTextSplits(
+          attributes._cssText,
+          n as HTMLStyleElement,
+        );
+        attributes._cssTextSplits = splits.join(' ');
+      }
     }
   }
   // form fields
@@ -1094,13 +1101,6 @@ export function serializeNodeWithId(
         typeof serializedNode.attributes._cssText === 'string'
       ) {
         bypassOptions.blankTextNodes = true;
-        if (n.childNodes.length > 1) {
-          const splits = findCssTextSplits(
-            serializedNode.attributes._cssText,
-            n as HTMLStyleElement,
-          );
-          serializedNode.attributes._cssTextSplits = splits.join(' ');
-        }
       }
       for (const childN of Array.from(dom.childNodes(n))) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -403,6 +403,7 @@ function serializeNode(
      * `newlyAddedElement: true` skips scrollTop and scrollLeft check
      */
     newlyAddedElement?: boolean;
+    blankTextNodes?: boolean;
   },
 ): serializedNode | false {
   const {
@@ -420,6 +421,7 @@ function serializeNode(
     recordCanvas,
     keepIframeSrcFn,
     newlyAddedElement = false,
+    blankTextNodes = false,
   } = options;
   // Only record root id when document object is not the base document
   const rootId = getRootId(doc, mirror);
@@ -466,6 +468,7 @@ function serializeNode(
         needsMask,
         maskTextFn,
         rootId,
+        blankTextNodes,
       });
     case n.CDATA_SECTION_NODE:
       return {
@@ -497,48 +500,54 @@ function serializeTextNode(
     needsMask: boolean;
     maskTextFn: MaskTextFn | undefined;
     rootId: number | undefined;
+    blankTextNodes?: boolean;
   },
 ): serializedNode {
-  const { needsMask, maskTextFn, rootId } = options;
+  const { needsMask, maskTextFn, rootId, blankTextNodes } = options;
   // The parent node may not be a html element which has a tagName attribute.
   // So just let it be undefined which is ok in this use case.
   const parent = dom.parentNode(n);
   const parentTagName = parent && (parent as HTMLElement).tagName;
-  let text = dom.textContent(n);
+  let textContent: string | null = '';
   const isStyle = parentTagName === 'STYLE' ? true : undefined;
   const isScript = parentTagName === 'SCRIPT' ? true : undefined;
-  if (isStyle && text) {
-    try {
-      // try to read style sheet
+  if (isScript) {
+    textContent = 'SCRIPT_PLACEHOLDER';
+  } else if (!blankTextNodes) {
+    textContent = dom.textContent(n);
+    if (isStyle && textContent) {
+      // This branch is solely for the use of mutation
       if (n.nextSibling || n.previousSibling) {
         // This is not the only child of the stylesheet.
         // We can't read all of the sheet's .cssRules and expect them
         // to _only_ include the current rule(s) added by the text node.
         // So we'll be conservative and keep textContent as-is.
       } else if ((parent as HTMLStyleElement).sheet?.cssRules) {
-        text = stringifyStylesheet((parent as HTMLStyleElement).sheet!);
+        try {
+          textContent = stringifyStylesheet(
+            (parent as HTMLStyleElement).sheet!,
+          );
+        } catch (err) {
+          console.warn(
+            `Cannot get CSS styles from text's parentNode. Error: ${
+              err as string
+            }`,
+            n,
+          );
+        }
       }
-    } catch (err) {
-      console.warn(
-        `Cannot get CSS styles from text's parentNode. Error: ${err as string}`,
-        n,
-      );
+      textContent = absolutifyURLs(textContent, getHref(options.doc));
     }
-    text = absolutifyURLs(text, getHref(options.doc));
   }
-  if (isScript) {
-    text = 'SCRIPT_PLACEHOLDER';
-  }
-  if (!isStyle && !isScript && text && needsMask) {
-    text = maskTextFn
-      ? maskTextFn(text, dom.parentElement(n))
-      : text.replace(/[\S]/g, '*');
+  if (!isScript && !isStyle && textContent && needsMask) {
+    textContent = maskTextFn
+      ? maskTextFn(textContent, dom.parentElement(n))
+      : textContent.replace(/[\S]/g, '*');
   }
 
   return {
     type: NodeType.Text,
-    textContent: text || '',
-    isStyle,
+    textContent: textContent || '',
     rootId,
   };
 }
@@ -608,13 +617,7 @@ function serializeElementNode(
       attributes._cssText = cssText;
     }
   }
-  // dynamic stylesheet
-  if (
-    tagName === 'style' &&
-    (n as HTMLStyleElement).sheet &&
-    // TODO: Currently we only try to get dynamic stylesheet when it is an empty style element
-    !(n.innerText || dom.textContent(n) || '').trim().length
-  ) {
+  if (tagName === 'style' && (n as HTMLStyleElement).sheet) {
     const cssText = stringifyStylesheet(
       (n as HTMLStyleElement).sheet as CSSStyleSheet,
     );
@@ -937,6 +940,7 @@ export function serializeNodeWithId(
       node: serializedElementNodeWithId,
     ) => unknown;
     stylesheetLoadTimeout?: number;
+    blankTextNodes?: boolean;
   },
 ): serializedNodeWithId | null {
   const {
@@ -962,6 +966,7 @@ export function serializeNodeWithId(
     stylesheetLoadTimeout = 5000,
     keepIframeSrcFn = () => false,
     newlyAddedElement = false,
+    blankTextNodes = false,
   } = options;
   let { needsMask } = options;
   let { preserveWhiteSpace = true } = options;
@@ -992,6 +997,7 @@ export function serializeNodeWithId(
     recordCanvas,
     keepIframeSrcFn,
     newlyAddedElement,
+    blankTextNodes,
   });
   if (!_serializedNode) {
     // TODO: dev only
@@ -1007,7 +1013,6 @@ export function serializeNodeWithId(
     slimDOMExcluded(_serializedNode, slimDOMOptions) ||
     (!preserveWhiteSpace &&
       _serializedNode.type === NodeType.Text &&
-      !_serializedNode.isStyle &&
       !_serializedNode.textContent.replace(/^\s+|\s+$/gm, '').length)
   ) {
     id = IGNORED_NODE;
@@ -1072,6 +1077,7 @@ export function serializeNodeWithId(
       onStylesheetLoad,
       stylesheetLoadTimeout,
       keepIframeSrcFn,
+      blankTextNodes: false,
     };
 
     if (
@@ -1081,6 +1087,12 @@ export function serializeNodeWithId(
     ) {
       // value parameter in DOM reflects the correct value, so ignore childNode
     } else {
+      if (
+        serializedNode.type === NodeType.Element &&
+        (serializedNode as elementNode).attributes._cssText !== undefined
+      ) {
+        bypassOptions.blankTextNodes = true;
+      }
       for (const childN of Array.from(dom.childNodes(n))) {
         const serializedChildNode = serializeNodeWithId(childN, bypassOptions);
         if (serializedChildNode) {

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -45,6 +45,10 @@ export type elementNode = {
 export type textNode = {
   type: NodeType.Text;
   textContent: string;
+  /**
+   * @deprecated styles are now always snapshotted against parent <style> element
+   * style mutations can still happen via an added textNode, but they don't need this attribute for correct replay
+   */
   isStyle?: true;
 };
 

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -20,9 +20,19 @@ export type documentTypeNode = {
   systemId: string;
 };
 
-export type attributes = {
-  [key: string]: string | number | true | null;
+type cssTextKeyAttr = {
+  _cssText?: string;
+  _cssTextSplits?: string;
 };
+
+export type attributes = cssTextKeyAttr & {
+  [key: string]:
+    | string
+    | number // properties e.g. rr_scrollLeft or rr_mediaCurrentTime
+    | true // e.g. checked  on <input type="radio">
+    | null; // an indication that an attribute was removed (during a mutation)
+};
+
 export type legacyAttributes = {
   /**
    * @deprecated old bug in rrweb was causing these to always be set

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -22,7 +22,6 @@ export type documentTypeNode = {
 
 type cssTextKeyAttr = {
   _cssText?: string;
-  _cssTextSplits?: string;
 };
 
 export type attributes = cssTextKeyAttr & {
@@ -90,6 +89,11 @@ export type serializedNodeWithId = serializedNode & { id: number };
 export type serializedElementNodeWithId = Extract<
   serializedNodeWithId,
   Record<'type', NodeType.Element>
+>;
+
+export type serializedTextNodeWithId = Extract<
+  serializedNodeWithId,
+  Record<'type', NodeType.Text>
 >;
 
 export type tagMap = {

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -443,10 +443,12 @@ export function absolutifyURLs(cssText: string | null, href: string): string {
   );
 }
 
-function normalizeCssString(cssText: string): string {
-  // remove spaces
-  // TODO: normalize other differences between css as authored vs. stringifyStylesheet
-  return cssText.replace(/[\s]/g, '');
+/**
+ * Intention is to normalize by remove spaces, semicolons and CSS comments
+ * so that we can compare css as authored vs. output of stringifyStylesheet
+ */
+export function normalizeCssString(cssText: string): string {
+  return cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, '');
 }
 
 /**

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -449,16 +449,15 @@ function normalizeCssString(cssText: string): string {
  * performance is not considered as this is anticipated to be very much an edge case
  * (javascript is needed to add extra text nodes to a <style>)
  */
-export function findCssTextSplits(
+export function splitCssText(
   cssText: string,
   style: HTMLStyleElement,
-): number[] {
+): string[] {
   const childNodes = Array.from(style.childNodes);
-  const splits = [];
+  const splits: string[] = [];
   if (childNodes.length > 1 && cssText && typeof cssText === 'string') {
     const cssTextNorm = normalizeCssString(cssText);
     for (let i = 1; i < childNodes.length; i++) {
-      let split = 0; // marker for 'no split found'
       if (
         childNodes[i].textContent &&
         typeof childNodes[i].textContent === 'string'
@@ -474,16 +473,23 @@ export function findCssTextSplits(
               if (
                 normalizeCssString(cssText.substring(0, k)).length === splitNorm
               ) {
-                split = k;
+                splits.push(cssText.substring(0, k));
+                cssText = cssText.substring(k);
               }
             }
             break;
           }
         }
       }
-      splits.push(split);
     }
   }
-  splits.push(cssText.length); // a check in case the cssText is altered in transit
+  splits.push(cssText); // either the full thing if no splits were found, or the last split
   return splits;
+}
+
+export function markCssSplits(
+  cssText: string,
+  style: HTMLStyleElement,
+): string {
+  return splitCssText(cssText, style).join('/* rr_split */');
 }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -429,6 +429,12 @@ export function absolutifyURLs(cssText: string | null, href: string): string {
   );
 }
 
+function normalizeCssString(cssText: string): string {
+  // remove spaces
+  // TODO: normalize other differences between css as authored vs. stringifyStylesheet
+  return cssText.replace(/[\s]/g, '');
+}
+
 /**
  * Maps the output of stringifyStylesheet to individual text nodes of a <style> element
  * performance is not considered as this is anticipated to be very much an edge case
@@ -441,17 +447,27 @@ export function findCssTextSplits(
   const childNodes = Array.from(style.childNodes);
   const splits = [];
   if (childNodes.length > 1 && cssText && typeof cssText === 'string') {
+    const cssTextNorm = normalizeCssString(cssText);
     for (let i = 1; i < childNodes.length; i++) {
       let split = 0; // marker for 'no split found'
       if (
         childNodes[i].textContent &&
         typeof childNodes[i].textContent === 'string'
       ) {
-        for (let j = 3; j < childNodes[i].textContent!.length; j++) {
+        const textContentNorm = normalizeCssString(childNodes[i].textContent!);
+        for (let j = 3; j < textContentNorm.length; j++) {
           // find the smallest substring that appears only once
-          let bit = childNodes[i].textContent!.substring(0, j);
-          if (cssText.split(bit).length === 2) {
-            split = cssText.indexOf(bit);
+          const bit = textContentNorm.substring(0, j);
+          if (cssTextNorm.split(bit).length === 2) {
+            const splitNorm = cssTextNorm.indexOf(bit);
+            // find the split point in the original text
+            for (let k = splitNorm; k < cssText.length; k++) {
+              if (
+                normalizeCssString(cssText.substring(0, k)).length === splitNorm
+              ) {
+                split = k;
+              }
+            }
             break;
           }
         }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -114,8 +114,13 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
     if (!rules) {
       return null;
     }
+    let sheetHref = s.href;
+    if (!sheetHref && s.ownerNode && s.ownerNode.ownerDocument) {
+      // an inline <style> element
+      sheetHref = s.ownerNode.ownerDocument.location.href;
+    }
     const stringifiedRules = Array.from(rules, (rule: CSSRule) =>
-      stringifyRule(rule, s.href),
+      stringifyRule(rule, sheetHref),
     ).join('');
     return fixBrowserCompatibilityIssuesInCSS(stringifiedRules);
   } catch (error) {

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -99,6 +99,15 @@ export function escapeImportStatement(rule: CSSImportRule): string {
   return statement.join(' ') + ';';
 }
 
+/*
+ * serialize the css rules from the .sheet property
+ * for <link rel="stylesheet"> elements, this is the only way of getting the rules without a FETCH
+ * for <style> elements, this is less preferable to looking at childNodes[0].textContent
+ * (which will include vendor prefixed rules which may not be used or visible to the recorded browser,
+ * but which might be needed by the replayer browser)
+ * however, at snapshot time, we don't know whether the style element has suffered
+ * any programmatic manipulation prior to the snapshot, in which case the .sheet would be more up to date
+ */
 export function stringifyStylesheet(s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules;

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -428,3 +428,36 @@ export function absolutifyURLs(cssText: string | null, href: string): string {
     },
   );
 }
+
+/**
+ * Maps the output of stringifyStylesheet to individual text nodes of a <style> element
+ * performance is not considered as this is anticipated to be very much an edge case
+ * (javascript is needed to add extra text nodes to a <style>)
+ */
+export function findCssTextSplits(
+  cssText: string,
+  style: HTMLStyleElement,
+): number[] {
+  const childNodes = Array.from(style.childNodes);
+  const splits = [];
+  if (childNodes.length > 1 && cssText && typeof cssText === 'string') {
+    for (let i = 1; i < childNodes.length; i++) {
+      let split = 0; // marker for 'no split found'
+      if (
+        childNodes[i].textContent &&
+        typeof childNodes[i].textContent === 'string'
+      ) {
+        for (let j = 3; j < childNodes[i].textContent!.length; j++) {
+          // find the smallest substring that appears only once
+          let bit = childNodes[i].textContent!.substring(0, j);
+          if (cssText.split(bit).length === 2) {
+            split = cssText.indexOf(bit);
+            break;
+          }
+        }
+      }
+      splits.push(split);
+    }
+  }
+  return splits;
+}

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -456,7 +456,7 @@ export function findCssTextSplits(
       ) {
         const textContentNorm = normalizeCssString(childNodes[i].textContent!);
         for (let j = 3; j < textContentNorm.length; j++) {
-          // find the smallest substring that appears only once
+          // find a  substring that appears only once
           const bit = textContentNorm.substring(0, j);
           if (cssTextNorm.split(bit).length === 2) {
             const splitNorm = cssTextNorm.indexOf(bit);
@@ -475,5 +475,6 @@ export function findCssTextSplits(
       splits.push(split);
     }
   }
+  splits.push(cssText.length); // a check in case the cssText is altered in transit
   return splits;
 }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -480,6 +480,7 @@ export function splitCssText(
               ) {
                 splits.push(cssText.substring(0, k));
                 cssText = cssText.substring(k);
+                break;
               }
             }
             break;

--- a/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -1094,12 +1094,13 @@ exports[`shadow DOM integration tests > snapshot shadow DOM 1`] = `
                 {
                   \\"type\\": 2,
                   \\"tagName\\": \\"style\\",
-                  \\"attributes\\": {},
+                  \\"attributes\\": {
+                    \\"_cssText\\": \\":host { display: inline-block; width: 650px; font-family: \\\\\\"Roboto Slab\\\\\\"; contain: content; }:host([background]) { background: var(--background-color, #9E9E9E); border-radius: 10px; padding: 10px; }#panels { box-shadow: rgba(0, 0, 0, 0.3) 0px 2px 2px; background: white; border-radius: 3px; padding: 16px; height: 250px; overflow: auto; }#tabs { display: inline-flex; user-select: none; }#tabs slot { display: inline-flex; }#tabs ::slotted(*) { font: 400 16px / 22px Roboto; padding: 16px 8px; margin: 0px; text-align: center; width: 100px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; cursor: pointer; border-top-left-radius: 3px; border-top-right-radius: 3px; background: linear-gradient(rgb(250, 250, 250), rgb(238, 238, 238)); border: none; }#tabs ::slotted([aria-selected=\\\\\\"true\\\\\\"]) { font-weight: 600; background: white; box-shadow: none; }#tabs ::slotted(:focus) { z-index: 1; }#panels ::slotted([aria-hidden=\\\\\\"true\\\\\\"]) { display: none; }\\"
+                  },
                   \\"childNodes\\": [
                     {
                       \\"type\\": 3,
-                      \\"textContent\\": \\":host { display: inline-block; width: 650px; font-family: \\\\\\"Roboto Slab\\\\\\"; contain: content; }:host([background]) { background: var(--background-color, #9E9E9E); border-radius: 10px; padding: 10px; }#panels { box-shadow: rgba(0, 0, 0, 0.3) 0px 2px 2px; background: white; border-radius: 3px; padding: 16px; height: 250px; overflow: auto; }#tabs { display: inline-flex; user-select: none; }#tabs slot { display: inline-flex; }#tabs ::slotted(*) { font: 400 16px / 22px Roboto; padding: 16px 8px; margin: 0px; text-align: center; width: 100px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; cursor: pointer; border-top-left-radius: 3px; border-top-right-radius: 3px; background: linear-gradient(rgb(250, 250, 250), rgb(238, 238, 238)); border: none; }#tabs ::slotted([aria-selected=\\\\\\"true\\\\\\"]) { font-weight: 600; background: white; box-shadow: none; }#tabs ::slotted(:focus) { z-index: 1; }#panels ::slotted([aria-hidden=\\\\\\"true\\\\\\"]) { display: none; }\\",
-                      \\"isStyle\\": true,
+                      \\"textContent\\": \\"\\",
                       \\"id\\": 38
                     }
                   ],

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -9,9 +9,9 @@ import { splitCssText, stringifyStylesheet } from './../src/utils';
 import { applyCssSplits } from './../src/rebuild';
 import {
   NodeType,
-  serializedElementNodeWithId,
-  BuildCache,
-  textNode,
+  type serializedElementNodeWithId,
+  type BuildCache,
+  type textNode,
 } from '../src/types';
 
 describe('css parser', () => {

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -109,6 +109,26 @@ describe('css splitter', () => {
     }
   });
 
+  it('finds css textElement splits correctly when comments are present', () => {
+    const window = new Window({ url: 'https://localhost:8080' });
+    const document = window.document;
+    // as authored, with comment, missing semicolons
+    document.head.innerHTML =
+      '<style>.a{color:red}.b{color:blue} /* author comment */</style>';
+    const style = document.querySelector('style');
+    if (style) {
+      style.append('/* author comment */.a{color:red}.b{color:green}');
+
+      // how it is currently stringified (spaces present)
+      const expected = [
+        '.a { color: red; } .b { color: blue; }',
+        '.a { color: red; } .b { color: green; }',
+      ];
+      const browserSheet = expected.join('');
+      expect(splitCssText(browserSheet, style)).toEqual(expected);
+    }
+  });
+
   it('finds css textElement splits correctly when vendor prefixed rules have been removed', () => {
     const style = JSDOM.fragment(`<style></style>`).querySelector('style');
     if (style) {

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -1,6 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { describe, it, expect } from 'vitest';
 import { mediaSelectorPlugin, pseudoClassPlugin } from '../src/css';
 import postcss, { AcceptedPlugin } from 'postcss';
+import { JSDOM } from 'jsdom';
+import { findCssTextSplits, stringifyStylesheet } from './../src/utils';
 
 describe('css parser', () => {
   function parse(plugin: AcceptedPlugin, input: string): string {
@@ -71,5 +76,26 @@ li[attr="weirder\\"("] a.\\:hover {background-color: red;}`);
 li[attr="has,comma"] a.\\:hover {background: red;}`,
       );
     });
+  });
+});
+
+describe('css splitter', () => {
+  it('finds css textElement splits correctly', () => {
+    const style = JSDOM.fragment(`<style></style>`).querySelector('style');
+    if (style) {
+      // as authored, e.g. no spaces
+      style.appendChild(JSDOM.fragment('.a{background-color:red;}'));
+      style.appendChild(JSDOM.fragment('.a{background-color:black;}'));
+
+      // how it is currently stringified (spaces present)
+      let browserSheet = '.a { background-color: red; }';
+      let expectedSplit = browserSheet.length;
+      browserSheet += '.a { background-color: black; }';
+
+      // can't do this as JSDOM doesn't have style.sheet
+      //expect(stringifyStylesheet(style.sheet!)).toEqual(browserSheet);
+
+      expect(findCssTextSplits(browserSheet, style)).toEqual([expectedSplit]);
+    }
   });
 });

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -169,6 +169,7 @@ describe('applyCssSplits css rejoiner', function () {
   });
 
   it('applies css splits correctly', () => {
+    // happy path
     applyCssSplits(
       sn,
       fullCssText,
@@ -180,5 +181,95 @@ describe('applyCssSplits css rejoiner', function () {
     expect((sn.childNodes[1] as textNode).textContent).toEqual(
       otherHalfCssText,
     );
+  });
+
+  it('applies css splits correctly even when there are too many child nodes', () => {
+    let sn3 = {
+      type: NodeType.Element,
+      tagName: 'style',
+      childNodes: [
+        {
+          type: NodeType.Text,
+          textContent: '',
+        },
+        {
+          type: NodeType.Text,
+          textContent: '',
+        },
+        {
+          type: NodeType.Text,
+          textContent: '',
+        },
+      ],
+    } as serializedElementNodeWithId;
+    applyCssSplits(
+      sn3,
+      fullCssText,
+      [halfCssText.length, fullCssText.length],
+      false,
+      mockLastUnusedArg,
+    );
+    expect((sn3.childNodes[0] as textNode).textContent).toEqual(halfCssText);
+    expect((sn3.childNodes[1] as textNode).textContent).toEqual(
+      otherHalfCssText,
+    );
+    expect((sn3.childNodes[2] as textNode).textContent).toEqual('');
+  });
+
+  it('maintains entire css text when there are too few child nodes', () => {
+    let sn1 = {
+      type: NodeType.Element,
+      tagName: 'style',
+      childNodes: [
+        {
+          type: NodeType.Text,
+          textContent: '',
+        },
+      ],
+    } as serializedElementNodeWithId;
+    applyCssSplits(
+      sn1,
+      fullCssText,
+      [halfCssText.length, fullCssText.length],
+      false,
+      mockLastUnusedArg,
+    );
+    expect((sn1.childNodes[0] as textNode).textContent).toEqual(fullCssText);
+  });
+
+  it('ignores css splits correctly when there is a mismatch in length check', () => {
+    applyCssSplits(sn, fullCssText, [2, 3], false, mockLastUnusedArg);
+    expect((sn.childNodes[0] as textNode).textContent).toEqual(fullCssText);
+    expect((sn.childNodes[1] as textNode).textContent).toEqual('');
+  });
+
+  it('ignores css splits correctly when we indicate a split is invalid with the zero marker', () => {
+    applyCssSplits(
+      sn,
+      fullCssText,
+      [0, fullCssText.length],
+      false,
+      mockLastUnusedArg,
+    );
+    expect((sn.childNodes[0] as textNode).textContent).toEqual(fullCssText);
+    expect((sn.childNodes[1] as textNode).textContent).toEqual('');
+  });
+
+  it('ignores css splits correctly with negative splits', () => {
+    applyCssSplits(sn, fullCssText, [-2, -4], false, mockLastUnusedArg);
+    expect((sn.childNodes[0] as textNode).textContent).toEqual(fullCssText);
+    expect((sn.childNodes[1] as textNode).textContent).toEqual('');
+  });
+
+  it('ignores css splits correctly with out of order splits', () => {
+    applyCssSplits(
+      sn,
+      fullCssText,
+      [fullCssText.length * 2, fullCssText.length],
+      false,
+      mockLastUnusedArg,
+    );
+    expect((sn.childNodes[0] as textNode).textContent).toEqual(fullCssText);
+    expect((sn.childNodes[1] as textNode).textContent).toEqual('');
   });
 });

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, beforeEach, expect } from 'vitest';
 import { mediaSelectorPlugin, pseudoClassPlugin } from '../src/css';
-import postcss, { AcceptedPlugin } from 'postcss';
+import postcss, { type AcceptedPlugin } from 'postcss';
 import { JSDOM } from 'jsdom';
 import { findCssTextSplits, stringifyStylesheet } from './../src/utils';
 import { applyCssSplits } from './../src/rebuild';

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -95,7 +95,43 @@ describe('css splitter', () => {
       // can't do this as JSDOM doesn't have style.sheet
       //expect(stringifyStylesheet(style.sheet!)).toEqual(browserSheet);
 
-      expect(findCssTextSplits(browserSheet, style)).toEqual([expectedSplit]);
+      expect(findCssTextSplits(browserSheet, style)).toEqual([
+        expectedSplit,
+        browserSheet.length,
+      ]);
+    }
+  });
+
+  it('finds css textElement splits correctly when vendor prefixed rules have been removed', () => {
+    const style = JSDOM.fragment(`<style></style>`).querySelector('style');
+    if (style) {
+      // as authored, with newlines
+      style.appendChild(
+        JSDOM.fragment(`.x {
+  -webkit-transition: all 4s ease;
+  content: 'try to keep a newline';
+  transition: all 4s ease;
+}`),
+      );
+      style.appendChild(
+        JSDOM.fragment(`.y {
+  -moz-transition: all 5s ease;
+  transition: all 5s ease;
+}`),
+      );
+      // browser .rules would usually omit the vendored versions and modifies the transition value
+      let browserSheet =
+        '.x { content: "try to keep a newline"; background: red; transition: 4s; }';
+      let expectedSplit = browserSheet.length;
+      browserSheet += '.y { transition: 5s; }';
+
+      // can't do this as JSDOM doesn't have style.sheet
+      //expect(stringifyStylesheet(style.sheet!)).toEqual(browserSheet);
+
+      expect(findCssTextSplits(browserSheet, style)).toEqual([
+        expectedSplit,
+        browserSheet.length,
+      ]);
     }
   });
 });

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -13,6 +13,7 @@ import {
   type BuildCache,
   type textNode,
 } from '../src/types';
+import { Window } from 'happy-dom';
 
 describe('css parser', () => {
   function parse(plugin: AcceptedPlugin, input: string): string {
@@ -88,11 +89,13 @@ li[attr="has,comma"] a.\\:hover {background: red;}`,
 
 describe('css splitter', () => {
   it('finds css textElement splits correctly', () => {
-    const style = JSDOM.fragment(`<style></style>`).querySelector('style');
+    const window = new Window({ url: 'https://localhost:8080' });
+    const document = window.document;
+    document.head.innerHTML = '<style>.a{background-color:red;}</style>';
+    const style = document.querySelector('style');
     if (style) {
       // as authored, e.g. no spaces
-      style.appendChild(JSDOM.fragment('.a{background-color:red;}'));
-      style.appendChild(JSDOM.fragment('.a{background-color:black;}'));
+      style.append('.a{background-color:black;}');
 
       // how it is currently stringified (spaces present)
       const expected = [
@@ -100,8 +103,7 @@ describe('css splitter', () => {
         '.a { background-color: black; }',
       ];
       const browserSheet = expected.join('');
-      // can't do this as JSDOM doesn't have style.sheet
-      //expect(stringifyStylesheet(style.sheet!)).toEqual(browserSheet);
+      expect(stringifyStylesheet(style.sheet!)).toEqual(browserSheet);
 
       expect(splitCssText(browserSheet, style)).toEqual(expected);
     }
@@ -133,6 +135,7 @@ describe('css splitter', () => {
       const browserSheet = expected.join('');
 
       // can't do this as JSDOM doesn't have style.sheet
+      // also happy-dom doesn't strip out vendor-prefixed rules like a real browser does
       //expect(stringifyStylesheet(style.sheet!)).toEqual(browserSheet);
 
       expect(splitCssText(browserSheet, style)).toEqual(expected);

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -10,7 +10,7 @@ import {
   createCache,
 } from '../src/rebuild';
 import { NodeType } from '../src/types';
-import { createMirror, Mirror } from '../src/utils';
+import { createMirror, Mirror, normalizeCssString } from '../src/utils';
 
 const expect = _expect as unknown as {
   <T = unknown>(actual: T): {
@@ -20,7 +20,7 @@ const expect = _expect as unknown as {
 
 expect.extend({
   toMatchCss: function (received: string, expected: string) {
-    const pass = normCss(received) === normCss(expected);
+    const pass = normalizeCssString(received) === normalizeCssString(expected);
     const message: () => string = () =>
       pass
         ? ''
@@ -31,10 +31,6 @@ expect.extend({
     };
   },
 });
-
-function normCss(cssText: string): string {
-  return cssText.replace(/[\s;]/g, '');
-}
 
 function getDuration(hrtime: [number, number]) {
   const [seconds, nanoseconds] = hrtime;

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -162,22 +162,27 @@ describe('style elements', () => {
   it('should serialize all rules of stylesheet when the sheet has a single child node', () => {
     const styleEl = render(`<style>body { color: red; }</style>`);
     styleEl.sheet?.insertRule('section { color: blue; }');
-    expect(serializeNode(styleEl.childNodes[0])).toMatchObject({
-      isStyle: true,
+    expect(serializeNode(styleEl)).toMatchObject({
       rootId: undefined,
-      textContent: 'section {color: blue;}body {color: red;}',
-      type: 3,
+      attributes: {
+        _cssText: 'section {color: blue;}body {color: red;}',
+      },
+      type: 2,
     });
   });
 
-  it('should serialize individual text nodes on stylesheets with multiple child nodes', () => {
+  it('should serialize all rules on stylesheets with mix of insertion type', () => {
     const styleEl = render(`<style>body { color: red; }</style>`);
+    styleEl.sheet?.insertRule('section.lost { color: unseeable; }'); // browser throws this away after append
     styleEl.append(document.createTextNode('section { color: blue; }'));
-    expect(serializeNode(styleEl.childNodes[1])).toMatchObject({
-      isStyle: true,
+    styleEl.sheet?.insertRule('section.working { color: pink; }');
+    expect(serializeNode(styleEl)).toMatchObject({
       rootId: undefined,
-      textContent: 'section { color: blue; }',
-      type: 3,
+      attributes: {
+        _cssText:
+          'section.working {color: pink;}body {color: red;}section {color: blue;}',
+      },
+      type: 2,
     });
   });
 });

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -180,7 +180,7 @@ describe('style elements', () => {
       rootId: undefined,
       attributes: {
         _cssText:
-          'section.working {color: pink;}body {color: red;}section {color: blue;}',
+          'section.working {color: pink;}body {color: red;}/* rr_split */section {color: blue;}',
       },
       type: 2,
     });

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "npm run prepack",
     "prepack": "npm run build",
-    "retest": "PUPPETEER_HEADLESS=true yarn retest:headful",
+    "retest": "cross-env PUPPETEER_HEADLESS=true yarn retest:headful",
     "retest:headful": "vitest run --exclude test/benchmark",
     "build-and-test": "yarn build && yarn retest",
     "test:headless": "cross-env PUPPETEER_HEADLESS=true yarn build-and-test",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "prepare": "npm run prepack",
     "prepack": "npm run build",
-    "retest": "vitest run --exclude test/benchmark",
+    "retest": "PUPPETEER_HEADLESS=true yarn retest:headful",
+    "retest:headful": "vitest run --exclude test/benchmark",
     "build-and-test": "yarn build && yarn retest",
     "test:headless": "cross-env PUPPETEER_HEADLESS=true yarn build-and-test",
     "test:headful": "cross-env PUPPETEER_HEADLESS=false yarn build-and-test",

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -290,6 +290,7 @@ export default class MutationBuffer {
       if (!parent || !inDom(n)) {
         return;
       }
+      let cssCaptured = false;
       if (n.nodeType === Node.TEXT_NODE) {
         const parentTag = (parent as Element).tagName;
         if (parentTag === 'TEXTAREA') {
@@ -298,7 +299,7 @@ export default class MutationBuffer {
         } else if (parentTag === 'STYLE' && this.addedSet.has(parent)) {
           // css content will be recorded via parent's _cssText attribute when
           // mutation adds entire <style> element
-          return;
+          cssCaptured = true;
         }
       }
 
@@ -348,6 +349,7 @@ export default class MutationBuffer {
         onStylesheetLoad: (link, childSn) => {
           this.stylesheetManager.attachLinkElement(link, childSn);
         },
+        cssCaptured,
       });
       if (sn) {
         adds.push({

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1,5 +1,6 @@
 import {
   rebuild,
+  adaptCssForReplay,
   buildNodeWithSN,
   NodeType,
   type BuildCache,
@@ -1746,7 +1747,14 @@ export class Replayer {
         }
         return this.warnNodeNotFound(d, mutation.id);
       }
-      target.textContent = mutation.value;
+
+      const parentEl = target.parentElement as Element | RRElement;
+      if (mutation.value && parentEl && parentEl.tagName === 'STYLE') {
+        // assumes hackCss: true (which isn't currently configurable from rrweb)
+        target.textContent = adaptCssForReplay(mutation.value, this.cache);
+      } else {
+        target.textContent = mutation.value;
+      }
 
       /**
        * https://github.com/rrweb-io/rrweb/pull/865

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -881,6 +881,9 @@ export class Replayer {
         'html.rrweb-paused *, html.rrweb-paused *:before, html.rrweb-paused *:after { animation-play-state: paused !important; }',
       );
     }
+    if (!injectStylesRules.length) {
+      return;
+    }
     if (this.usingVirtualDom) {
       const styleEl = this.virtualDom.createElement('style');
       this.virtualDom.mirror.add(

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -16522,6 +16522,11 @@ exports[`record integration tests > should record style mutations with multiple 
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\",
                         \\"id\\": 7
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\",
+                        \\"id\\": 8
                       }
                     ],
                     \\"id\\": 6
@@ -16529,7 +16534,7 @@ exports[`record integration tests > should record style mutations with multiple 
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n        \\",
-                    \\"id\\": 8
+                    \\"id\\": 9
                   },
                   {
                     \\"type\\": 2,
@@ -16539,10 +16544,10 @@ exports[`record integration tests > should record style mutations with multiple 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 10
+                        \\"id\\": 11
                       }
                     ],
-                    \\"id\\": 9
+                    \\"id\\": 10
                   }
                 ],
                 \\"id\\": 4
@@ -16550,7 +16555,7 @@ exports[`record integration tests > should record style mutations with multiple 
               {
                 \\"type\\": 3,
                 \\"textContent\\": \\"\\\\n        \\",
-                \\"id\\": 11
+                \\"id\\": 12
               },
               {
                 \\"type\\": 2,
@@ -16560,7 +16565,7 @@ exports[`record integration tests > should record style mutations with multiple 
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n\\\\t        \\",
-                    \\"id\\": 13
+                    \\"id\\": 14
                   },
                   {
                     \\"type\\": 2,
@@ -16569,12 +16574,12 @@ exports[`record integration tests > should record style mutations with multiple 
                       \\"id\\": \\"one\\"
                     },
                     \\"childNodes\\": [],
-                    \\"id\\": 14
+                    \\"id\\": 15
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n          \\",
-                    \\"id\\": 15
+                    \\"id\\": 16
                   },
                   {
                     \\"type\\": 2,
@@ -16583,12 +16588,12 @@ exports[`record integration tests > should record style mutations with multiple 
                       \\"id\\": \\"two\\"
                     },
                     \\"childNodes\\": [],
-                    \\"id\\": 16
+                    \\"id\\": 17
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n\\\\t        \\",
-                    \\"id\\": 17
+                    \\"id\\": 18
                   },
                   {
                     \\"type\\": 2,
@@ -16598,18 +16603,18 @@ exports[`record integration tests > should record style mutations with multiple 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 19
+                        \\"id\\": 20
                       }
                     ],
-                    \\"id\\": 18
+                    \\"id\\": 19
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n        \\\\n      \\",
-                    \\"id\\": 20
+                    \\"id\\": 21
                   }
                 ],
-                \\"id\\": 12
+                \\"id\\": 13
               }
             ],
             \\"id\\": 3
@@ -16641,25 +16646,25 @@ exports[`record integration tests > should record style mutations with multiple 
               \\"_cssText\\": \\"#two { color: rgb(255, 0, 0); }\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 21
-          }
-        },
-        {
-          \\"parentId\\": 21,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"\\",
             \\"id\\": 22
           }
         },
         {
-          \\"parentId\\": 21,
-          \\"nextId\\": 22,
+          \\"parentId\\": 22,
+          \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"\\",
             \\"id\\": 23
+          }
+        },
+        {
+          \\"parentId\\": 22,
+          \\"nextId\\": 23,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"\\",
+            \\"id\\": 24
           }
         }
       ]

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1133,39 +1133,26 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
-                      \\"_cssText\\": \\"body { background-color: black; }\\"
+                      \\"_cssText\\": \\"body { background-color: black; }body { color: darkgreen; }\\"
                     },
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\",
                         \\"id\\": 14
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\",
+                        \\"id\\": 15
                       }
                     ],
                     \\"id\\": 13
                   },
                   {
                     \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\",
-                    \\"id\\": 15
-                  }
-                ],
-                \\"id\\": 4
-              },
-              {
-                \\"type\\": 3,
-                \\"textContent\\": \\"\\\\n  \\",
-                \\"id\\": 16
-              },
-              {
-                \\"type\\": 2,
-                \\"tagName\\": \\"body\\",
-                \\"attributes\\": {},
-                \\"childNodes\\": [
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 18
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 16
                   },
                   {
                     \\"type\\": 2,
@@ -1175,18 +1162,54 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 20
+                        \\"id\\": 18
                       }
                     ],
+                    \\"id\\": 17
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
                     \\"id\\": 19
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 20
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"id\\": 22
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 24
+                      }
+                    ],
+                    \\"id\\": 23
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 21
+                    \\"id\\": 25
                   }
                 ],
-                \\"id\\": 17
+                \\"id\\": 21
               }
             ],
             \\"id\\": 3
@@ -1214,16 +1237,16 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\".absolutify { background-image: url(\\\\\\"http://localhost:3030/rel\\\\\\"); }\\",
-            \\"id\\": 22
+            \\"id\\": 26
           }
         },
         {
           \\"parentId\\": 13,
-          \\"nextId\\": 22,
+          \\"nextId\\": 26,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"body { background-color: darkgreen; }\\",
-            \\"id\\": 23
+            \\"id\\": 27
           }
         }
       ]
@@ -1235,7 +1258,11 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
       \\"source\\": 0,
       \\"texts\\": [
         {
-          \\"id\\": 23,
+          \\"id\\": 15,
+          \\"value\\": \\"body { color: purple; }\\"
+        },
+        {
+          \\"id\\": 27,
           \\"value\\": \\"body { background-color: purple; }\\"
         }
       ],

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1374,13 +1374,38 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
             \\"type\\": 2,
             \\"tagName\\": \\"style\\",
             \\"attributes\\": {
-              \\"_cssText\\": \\".record-once { color: brown; }\\"
+              \\"id\\": \\"goldilocks\\",
+              \\"_cssText\\": \\"body { color: brown; }\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 39
           }
+        },
+        {
+          \\"parentId\\": 39,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"\\",
+            \\"id\\": 40
+          }
         }
       ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [
+        {
+          \\"id\\": 40,
+          \\"value\\": \\"body { color: gold }\\"
+        }
+      ],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": []
     }
   }
 ]"
@@ -16401,6 +16426,15 @@ exports[`record integration tests > should record style mutations and replay the
             },
             \\"childNodes\\": [],
             \\"id\\": 21
+          }
+        },
+        {
+          \\"parentId\\": 21,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"\\",
+            \\"id\\": 22
           }
         }
       ]

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1034,6 +1034,225 @@ exports[`record integration tests > can mask character data mutations with regex
 ]"
 `;
 
+exports[`record integration tests > can record and replay style mutations 1`] = `
+"[
+  {
+    \\"type\\": 0,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 1,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {
+              \\"lang\\": \\"en\\"
+            },
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"charset\\": \\"UTF-8\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"name\\": \\"viewport\\",
+                      \\"content\\": \\"width=device-width, initial-scale=1.0\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"title\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"style\\",
+                        \\"id\\": 11
+                      }
+                    ],
+                    \\"id\\": 10
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 12
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"body { background-color: black; }\\",
+                        \\"isStyle\\": true,
+                        \\"id\\": 14
+                      }
+                    ],
+                    \\"id\\": 13
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 15
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 16
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 20
+                      }
+                    ],
+                    \\"id\\": 19
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
+                    \\"id\\": 21
+                  }
+                ],
+                \\"id\\": 17
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 13,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"body { background-color: darkgreen; }\\",
+            \\"isStyle\\": true,
+            \\"id\\": 22
+          }
+        }
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [
+        {
+          \\"id\\": 22,
+          \\"value\\": \\"body { background-color: purple; }\\"
+        }
+      ],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [
+        {
+          \\"id\\": 14,
+          \\"value\\": \\"\\\\n      body { background-color: black !important; }\\\\n    \\"
+        }
+      ],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  }
+]"
+`;
+
 exports[`record integration tests > can record attribute mutation 1`] = `
 "[
   {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -16364,15 +16364,6 @@ exports[`record integration tests > should record style mutations and replay the
             \\"childNodes\\": [],
             \\"id\\": 21
           }
-        },
-        {
-          \\"parentId\\": 21,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 3,
-            \\"textContent\\": \\"#two { color: rgb(255, 0, 0); }\\",
-            \\"id\\": 22
-          }
         }
       ]
     }

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -16649,7 +16649,7 @@ exports[`record integration tests > should record style mutations with multiple 
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"/* world */\\",
+            \\"textContent\\": \\"\\",
             \\"id\\": 22
           }
         },
@@ -16658,7 +16658,7 @@ exports[`record integration tests > should record style mutations with multiple 
           \\"nextId\\": 22,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"/* hello */\\",
+            \\"textContent\\": \\"\\",
             \\"id\\": 23
           }
         }

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1133,7 +1133,8 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
-                      \\"_cssText\\": \\"body { background-color: black; }body { color: darkgreen; }\\"
+                      \\"_cssText\\": \\"body { background-color: black; }body { color: orange !important; }\\",
+                      \\"_cssTextSplits\\": \\"33\\"
                     },
                     \\"childNodes\\": [
                       {
@@ -1259,7 +1260,11 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
       \\"texts\\": [
         {
           \\"id\\": 15,
-          \\"value\\": \\"body { color: purple; }\\"
+          \\"value\\": \\"body { color: yellow; }\\"
+        },
+        {
+          \\"id\\": 15,
+          \\"value\\": \\"body { color: yellow; }\\"
         },
         {
           \\"id\\": 27,

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1134,8 +1134,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
                       \\"id\\": \\"dual-textContent\\",
-                      \\"_cssText\\": \\"body { background-color: black; }body { color: orange !important; }\\",
-                      \\"_cssTextSplits\\": \\"33 67\\"
+                      \\"_cssText\\": \\"body { background-color: black; }/* rr_split */body { color: orange !important; }\\"
                     },
                     \\"childNodes\\": [
                       {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1135,7 +1135,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                     \\"attributes\\": {
                       \\"id\\": \\"dual-textContent\\",
                       \\"_cssText\\": \\"body { background-color: black; }body { color: orange !important; }\\",
-                      \\"_cssTextSplits\\": \\"33\\"
+                      \\"_cssTextSplits\\": \\"33 67\\"
                     },
                     \\"childNodes\\": [
                       {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1133,6 +1133,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
+                      \\"id\\": \\"dual-textContent\\",
                       \\"_cssText\\": \\"body { background-color: black; }body { color: orange !important; }\\",
                       \\"_cssTextSplits\\": \\"33\\"
                     },
@@ -1170,26 +1171,44 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                   },
                   {
                     \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"textContent\\": \\"\\\\n    \\",
                     \\"id\\": 19
-                  }
-                ],
-                \\"id\\": 4
-              },
-              {
-                \\"type\\": 3,
-                \\"textContent\\": \\"\\\\n  \\",
-                \\"id\\": 20
-              },
-              {
-                \\"type\\": 2,
-                \\"tagName\\": \\"body\\",
-                \\"attributes\\": {},
-                \\"childNodes\\": [
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"single-textContent\\",
+                      \\"_cssText\\": \\"a:hover { outline: red solid 1px; }\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\",
+                        \\"id\\": 21
+                      }
+                    ],
+                    \\"id\\": 20
+                  },
                   {
                     \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"textContent\\": \\"\\\\n    \\",
                     \\"id\\": 22
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"empty\\",
+                      \\"_cssText\\": \\"a:hover { outline: blue solid 1px; }\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 23
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 24
                   },
                   {
                     \\"type\\": 2,
@@ -1199,18 +1218,54 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 24
+                        \\"id\\": 26
                       }
                     ],
-                    \\"id\\": 23
+                    \\"id\\": 25
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 27
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 28
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"id\\": 30
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 32
+                      }
+                    ],
+                    \\"id\\": 31
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 25
+                    \\"id\\": 33
                   }
                 ],
-                \\"id\\": 21
+                \\"id\\": 29
               }
             ],
             \\"id\\": 3
@@ -1238,16 +1293,16 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\".absolutify { background-image: url(\\\\\\"http://localhost:3030/rel\\\\\\"); }\\",
-            \\"id\\": 26
+            \\"id\\": 34
           }
         },
         {
           \\"parentId\\": 13,
-          \\"nextId\\": 26,
+          \\"nextId\\": 34,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"body { background-color: darkgreen; }\\",
-            \\"id\\": 27
+            \\"id\\": 35
           }
         }
       ]
@@ -1267,7 +1322,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"value\\": \\"body { color: yellow; }\\"
         },
         {
-          \\"id\\": 27,
+          \\"id\\": 35,
           \\"value\\": \\"body { background-color: purple; }\\"
         }
       ],

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1224,8 +1224,28 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                   },
                   {
                     \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"textContent\\": \\"\\\\n    \\",
                     \\"id\\": 27
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"hover-mutation\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n      /* replaceme */\\\\n    \\",
+                        \\"id\\": 29
+                      }
+                    ],
+                    \\"id\\": 28
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 30
                   }
                 ],
                 \\"id\\": 4
@@ -1233,7 +1253,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
               {
                 \\"type\\": 3,
                 \\"textContent\\": \\"\\\\n  \\",
-                \\"id\\": 28
+                \\"id\\": 31
               },
               {
                 \\"type\\": 2,
@@ -1243,7 +1263,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 30
+                    \\"id\\": 33
                   },
                   {
                     \\"type\\": 2,
@@ -1253,18 +1273,18 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 32
+                        \\"id\\": 35
                       }
                     ],
-                    \\"id\\": 31
+                    \\"id\\": 34
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 33
+                    \\"id\\": 36
                   }
                 ],
-                \\"id\\": 29
+                \\"id\\": 32
               }
             ],
             \\"id\\": 3
@@ -1292,16 +1312,16 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\".absolutify { background-image: url(\\\\\\"http://localhost:3030/rel\\\\\\"); }\\",
-            \\"id\\": 34
+            \\"id\\": 37
           }
         },
         {
           \\"parentId\\": 13,
-          \\"nextId\\": 34,
+          \\"nextId\\": 37,
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"body { background-color: darkgreen; }\\",
-            \\"id\\": 35
+            \\"id\\": 38
           }
         }
       ]
@@ -1321,7 +1341,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"value\\": \\"body { color: yellow; }\\"
         },
         {
-          \\"id\\": 35,
+          \\"id\\": 38,
           \\"value\\": \\"body { background-color: purple; }\\"
         }
       ],
@@ -1338,6 +1358,10 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
         {
           \\"id\\": 14,
           \\"value\\": \\"\\\\n      body { background-color: black !important; }\\\\n    \\"
+        },
+        {
+          \\"id\\": 29,
+          \\"value\\": \\"a:hover { outline: cyan solid 1px; }\\"
         }
       ],
       \\"attributes\\": [],

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1349,6 +1349,270 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
 ]"
 `;
 
+exports[`record integration tests > can record and replay textarea mutations correctly 1`] = `
+"[
+  {
+    \\"type\\": 0,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 1,
+    \\"data\\": {}
+  },
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {
+              \\"lang\\": \\"en\\"
+            },
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"charset\\": \\"UTF-8\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"meta\\",
+                    \\"attributes\\": {
+                      \\"name\\": \\"viewport\\",
+                      \\"content\\": \\"width=device-width, initial-scale=1.0\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"title\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"Empty\\",
+                        \\"id\\": 11
+                      }
+                    ],
+                    \\"id\\": 10
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\",
+                    \\"id\\": 12
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n  \\",
+                \\"id\\": 13
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\",
+                    \\"id\\": 15
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"one\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 16
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
+                    \\"id\\": 17
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 19
+                      }
+                    ],
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
+                    \\"id\\": 20
+                  }
+                ],
+                \\"id\\": 14
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 14,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"textarea\\",
+            \\"attributes\\": {
+              \\"value\\": \\"pre value\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 21
+          }
+        }
+      ]
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 21,
+          \\"attributes\\": {
+            \\"value\\": \\"ok\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 21,
+          \\"attributes\\": {
+            \\"value\\": \\"ok3\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 2,
+      \\"type\\": 5,
+      \\"id\\": 21
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"1ok3\\",
+      \\"isChecked\\": false,
+      \\"id\\": 21
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [
+        {
+          \\"id\\": 21,
+          \\"attributes\\": {
+            \\"value\\": \\"ignore\\"
+          }
+        }
+      ],
+      \\"removes\\": [],
+      \\"adds\\": []
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 5,
+      \\"text\\": \\"12ok3\\",
+      \\"isChecked\\": false,
+      \\"id\\": 21
+    }
+  }
+]"
+`;
+
 exports[`record integration tests > can record attribute mutation 1`] = `
 "[
   {
@@ -4140,270 +4404,6 @@ exports[`record integration tests > can record style changes compactly and prese
       ],
       \\"removes\\": [],
       \\"adds\\": []
-    }
-  }
-]"
-`;
-
-exports[`record integration tests > can record textarea mutations correctly 1`] = `
-"[
-  {
-    \\"type\\": 0,
-    \\"data\\": {}
-  },
-  {
-    \\"type\\": 1,
-    \\"data\\": {}
-  },
-  {
-    \\"type\\": 4,
-    \\"data\\": {
-      \\"href\\": \\"about:blank\\",
-      \\"width\\": 1920,
-      \\"height\\": 1080
-    }
-  },
-  {
-    \\"type\\": 2,
-    \\"data\\": {
-      \\"node\\": {
-        \\"type\\": 0,
-        \\"childNodes\\": [
-          {
-            \\"type\\": 1,
-            \\"name\\": \\"html\\",
-            \\"publicId\\": \\"\\",
-            \\"systemId\\": \\"\\",
-            \\"id\\": 2
-          },
-          {
-            \\"type\\": 2,
-            \\"tagName\\": \\"html\\",
-            \\"attributes\\": {
-              \\"lang\\": \\"en\\"
-            },
-            \\"childNodes\\": [
-              {
-                \\"type\\": 2,
-                \\"tagName\\": \\"head\\",
-                \\"attributes\\": {},
-                \\"childNodes\\": [
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 5
-                  },
-                  {
-                    \\"type\\": 2,
-                    \\"tagName\\": \\"meta\\",
-                    \\"attributes\\": {
-                      \\"charset\\": \\"UTF-8\\"
-                    },
-                    \\"childNodes\\": [],
-                    \\"id\\": 6
-                  },
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 7
-                  },
-                  {
-                    \\"type\\": 2,
-                    \\"tagName\\": \\"meta\\",
-                    \\"attributes\\": {
-                      \\"name\\": \\"viewport\\",
-                      \\"content\\": \\"width=device-width, initial-scale=1.0\\"
-                    },
-                    \\"childNodes\\": [],
-                    \\"id\\": 8
-                  },
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 9
-                  },
-                  {
-                    \\"type\\": 2,
-                    \\"tagName\\": \\"title\\",
-                    \\"attributes\\": {},
-                    \\"childNodes\\": [
-                      {
-                        \\"type\\": 3,
-                        \\"textContent\\": \\"Empty\\",
-                        \\"id\\": 11
-                      }
-                    ],
-                    \\"id\\": 10
-                  },
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\",
-                    \\"id\\": 12
-                  }
-                ],
-                \\"id\\": 4
-              },
-              {
-                \\"type\\": 3,
-                \\"textContent\\": \\"\\\\n  \\",
-                \\"id\\": 13
-              },
-              {
-                \\"type\\": 2,
-                \\"tagName\\": \\"body\\",
-                \\"attributes\\": {},
-                \\"childNodes\\": [
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n    \\",
-                    \\"id\\": 15
-                  },
-                  {
-                    \\"type\\": 2,
-                    \\"tagName\\": \\"div\\",
-                    \\"attributes\\": {
-                      \\"id\\": \\"one\\"
-                    },
-                    \\"childNodes\\": [],
-                    \\"id\\": 16
-                  },
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 17
-                  },
-                  {
-                    \\"type\\": 2,
-                    \\"tagName\\": \\"script\\",
-                    \\"attributes\\": {},
-                    \\"childNodes\\": [
-                      {
-                        \\"type\\": 3,
-                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 19
-                      }
-                    ],
-                    \\"id\\": 18
-                  },
-                  {
-                    \\"type\\": 3,
-                    \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 20
-                  }
-                ],
-                \\"id\\": 14
-              }
-            ],
-            \\"id\\": 3
-          }
-        ],
-        \\"id\\": 1
-      },
-      \\"initialOffset\\": {
-        \\"left\\": 0,
-        \\"top\\": 0
-      }
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 0,
-      \\"texts\\": [],
-      \\"attributes\\": [],
-      \\"removes\\": [],
-      \\"adds\\": [
-        {
-          \\"parentId\\": 14,
-          \\"nextId\\": null,
-          \\"node\\": {
-            \\"type\\": 2,
-            \\"tagName\\": \\"textarea\\",
-            \\"attributes\\": {
-              \\"value\\": \\"pre value\\"
-            },
-            \\"childNodes\\": [],
-            \\"id\\": 21
-          }
-        }
-      ]
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 0,
-      \\"texts\\": [],
-      \\"attributes\\": [
-        {
-          \\"id\\": 21,
-          \\"attributes\\": {
-            \\"value\\": \\"ok\\"
-          }
-        }
-      ],
-      \\"removes\\": [],
-      \\"adds\\": []
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 0,
-      \\"texts\\": [],
-      \\"attributes\\": [
-        {
-          \\"id\\": 21,
-          \\"attributes\\": {
-            \\"value\\": \\"ok3\\"
-          }
-        }
-      ],
-      \\"removes\\": [],
-      \\"adds\\": []
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 2,
-      \\"type\\": 5,
-      \\"id\\": 21
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"1ok3\\",
-      \\"isChecked\\": false,
-      \\"id\\": 21
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 0,
-      \\"texts\\": [],
-      \\"attributes\\": [
-        {
-          \\"id\\": 21,
-          \\"attributes\\": {
-            \\"value\\": \\"ignore\\"
-          }
-        }
-      ],
-      \\"removes\\": [],
-      \\"adds\\": []
-    }
-  },
-  {
-    \\"type\\": 3,
-    \\"data\\": {
-      \\"source\\": 5,
-      \\"text\\": \\"12ok3\\",
-      \\"isChecked\\": false,
-      \\"id\\": 21
     }
   }
 ]"

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1547,10 +1547,23 @@ exports[`record integration tests > can record and replay textarea mutations cor
             \\"type\\": 2,
             \\"tagName\\": \\"textarea\\",
             \\"attributes\\": {
-              \\"value\\": \\"pre value\\"
+              \\"id\\": \\"ta2\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 21
+          }
+        },
+        {
+          \\"parentId\\": 14,
+          \\"nextId\\": 21,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"textarea\\",
+            \\"attributes\\": {
+              \\"value\\": \\"pre value\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 22
           }
         }
       ]
@@ -1563,9 +1576,15 @@ exports[`record integration tests > can record and replay textarea mutations cor
       \\"texts\\": [],
       \\"attributes\\": [
         {
-          \\"id\\": 21,
+          \\"id\\": 22,
           \\"attributes\\": {
             \\"value\\": \\"ok\\"
+          }
+        },
+        {
+          \\"id\\": 21,
+          \\"attributes\\": {
+            \\"value\\": \\"added\\"
           }
         }
       ],
@@ -1580,13 +1599,18 @@ exports[`record integration tests > can record and replay textarea mutations cor
       \\"texts\\": [],
       \\"attributes\\": [
         {
-          \\"id\\": 21,
+          \\"id\\": 22,
           \\"attributes\\": {
             \\"value\\": \\"ok3\\"
           }
         }
       ],
-      \\"removes\\": [],
+      \\"removes\\": [
+        {
+          \\"parentId\\": 14,
+          \\"id\\": 21
+        }
+      ],
       \\"adds\\": []
     }
   },
@@ -1595,7 +1619,7 @@ exports[`record integration tests > can record and replay textarea mutations cor
     \\"data\\": {
       \\"source\\": 2,
       \\"type\\": 5,
-      \\"id\\": 21
+      \\"id\\": 22
     }
   },
   {
@@ -1604,7 +1628,7 @@ exports[`record integration tests > can record and replay textarea mutations cor
       \\"source\\": 5,
       \\"text\\": \\"1ok3\\",
       \\"isChecked\\": false,
-      \\"id\\": 21
+      \\"id\\": 22
     }
   },
   {
@@ -1614,7 +1638,7 @@ exports[`record integration tests > can record and replay textarea mutations cor
       \\"texts\\": [],
       \\"attributes\\": [
         {
-          \\"id\\": 21,
+          \\"id\\": 22,
           \\"attributes\\": {
             \\"value\\": \\"ignore\\"
           }
@@ -1630,7 +1654,7 @@ exports[`record integration tests > can record and replay textarea mutations cor
       \\"source\\": 5,
       \\"text\\": \\"12ok3\\",
       \\"isChecked\\": false,
-      \\"id\\": 21
+      \\"id\\": 22
     }
   }
 ]"

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1212,9 +1212,19 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"nextId\\": null,
           \\"node\\": {
             \\"type\\": 3,
-            \\"textContent\\": \\"body { background-color: darkgreen; }\\",
+            \\"textContent\\": \\".absolutify { background-image: url(\\\\\\"http://localhost:3030/rel\\\\\\"); }\\",
             \\"isStyle\\": true,
             \\"id\\": 22
+          }
+        },
+        {
+          \\"parentId\\": 13,
+          \\"nextId\\": 22,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"body { background-color: darkgreen; }\\",
+            \\"isStyle\\": true,
+            \\"id\\": 23
           }
         }
       ]
@@ -1226,7 +1236,7 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
       \\"source\\": 0,
       \\"texts\\": [
         {
-          \\"id\\": 22,
+          \\"id\\": 23,
           \\"value\\": \\"body { background-color: purple; }\\"
         }
       ],

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -16471,6 +16471,203 @@ exports[`record integration tests > should record style mutations and replay the
 ]"
 `;
 
+exports[`record integration tests > should record style mutations with multiple child nodes and replay them correctly 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {
+              \\"lang\\": \\"en\\"
+            },
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n\\\\t        \\",
+                    \\"id\\": 5
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\"#one { color: rgb(255, 0, 0); }\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\",
+                        \\"id\\": 7
+                      }
+                    ],
+                    \\"id\\": 6
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\",
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 10
+                      }
+                    ],
+                    \\"id\\": 9
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 3,
+                \\"textContent\\": \\"\\\\n        \\",
+                \\"id\\": 11
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n\\\\t        \\",
+                    \\"id\\": 13
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"one\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 14
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 15
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"id\\": \\"two\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 16
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n\\\\t        \\",
+                    \\"id\\": 17
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"script\\",
+                    \\"attributes\\": {},
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
+                        \\"id\\": 19
+                      }
+                    ],
+                    \\"id\\": 18
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\\\n      \\",
+                    \\"id\\": 20
+                  }
+                ],
+                \\"id\\": 12
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  },
+  {
+    \\"type\\": 3,
+    \\"data\\": {
+      \\"source\\": 0,
+      \\"texts\\": [],
+      \\"attributes\\": [],
+      \\"removes\\": [],
+      \\"adds\\": [
+        {
+          \\"parentId\\": 4,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"style\\",
+            \\"attributes\\": {
+              \\"_cssText\\": \\"#two { color: rgb(255, 0, 0); }\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 21
+          }
+        },
+        {
+          \\"parentId\\": 21,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"/* world */\\",
+            \\"id\\": 22
+          }
+        },
+        {
+          \\"parentId\\": 21,
+          \\"nextId\\": 22,
+          \\"node\\": {
+            \\"type\\": 3,
+            \\"textContent\\": \\"/* hello */\\",
+            \\"id\\": 23
+          }
+        }
+      ]
+    }
+  }
+]"
+`;
+
 exports[`record integration tests > should record webgl canvas mutations 1`] = `
 "[
   {

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1366,7 +1366,21 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
       ],
       \\"attributes\\": [],
       \\"removes\\": [],
-      \\"adds\\": []
+      \\"adds\\": [
+        {
+          \\"parentId\\": 32,
+          \\"nextId\\": null,
+          \\"node\\": {
+            \\"type\\": 2,
+            \\"tagName\\": \\"style\\",
+            \\"attributes\\": {
+              \\"_cssText\\": \\".record-once { color: brown; }\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 39
+          }
+        }
+      ]
     }
   }
 ]"

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1132,12 +1132,13 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
                   {
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
-                    \\"attributes\\": {},
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\"body { background-color: black; }\\"
+                    },
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"body { background-color: black; }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 14
                       }
                     ],
@@ -1213,7 +1214,6 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\".absolutify { background-image: url(\\\\\\"http://localhost:3030/rel\\\\\\"); }\\",
-            \\"isStyle\\": true,
             \\"id\\": 22
           }
         },
@@ -1223,7 +1223,6 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"body { background-color: darkgreen; }\\",
-            \\"isStyle\\": true,
             \\"id\\": 23
           }
         }
@@ -5445,12 +5444,13 @@ exports[`record integration tests > mutations should work when blocked class is 
                   {
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
-                    \\"attributes\\": {},
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\"#b-class, #b-class-2 { height: 33px; width: 200px; }\\"
+                    },
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"#b-class, #b-class-2 { height: 33px; width: 200px; }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 9
                       }
                     ],
@@ -8161,12 +8161,13 @@ exports[`record integration tests > should nest record iframe 1`] = `
                   {
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
-                    \\"attributes\\": {},
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\"iframe { width: 500px; height: 500px; }\\"
+                    },
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"iframe { width: 500px; height: 500px; }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 14
                       }
                     ],
@@ -11704,7 +11705,6 @@ exports[`record integration tests > should record dynamic CSS changes 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\",
-                        \\"isStyle\\": true,
                         \\"id\\": 18
                       }
                     ],
@@ -14972,12 +14972,13 @@ exports[`record integration tests > should record shadow DOM 1`] = `
                   {
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
-                    \\"attributes\\": {},
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\".my-element { margin: 0px 0px 1rem; }iframe { border: 0px; width: 100%; padding: 0px; }body { max-width: 400px; margin: 1rem auto; padding: 0px 1rem; font-family: \\\\\\"comic sans ms\\\\\\"; }\\"
+                    },
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\".my-element { margin: 0px 0px 1rem; }iframe { border: 0px; width: 100%; padding: 0px; }body { max-width: 400px; margin: 1rem auto; padding: 0px 1rem; font-family: \\\\\\"comic sans ms\\\\\\"; }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 14
                       }
                     ],
@@ -15055,12 +15056,13 @@ exports[`record integration tests > should record shadow DOM 1`] = `
                       {
                         \\"type\\": 2,
                         \\"tagName\\": \\"style\\",
-                        \\"attributes\\": {},
+                        \\"attributes\\": {
+                          \\"_cssText\\": \\"body { margin: 0px; }p { border: 1px solid rgb(204, 204, 204); padding: 1rem; color: red; font-family: sans-serif; }\\"
+                        },
                         \\"childNodes\\": [
                           {
                             \\"type\\": 3,
-                            \\"textContent\\": \\"body { margin: 0px; }p { border: 1px solid rgb(204, 204, 204); padding: 1rem; color: red; font-family: sans-serif; }\\",
-                            \\"isStyle\\": true,
+                            \\"textContent\\": \\"\\",
                             \\"id\\": 28
                           }
                         ],
@@ -16129,8 +16131,7 @@ exports[`record integration tests > should record style mutations and replay the
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"#one { color: rgb(255, 0, 0); }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 7
                       }
                     ],
@@ -16260,7 +16261,6 @@ exports[`record integration tests > should record style mutations and replay the
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"#two { color: rgb(255, 0, 0); }\\",
-            \\"isStyle\\": true,
             \\"id\\": 22
           }
         }

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -1387,8 +1387,7 @@ exports[`record > captures inserted style text nodes correctly 1`] = `
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
-                      \\"_cssText\\": \\"div { color: red; }section { color: blue; }\\",
-                      \\"_cssTextSplits\\": \\"19 43\\"
+                      \\"_cssText\\": \\"div { color: red; }/* rr_split */section { color: blue; }\\"
                     },
                     \\"childNodes\\": [
                       {

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -1388,7 +1388,7 @@ exports[`record > captures inserted style text nodes correctly 1`] = `
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
                       \\"_cssText\\": \\"div { color: red; }section { color: blue; }\\",
-                      \\"_cssTextSplits\\": \\"19\\"
+                      \\"_cssTextSplits\\": \\"19 43\\"
                     },
                     \\"childNodes\\": [
                       {

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -1387,7 +1387,8 @@ exports[`record > captures inserted style text nodes correctly 1`] = `
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
                     \\"attributes\\": {
-                      \\"_cssText\\": \\"div { color: red; }section { color: blue; }\\"
+                      \\"_cssText\\": \\"div { color: red; }section { color: blue; }\\",
+                      \\"_cssTextSplits\\": \\"19\\"
                     },
                     \\"childNodes\\": [
                       {

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -1386,18 +1386,18 @@ exports[`record > captures inserted style text nodes correctly 1`] = `
                   {
                     \\"type\\": 2,
                     \\"tagName\\": \\"style\\",
-                    \\"attributes\\": {},
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\"div { color: red; }section { color: blue; }\\"
+                    },
                     \\"childNodes\\": [
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"div { color: red; }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 6
                       },
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"section { color: blue; }\\",
-                        \\"isStyle\\": true,
+                        \\"textContent\\": \\"\\",
                         \\"id\\": 7
                       }
                     ],
@@ -1460,7 +1460,6 @@ exports[`record > captures inserted style text nodes correctly 1`] = `
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"h1 { color: pink; }\\",
-            \\"isStyle\\": true,
             \\"id\\": 12
           }
         },
@@ -1470,7 +1469,6 @@ exports[`record > captures inserted style text nodes correctly 1`] = `
           \\"node\\": {
             \\"type\\": 3,
             \\"textContent\\": \\"span { color: orange; }\\",
-            \\"isStyle\\": true,
             \\"id\\": 13
           }
         }

--- a/packages/rrweb/test/html/style.html
+++ b/packages/rrweb/test/html/style.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>style</title>
-    <style>
+    <style id="dual-textContent">
       body { background-color: black; }
     </style>
     <script>
@@ -12,6 +12,15 @@
       document.querySelector('style').append(
         document.createTextNode('body { color: orange !important; }')
       );
+    </script>
+    <style id="single-textContent">
+      a:hover { outline: 1px solid red; }
+    </style>
+    <style id="empty"></style>
+    <script>
+      // this simulates how <link> is stringified
+      let empty = document.getElementById('empty');
+      empty.sheet.insertRule('a:hover { outline: 1px solid blue; }');
     </script>
   </head>
   <body>

--- a/packages/rrweb/test/html/style.html
+++ b/packages/rrweb/test/html/style.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>style</title>
+    <style>
+      body { background-color: black; }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/rrweb/test/html/style.html
+++ b/packages/rrweb/test/html/style.html
@@ -10,7 +10,7 @@
     <script>
       // not the same from the POV of the DOM of just sticking this text in above
       document.querySelector('style').append(
-        document.createTextNode('body { color: darkgreen; }')
+        document.createTextNode('body { color: orange !important; }')
       );
     </script>
   </head>

--- a/packages/rrweb/test/html/style.html
+++ b/packages/rrweb/test/html/style.html
@@ -7,6 +7,12 @@
     <style>
       body { background-color: black; }
     </style>
+    <script>
+      // not the same from the POV of the DOM of just sticking this text in above
+      document.querySelector('style').append(
+        document.createTextNode('body { color: darkgreen; }')
+      );
+    </script>
   </head>
   <body>
   </body>

--- a/packages/rrweb/test/html/style.html
+++ b/packages/rrweb/test/html/style.html
@@ -22,6 +22,9 @@
       let empty = document.getElementById('empty');
       empty.sheet.insertRule('a:hover { outline: 1px solid blue; }');
     </script>
+    <style id="hover-mutation">
+      /* replaceme */
+    </style>
   </head>
   <body>
   </body>

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -166,6 +166,74 @@ describe('record integration tests', function (this: ISuite) {
     ]);
   });
 
+  it('can record and replay style mutations', async () => {
+    // TODO: we could get a lot more elaborate here with mixed textContent and insertRule mutations
+    const page: puppeteer.Page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.setContent(getHtml.call(this, 'style.html'));
+
+    await waitForRAF(page); // ensure mutations aren't included in fullsnapshot
+
+    await page.evaluate(() => {
+      let styleEl = document.querySelector('style');
+      if (styleEl) {
+        styleEl.append(
+          document.createTextNode('body { background-color: darkgreen; }'),
+        );
+      }
+    });
+    await waitForRAF(page);
+    await page.evaluate(() => {
+      let styleEl = document.querySelector('style');
+      if (styleEl) {
+        styleEl.childNodes.forEach((cn) => {
+          if (cn.textContent) {
+            cn.textContent = cn.textContent.replace('darkgreen', 'purple');
+          }
+        });
+      }
+    });
+    await waitForRAF(page);
+    await page.evaluate(() => {
+      let styleEl = document.querySelector('style');
+      if (styleEl) {
+        styleEl.childNodes.forEach((cn) => {
+          if (cn.textContent) {
+            cn.textContent = cn.textContent.replace(
+              'black',
+              'black !important',
+            );
+          }
+        });
+      }
+    });
+
+    const snapshots = (await page.evaluate(
+      'window.snapshots',
+    )) as eventWithTime[];
+
+    // following ensures that the ./rel url has been absolutized (in a mutation)
+    await assertSnapshot(snapshots);
+
+    // check after each mutation and text input
+    const replayStyleValues = await page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(window.snapshots);
+      const vals = [];
+      window.snapshots.filter((e)=>e.data.attributes || e.data.source === 5).forEach((e)=>{
+        replayer.pause((e.timestamp - window.snapshots[0].timestamp)+1);
+        vals.push(getComputedStyle(replayer.iframe.contentDocument.querySelector('body'))['background-color']);
+});
+      vals;
+`);
+
+    expect(replayStyleValues).toEqual([
+      'rgb(0, 100, 0)', // darkgreen
+      'rgb(128, 0, 128)', // purple
+      'rgb(0, 0, 0)', // black !important
+    ]);
+  });
+
   it('can record childList mutations', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -1487,13 +1487,13 @@ describe('record integration tests', function (this: ISuite) {
         <head>
 	        <style>
           /* hello */
-          /* world */
           </style>
         </head>
         <body>
 	        <div id="one"></div>
           <div id="two"></div>
 	        <script>
+		        document.querySelector("style").append(document.createTextNode("/* world */"));
 		        document.querySelector("style").sheet.insertRule('#one { color: ${Color}; }', 0);
 	        </script>
         </body></html>

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -117,7 +117,7 @@ describe('record integration tests', function (this: ISuite) {
       ta2.id = 'ta2';
       document.body.append(ta2);
     });
-    await page.waitForTimeout(5);
+    await waitForRAF(page);
     await page.evaluate(() => {
       const t = document.querySelector('textarea') as HTMLTextAreaElement;
       t.innerText = 'ok'; // this mutation should be recorded
@@ -125,16 +125,16 @@ describe('record integration tests', function (this: ISuite) {
       const ta2t = document.createTextNode('added');
       document.getElementById('ta2').append(ta2t);
     });
-    await page.waitForTimeout(5);
+    await waitForRAF(page);
     await page.evaluate(() => {
       const t = document.querySelector('textarea') as HTMLTextAreaElement;
       (t.childNodes[0] as Text).appendData('3'); // this mutation is also valid
 
       document.getElementById('ta2').remove(); // done with this
     });
-    await page.waitForTimeout(5);
+    await waitForRAF(page);
     await page.type('textarea', '1'); // types (inserts) at index 0, in front of existing text
-    await page.waitForTimeout(5);
+    await waitForRAF(page);
     await page.evaluate(() => {
       const t = document.querySelector('textarea') as HTMLTextAreaElement;
       // user has typed so childNode content should now be ignored
@@ -145,7 +145,7 @@ describe('record integration tests', function (this: ISuite) {
       // there is nothing explicit in rrweb which enforces this, but this test may protect against
       // a future change where a mutation on a textarea incorrectly updates the .value
     });
-    await page.waitForTimeout(5);
+    await waitForRAF(page);
     await page.type('textarea', '2'); // cursor is at index 1
 
     const snapshots = (await page.evaluate(

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -238,6 +238,8 @@ describe('record integration tests', function (this: ISuite) {
           'color': bodyStyle['color'],
         });
       });
+      vals.push(replayer.iframe.contentDocument.getElementById('single-textContent').innerText);
+      vals.push(replayer.iframe.contentDocument.getElementById('empty').innerText);
       vals;
 `);
 
@@ -254,6 +256,8 @@ describe('record integration tests', function (this: ISuite) {
         'background-color': 'rgb(0, 0, 0)', // black !important
         color: 'rgb(255, 255, 0)', // yellow
       },
+      'a:hover,\na.\\:hover { outline: red solid 1px; }', // has run adaptCssForReplay
+      'a:hover,\na.\\:hover { outline: blue solid 1px; }', // has run adaptCssForReplay
     ]);
   });
 

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -1378,12 +1378,8 @@ describe('record integration tests', function (this: ISuite) {
   });
 
   /**
-   * https://github.com/rrweb-io/rrweb/pull/1417
-   * This test is to make sure that this problem doesn't regress
-   * Test case description:
-   * 1. Record two style elements. One is recorded as a full snapshot and the other is recorded as an incremental snapshot.
-   * 2. Change the color of both style elements to yellow as incremental style mutation.
-   * 3. Replay the recorded events and check if the style mutation is applied correctly.
+   * the regression part of the following is now handled by replayer.test.ts::'can deal with duplicate/conflicting values on style elements'
+   * so this test could be dropped if we add more robust mixing of `insertRule` into 'can record and replay style mutations'
    */
   it('should record style mutations and replay them correctly', async () => {
     const page: puppeteer.Page = await browser.newPage();
@@ -1478,6 +1474,8 @@ describe('record integration tests', function (this: ISuite) {
   });
 
   it('should record style mutations with multiple child nodes and replay them correctly', async () => {
+    // ensure that presence of multiple text nodes doesn't interfere with programmatic insertRule operations
+
     const page: puppeteer.Page = await browser.newPage();
     const Color = 'rgb(255, 0, 0)'; // red color
 

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -239,6 +239,9 @@ describe('record integration tests', function (this: ISuite) {
           }
         });
       }
+      let st = document.createElement('style');
+      st.innerText = '.record-once { color: brown }';
+      document.body.append(st);
     });
 
     const snapshots = (await page.evaluate(

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -240,8 +240,21 @@ describe('record integration tests', function (this: ISuite) {
         });
       }
       let st = document.createElement('style');
-      st.innerText = '.record-once { color: brown }';
+      st.id = 'goldilocks';
+      st.innerText = 'body { color: brown }';
       document.body.append(st);
+    });
+
+    await waitForRAF(page);
+    await page.evaluate(() => {
+      let styleEl = document.getElementById('goldilocks');
+      if (styleEl) {
+        styleEl.childNodes.forEach((cn) => {
+          if (cn.textContent) {
+            cn.textContent = cn.textContent.replace('brown', 'gold');
+          }
+        });
+      }
     });
 
     const snapshots = (await page.evaluate(
@@ -281,7 +294,11 @@ describe('record integration tests', function (this: ISuite) {
       },
       {
         'background-color': 'rgb(0, 0, 0)', // black !important
-        color: 'rgb(255, 255, 0)', // yellow
+        color: 'rgb(165, 42, 42)', // brown
+      },
+      {
+        'background-color': 'rgb(0, 0, 0)',
+        color: 'rgb(255, 215, 0)', // gold
       },
       'a:hover,\na.\\:hover { outline: red solid 1px; }', // has run adaptCssForReplay
       'a:hover,\na.\\:hover { outline: blue solid 1px; }', // has run adaptCssForReplay

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -191,7 +191,7 @@ describe('record integration tests', function (this: ISuite) {
     await waitForRAF(page); // ensure mutations aren't included in fullsnapshot
 
     await page.evaluate(() => {
-      let styleEl = document.querySelector('style');
+      let styleEl = document.querySelector('style#dual-textContent');
       if (styleEl) {
         styleEl.append(
           document.createTextNode('body { background-color: darkgreen; }'),
@@ -205,7 +205,7 @@ describe('record integration tests', function (this: ISuite) {
     });
     await waitForRAF(page);
     await page.evaluate(() => {
-      let styleEl = document.querySelector('style');
+      let styleEl = document.querySelector('style#dual-textContent');
       if (styleEl) {
         styleEl.childNodes.forEach((cn) => {
           if (cn.textContent) {
@@ -220,7 +220,7 @@ describe('record integration tests', function (this: ISuite) {
     });
     await waitForRAF(page);
     await page.evaluate(() => {
-      let styleEl = document.querySelector('style');
+      let styleEl = document.querySelector('style#dual-textContent');
       if (styleEl) {
         styleEl.childNodes.forEach((cn) => {
           if (cn.textContent) {
@@ -231,7 +231,7 @@ describe('record integration tests', function (this: ISuite) {
           }
         });
       }
-      let hoverMutationStyleEl = document.getElementById('hover-mutation');
+      let hoverMutationStyleEl = document.querySelector('style#hover-mutation');
       if (hoverMutationStyleEl) {
         hoverMutationStyleEl.childNodes.forEach((cn) => {
           if (cn.textContent) {
@@ -247,7 +247,7 @@ describe('record integration tests', function (this: ISuite) {
 
     await waitForRAF(page);
     await page.evaluate(() => {
-      let styleEl = document.getElementById('goldilocks');
+      let styleEl = document.querySelector('style#goldilocks');
       if (styleEl) {
         styleEl.childNodes.forEach((cn) => {
           if (cn.textContent) {

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -169,7 +169,7 @@ describe('record integration tests', function (this: ISuite) {
   it('can record and replay style mutations', async () => {
     // TODO: we could get a lot more elaborate here with mixed textContent and insertRule mutations
     const page: puppeteer.Page = await browser.newPage();
-    await page.goto('about:blank');
+    await page.goto(`${serverURL}/html`);
     await page.setContent(getHtml.call(this, 'style.html'));
 
     await waitForRAF(page); // ensure mutations aren't included in fullsnapshot
@@ -179,6 +179,11 @@ describe('record integration tests', function (this: ISuite) {
       if (styleEl) {
         styleEl.append(
           document.createTextNode('body { background-color: darkgreen; }'),
+        );
+        styleEl.append(
+          document.createTextNode(
+            '.absolutify { background-image: url("./rel"); }',
+          ),
         );
       }
     });

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -101,7 +101,7 @@ describe('record integration tests', function (this: ISuite) {
     await assertSnapshot(snapshots);
   });
 
-  it('can record textarea mutations correctly', async () => {
+  it('can record and replay textarea mutations correctly', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');
     await page.setContent(getHtml.call(this, 'empty.html'));

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -195,6 +195,10 @@ describe('record integration tests', function (this: ISuite) {
         styleEl.childNodes.forEach((cn) => {
           if (cn.textContent) {
             cn.textContent = cn.textContent.replace('darkgreen', 'purple');
+            cn.textContent = cn.textContent.replace(
+              'orange !important',
+              'yellow',
+            );
           }
         });
       }
@@ -240,15 +244,15 @@ describe('record integration tests', function (this: ISuite) {
     expect(replayStyleValues).toEqual([
       {
         'background-color': 'rgb(0, 100, 0)', // darkgreen
-        color: 'rgb(0, 100, 0)', // darkgreen (from style.html)
+        color: 'rgb(255, 165, 0)', // orange (from style.html)
       },
       {
         'background-color': 'rgb(128, 0, 128)', // purple
-        color: 'rgb(128, 0, 128)', // purple
+        color: 'rgb(255, 255, 0)', // yellow
       },
       {
         'background-color': 'rgb(0, 0, 0)', // black !important
-        color: 'rgb(128, 0, 128)', // purple
+        color: 'rgb(255, 255, 0)', // yellow
       },
     ]);
   });

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -228,15 +228,28 @@ describe('record integration tests', function (this: ISuite) {
       const vals = [];
       window.snapshots.filter((e)=>e.data.attributes || e.data.source === 5).forEach((e)=>{
         replayer.pause((e.timestamp - window.snapshots[0].timestamp)+1);
-        vals.push(getComputedStyle(replayer.iframe.contentDocument.querySelector('body'))['background-color']);
-});
+        let bodyStyle = getComputedStyle(replayer.iframe.contentDocument.querySelector('body'))
+        vals.push({
+          'background-color': bodyStyle['background-color'],
+          'color': bodyStyle['color'],
+        });
+      });
       vals;
 `);
 
     expect(replayStyleValues).toEqual([
-      'rgb(0, 100, 0)', // darkgreen
-      'rgb(128, 0, 128)', // purple
-      'rgb(0, 0, 0)', // black !important
+      {
+        'background-color': 'rgb(0, 100, 0)', // darkgreen
+        color: 'rgb(0, 100, 0)', // darkgreen (from style.html)
+      },
+      {
+        'background-color': 'rgb(128, 0, 128)', // purple
+        color: 'rgb(128, 0, 128)', // purple
+      },
+      {
+        'background-color': 'rgb(0, 0, 0)', // black !important
+        color: 'rgb(128, 0, 128)', // purple
+      },
     ]);
   });
 

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -167,6 +167,7 @@ describe('record integration tests', function (this: ISuite) {
   });
 
   it('can record and replay style mutations', async () => {
+    // This test shows that the `isStyle` attribute on textContent is not needed in a mutation
     // TODO: we could get a lot more elaborate here with mixed textContent and insertRule mutations
     const page: puppeteer.Page = await browser.newPage();
     await page.goto(`${serverURL}/html`);

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -216,6 +216,14 @@ describe('record integration tests', function (this: ISuite) {
           }
         });
       }
+      let hoverMutationStyleEl = document.getElementById('hover-mutation');
+      if (hoverMutationStyleEl) {
+        hoverMutationStyleEl.childNodes.forEach((cn) => {
+          if (cn.textContent) {
+            cn.textContent = 'a:hover { outline: cyan solid 1px; }';
+          }
+        });
+      }
     });
 
     const snapshots = (await page.evaluate(
@@ -240,6 +248,7 @@ describe('record integration tests', function (this: ISuite) {
       });
       vals.push(replayer.iframe.contentDocument.getElementById('single-textContent').innerText);
       vals.push(replayer.iframe.contentDocument.getElementById('empty').innerText);
+      vals.push(replayer.iframe.contentDocument.getElementById('hover-mutation').innerText);
       vals;
 `);
 
@@ -258,6 +267,7 @@ describe('record integration tests', function (this: ISuite) {
       },
       'a:hover,\na.\\:hover { outline: red solid 1px; }', // has run adaptCssForReplay
       'a:hover,\na.\\:hover { outline: blue solid 1px; }', // has run adaptCssForReplay
+      'a:hover,\na.\\:hover { outline: cyan solid 1px; }', // has run adaptCssForReplay after text mutation
     ]);
   });
 

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -250,18 +250,18 @@ export function stringifySnapshots(snapshots: eventWithTime[]): string {
 
 function stripBlobURLsFromAttributes(node: {
   attributes: {
-    src?: string;
+    [key: string]: any;
   };
 }) {
-  if (
-    'src' in node.attributes &&
-    node.attributes.src &&
-    typeof node.attributes.src === 'string' &&
-    node.attributes.src.startsWith('blob:')
-  ) {
-    node.attributes.src = node.attributes.src
-      .replace(/[\w-]+$/, '...')
-      .replace(/:[0-9]+\//, ':xxxx/');
+  for (const attr in node.attributes) {
+    if (
+      typeof node.attributes[attr] === 'string' &&
+      node.attributes[attr].startsWith('blob:')
+    ) {
+      node.attributes[attr] = node.attributes[attr]
+        .replace(/[\w-]+$/, '...')
+        .replace(/:[0-9]+\//, ':xxxx/');
+    }
   }
 }
 


### PR DESCRIPTION
Prep PR for async <style> serialization via assets: refactor stringifyStylesheet to happen in a single place during initial snapshot.

- initial motivation was to change the approach on stringifying <style> elements to do so in a single place
 - I then learned that we need the style content present on child text elements, in order to support mutation
 - this is still supported, however the css content is now preferably stored in parent <style> element in that _cssText attribute, rather than in the (natural) position in the child text elements of that element.  This is to support the stylesheet-assets PR which will delay population of the _cssText attribute, as in both cases the snapshot will be recorded with empty child text elements
 - on rebuild, this content can now be 'spread' out to child text nodes (usually there's only one!) in order to give a correct target for any further text mutations on these children.
 - there is a new complex but comprehensive test 'can record and replay style text mutations' which covers all of this; it has been designed to ensure that it fails if css text is populated in the wrong way (e.g. putting the entire cssText on the first of many text children and leaving the others blank)