### PR TITLE
Fixes #1424 'types are not exported' error

### DIFF
--- a/.changeset/sixty-carrots-study.md
+++ b/.changeset/sixty-carrots-study.md
@@ -1,5 +1,5 @@
 ---
-"@rrweb/types": patch
+'@rrweb/types': patch
 ---
 
 Fixes #1424 'types are not exported' error

--- a/.changeset/sixty-carrots-study.md
+++ b/.changeset/sixty-carrots-study.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/types": patch
+---
+
+Fixes #1424 'types are not exported' error

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,6 +30,7 @@
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/types.js",
       "require": "./dist/types.umd.cjs"
     }


### PR DESCRIPTION
Fixes https://github.com/rrweb-io/rrweb/issues/1424 'types are not exported' error