### PR TITLE
protect against no parent node

### DIFF
--- a/.changeset/three-baboons-bow.md
+++ b/.changeset/three-baboons-bow.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+fix: protect against missing parentNode

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -441,7 +441,7 @@ export default class MutationBuffer {
       texts: this.texts
         .map((text) => {
           const n = text.node;
-          if ((n.parentNode as Element).tagName === 'TEXTAREA') {
+          if (n.parentNode && (n.parentNode as Element).tagName === 'TEXTAREA') {
             // the node is being ignored as it isn't in the mirror, so shift mutation to attributes on parent textarea
             this.genTextAreaValueMutation(n.parentNode as HTMLTextAreaElement);
           }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -441,7 +441,10 @@ export default class MutationBuffer {
       texts: this.texts
         .map((text) => {
           const n = text.node;
-          if (n.parentNode && (n.parentNode as Element).tagName === 'TEXTAREA') {
+          if (
+            n.parentNode &&
+            (n.parentNode as Element).tagName === 'TEXTAREA'
+          ) {
             // the node is being ignored as it isn't in the mirror, so shift mutation to attributes on parent textarea
             this.genTextAreaValueMutation(n.parentNode as HTMLTextAreaElement);
           }


### PR DESCRIPTION
The `parentNode` does not always exist causing the issue described in https://github.com/PostHog/posthog/issues/21447

<img width="807" alt="Screenshot 2024-04-09 at 17 32 10" src="https://github.com/rrweb-io/rrweb/assets/6685876/3310e8c4-ae4f-4024-84a1-ccfac8ff335e">

We should just protect against it not being there.

Looks like this broke in https://github.com/rrweb-io/rrweb/pull/1351 merged into the newest alpha-12 release