### PR TITLE
toString for patched methods returns original toString

### DIFF
--- a/.changeset/unlucky-beers-tap.md
+++ b/.changeset/unlucky-beers-tap.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+toString for patched methods returns original toString

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -144,6 +144,9 @@ export function patch(
     // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
     // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
     if (typeof wrapped === 'function') {
+      wrapped.toString = function () {
+        return original.toString();
+      };
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       wrapped.prototype = wrapped.prototype || {};
       Object.defineProperties(wrapped, {


### PR DESCRIPTION
We ran into an issue where [Stencil](https://stenciljs.com/) was detecting changes to attachShadow from the native and thinking that it needed to polyfill which in turn would break recording. If we instead make it so that our wrapped versions of functions just use the original then we can avoid that issue.