### PR TITLE
rrweb sends message to cross-origin iframe to force snapshot

### DIFF
--- a/.changeset/rotten-squids-run.md
+++ b/.changeset/rotten-squids-run.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+rrweb sends message to cross-origin iframe to force snapshot

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -50,7 +50,7 @@ export class IframeManager {
     }
   }
 
-  public setTakeFullSnapshot (takeFullSnapshot: (isCheckout?: boolean) => void) {
+  public setTakeFullSnapshot(takeFullSnapshot: (isCheckout?: boolean) => void) {
     this.takeFullSnapshot = takeFullSnapshot;
   }
 

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -50,6 +50,10 @@ export class IframeManager {
     }
   }
 
+  public setTakeFullSnapshot (takeFullSnapshot: (isCheckout?: boolean) => void) {
+    this.takeFullSnapshot = takeFullSnapshot;
+  }
+
   public addIframe(iframeEl: HTMLIFrameElement) {
     this.iframes.set(iframeEl, true);
     if (iframeEl.contentWindow)

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -278,6 +278,7 @@ function record<T = eventWithTime>(
     stylesheetManager: stylesheetManager,
     recordCrossOriginIframes,
     wrappedEmit,
+    takeFullSnapshot,
   });
 
   /**

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -41,8 +41,7 @@ import {
 } from './error-handler';
 
 let wrappedEmit!: (e: eventWithoutTime, isCheckout?: boolean) => void;
-
-let takeFullSnapshot!: (isCheckout?: boolean) => void;
+let takeFullSnapshot: (isCheckout?: boolean) => void = () => { /* no-op */ };
 let canvasManager!: CanvasManager;
 let recording = false;
 
@@ -412,6 +411,7 @@ function record<T = eventWithTime>(
         mirror.getId(document),
       );
   };
+  iframeManager.setTakeFullSnapshot(takeFullSnapshot);
 
   try {
     const handlers: listenerHandler[] = [];

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -41,7 +41,9 @@ import {
 } from './error-handler';
 
 let wrappedEmit!: (e: eventWithoutTime, isCheckout?: boolean) => void;
-let takeFullSnapshot: (isCheckout?: boolean) => void = () => { /* no-op */ };
+let takeFullSnapshot: (isCheckout?: boolean) => void = () => {
+  /* no-op */
+};
 let canvasManager!: CanvasManager;
 let recording = false;
 

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -216,6 +216,7 @@ export type CrossOriginIframeMessageEventContent<T = eventWithTime> = {
   // The origin of the iframe which originally emits this message. It is used to check the integrity of message and to filter out the rrweb messages which are forwarded by some sites.
   origin: string;
   isCheckout?: boolean;
+  snapshot?: boolean;
 };
 export type CrossOriginIframeMessageEvent =
   MessageEvent<CrossOriginIframeMessageEventContent>;


### PR DESCRIPTION
We often manually take snapshots in cross origin frame situations and were running into problems with no longer having the content of cross origin frames. We noticed that if we sent along a message to tell the cross origin frame to take a new snapshot whenever the parent frame took one then it resolved this issue.