### PR TITLE
Fix that blob urls persist on the shared anchor element and can't be later modified

### DIFF
--- a/.changeset/nervous-kiwis-nail.md
+++ b/.changeset/nervous-kiwis-nail.md
@@ -1,0 +1,6 @@
+---
+'rrweb-snapshot': patch
+'rrweb': patch
+---
+
+Bugfix after #1434 perf improvements: fix that blob urls persist on the shared anchor element and can't be later modified

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -218,6 +218,8 @@ function getHref(doc: Document, customHref?: string) {
   }
   if (!customHref) {
     customHref = '';
+  } else if (customHref.startsWith('blob:') || customHref.startsWith('data:')) {
+    return customHref;
   }
   // note: using `new URL` is slower. See #1434 or https://jsbench.me/uqlud17rxo/1
   a.setAttribute('href', customHref);


### PR DESCRIPTION
This came up in tests that have been added in snapshot.test.ts in #1239 

This bug is in master since this morning after I merged #1434 and that PR could do with some additional scrutiny now.