### PR TITLE
Pre commit auto prettier

### DIFF
--- a/.changeset/eleven-bobcats-peel.md
+++ b/.changeset/eleven-bobcats-peel.md
@@ -1,6 +1,6 @@
 ---
-'rrweb-snapshot': patch
-'rrweb': patch
+"rrweb-snapshot": patch
+"rrweb": patch
 ---
 
 better support for coexistence with older libraries (e.g. MooTools & Prototype.js) which modify the in-built `Array.from` function

--- a/.changeset/odd-items-watch.md
+++ b/.changeset/odd-items-watch.md
@@ -1,0 +1,4 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---

--- a/.changeset/odd-items-watch.md
+++ b/.changeset/odd-items-watch.md
@@ -1,4 +1,2 @@
 ---
-"rrweb-snapshot": patch
-"rrweb": patch
 ---

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn git-format-staged -f 'prettier --ignore-unknown --stdin-filepath "{}"' '*.ts' '*.md'

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "eslint-plugin-compat": "^4.2.0",
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-tsdoc": "^0.2.17",
+    "git-format-staged": "^3.1.1",
+    "husky": "^9.0.11",
     "markdownlint": "^0.25.1",
     "markdownlint-cli": "^0.31.1",
     "prettier": "2.8.4",
@@ -47,7 +49,8 @@
     "live-stream": "cd packages/rrweb && yarn live-stream",
     "lint": "yarn run concurrently --success=all -r -m=1 'yarn run markdownlint docs' 'yarn eslint packages/*/src --ext .ts,.tsx,.js,.jsx,.svelte'",
     "lint:report": "yarn eslint --output-file eslint_report.json --format json packages/*/src --ext .ts,.tsx,.js,.jsx",
-    "release": "yarn build:all && changeset publish"
+    "release": "yarn build:all && changeset publish",
+    "prepare": "husky"
   },
   "resolutions": {
     "**/jsdom/cssom": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "test:watch": "yarn turbo run test:watch",
     "test:update": "yarn turbo run test:update",
     "format": "yarn prettier --write '**/*.{ts,md}'",
-    "format:head": "git diff --name-only HEAD^ |grep '\\.ts$\\|\\.md$' |xargs yarn prettier --write",
     "dev": "yarn turbo run dev",
     "repl": "cd packages/rrweb && npm run repl",
     "live-stream": "cd packages/rrweb && yarn live-stream",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7602,6 +7602,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-format-staged@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/git-format-staged/-/git-format-staged-3.1.1.tgz#017862422263579c14cc0a4f46c0a9111ac2e0fd"
+  integrity sha512-P749fkktaiAchFZKR7bgdvruzhvbcIDr1uRBrS9/Wdimb7wH1Twchz9gOixj8tUaHVMuXY/ckDojfOwV6AxgPA==
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
@@ -8087,6 +8092,11 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+husky@^9.0.11:
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
+  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"


### PR DESCRIPTION
After you run `git commit -m "message"`, the hook kicks in and runs `prettier --write` against all files going into the commit (so long as there's no conflicts against the unstaged changes).

See Option 4 here: https://prettier.io/docs/en/precommit.html#option-4-git-format-stagedhttpsgithubcomhallettjgit-format-staged

And a blog post with further info https://www.olioapps.com/blog/automatic-code-formatting