### PR TITLE
perf(mutation): refactor parent removed detection to iterative procedure

### DIFF
--- a/.changeset/kind-kids-design.md
+++ b/.changeset/kind-kids-design.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Optimize performance of isParentRemoved by converting it to an iterative procedure

--- a/.changeset/silent-plants-perform.md
+++ b/.changeset/silent-plants-perform.md
@@ -1,5 +1,5 @@
 ---
-'rrweb': patch
+"rrweb": patch
 ---
 
 Return early for child same origin frames

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -802,15 +802,15 @@ function _isParentRemoved(
   n: Node,
   mirror: Mirror,
 ): boolean {
-  const { parentNode } = n;
-  if (!parentNode) {
-    return false;
+  let node: ParentNode | null = n.parentNode;
+  while(node) {
+    const parentId = mirror.getId(node);
+    if (removes.some((r) => r.id === parentId)) {
+      return true;
+    }
+    node = node.parentNode;
   }
-  const parentId = mirror.getId(parentNode);
-  if (removes.some((r) => r.id === parentId)) {
-    return true;
-  }
-  return _isParentRemoved(removes, parentNode, mirror);
+  return false;
 }
 
 function isAncestorInSet(set: Set<Node>, n: Node): boolean {

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -803,7 +803,7 @@ function _isParentRemoved(
   mirror: Mirror,
 ): boolean {
   let node: ParentNode | null = n.parentNode;
-  while(node) {
+  while (node) {
     const parentId = mirror.getId(node);
     if (removes.some((r) => r.id === parentId)) {
       return true;

--- a/packages/rrweb/test/benchmark/dom-mutation.test.ts
+++ b/packages/rrweb/test/benchmark/dom-mutation.test.ts
@@ -19,6 +19,12 @@ const suites: Array<
   //   times: 10,
   // },
   {
+    title: 'create 1000x 1 DOM nodes with deeply nested children',
+    html: 'benchmark-dom-mutation-deep-nested.html',
+    eval: 'window.workload()',
+    times: 10,
+  },
+  {
     title: 'create 1000x10 DOM nodes',
     html: 'benchmark-dom-mutation.html',
     eval: 'window.workload()',

--- a/packages/rrweb/test/html/benchmark-dom-mutation-deep-nested.html
+++ b/packages/rrweb/test/html/benchmark-dom-mutation-deep-nested.html
@@ -1,0 +1,31 @@
+<html>
+  <body></body>
+  <script>
+    function init() {
+      const count = 100;
+
+      let roots = [];
+      for (let i = 0; i < count; ++i) {
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+        roots.push(div);
+      }
+
+      let tree_depth = 256;
+      let children = [...roots];
+      while (tree_depth > 0) {
+        for (let i = 0; i < children.length; i++) {
+          const div = document.createElement('div');
+          children[i].appendChild(div);
+          children[i] = div;
+        }
+        tree_depth--;
+      }
+    }
+
+    window.workload = () => {
+        document.body.innerHTML = '';
+        init();
+    };
+  </script>
+</html>


### PR DESCRIPTION
While looking at some profiles on an adjacent [PR](https://github.com/rrweb-io/rrweb/pull/1277), I noticed that we were spending a lot of time inside isParentRemoved.

I added a benchmark to cover a new deep tree test.

Largest change is on the deep tree benchmark I added which went from 475.5 to 377.4ms, the rest looks more or less the same.

Before

    console.log
      ┌─────────┬────────────────────────────────┬───────┬──────────┬────────────────────┐
      │ (index) │             title              │ times │ duration │     durations      │
      ├─────────┼────────────────────────────────┼───────┼──────────┼────────────────────┤
      │    0    │ 'append 70 x 70 x 70 elements' │   3   │   1283   │ '1287, 1342, 1220' │
      └─────────┴────────────────────────────────┴───────┴──────────┴────────────────────┘

      at test/benchmark/replay-fast-forward.test.ts:139:17

    console.log
      ┌─────────┬────────────────────────────────────────────────┬───────┬──────────┬─────────────────┐
      │ (index) │                     title                      │ times │ duration │    durations    │
      ├─────────┼────────────────────────────────────────────────┼───────┼──────────┼─────────────────┤
      │    0    │ 'append 1000 elements and reverse their order' │   3   │   206    │ '211, 205, 202' │
      └─────────┴────────────────────────────────────────────────┴───────┴──────────┴─────────────────┘

      at test/benchmark/replay-fast-forward.test.ts:139:17

    console.log
      ┌─────────┬─────────────────────────────────────────────┬───────┬────────────────────┬────────────────────┐
      │ (index) │                    title                    │ times │      duration      │     durations      │
      ├─────────┼─────────────────────────────────────────────┼───────┼────────────────────┼────────────────────┤
      │    0    │ 'real events recorded on bugs.chromium.org' │   3   │ 1719.3333333333333 │ '1714, 1755, 1689' │
      └─────────┴─────────────────────────────────────────────┴───────┴────────────────────┴────────────────────┘


 console.log
      ┌─────────┬────────────────────────────────────────────────────────┬───────────────────────────────────────────┬─────────────────────┬───────┬──────────┬────────────────────────────────────────────────────┐
      │ (index) │                         title                          │                   html                    │        eval         │ times │ duration │                     durations                      │
      ├─────────┼────────────────────────────────────────────────────────┼───────────────────────────────────────────┼─────────────────────┼───────┼──────────┼────────────────────────────────────────────────────┤
      │    0    │ 'create 1000x 1 DOM nodes with deeply nested children' │ 'benchmark-dom-mutation-deep-nested.html' │ 'window.workload()' │  10   │  475.5   │ '481, 461, 488, 477, 470, 514, 449, 471, 472, 472' │
      └─────────┴────────────────────────────────────────────────────────┴───────────────────────────────────────────┴─────────────────────┴───────┴──────────┴────────────────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:52:53.804Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬────────────────────────────┬───────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────────────────────────┐
      │ (index) │           title            │             html              │        eval         │ times │ duration │                durations                 │
      ├─────────┼────────────────────────────┼───────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────────────────────────┤
      │    0    │ 'create 1000x10 DOM nodes' │ 'benchmark-dom-mutation.html' │ 'window.workload()' │  10   │   63.7   │ '66, 67, 65, 63, 63, 64, 63, 62, 62, 62' │
      └─────────┴────────────────────────────┴───────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:53:05.559Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬─────────────────────────────────────────────────────────┬──────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬─────────────────────────────────────────────┐
      │ (index) │                          title                          │                     html                     │        eval         │ times │ duration │                  durations                  │
      ├─────────┼─────────────────────────────────────────────────────────┼──────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼─────────────────────────────────────────────┤
      │    0    │ 'create 1000x10x2 DOM nodes and remove a bunch of them' │ 'benchmark-dom-mutation-add-and-remove.html' │ 'window.workload()' │  10   │    99    │ '100, 97, 99, 110, 91, 92, 113, 97, 96, 95' │
      └─────────┴─────────────────────────────────────────────────────────┴──────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴─────────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:53:09.485Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬──────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────┐
      │ (index) │                              title                               │                         html                          │        eval         │ times │ duration │      durations       │
      ├─────────┼──────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────┤
      │    0    │ 'create 1000 DOM nodes and append into its previous looped node' │ 'benchmark-dom-mutation-multiple-descendant-add.html' │ 'window.workload()' │   5   │   28.2   │ '27, 29, 28, 29, 28' │
      └─────────┴──────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:53:14.021Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬───────────────────────────────────────────────────────┬────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬───────────────────────────┐
      │ (index) │                         title                         │                    html                    │        eval         │ times │ duration │         durations         │
      ├─────────┼───────────────────────────────────────────────────────┼────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼───────────────────────────┤
      │    0    │ 'create 10000 DOM nodes and move it to new container' │ 'benchmark-dom-mutation-add-and-move.html' │ 'window.workload()' │   5   │  105.6   │ '102, 117, 105, 104, 100' │
      └─────────┴───────────────────────────────────────────────────────┴────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴───────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:53:16.499Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬────────────────────────────────────────┬──────────────────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────────────────────────┐
      │ (index) │                 title                  │                   html                   │        eval         │ times │ duration │                durations                 │
      ├─────────┼────────────────────────────────────────┼──────────────────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────────────────────────┤
      │    0    │ 'modify attributes on 10000 DOM nodes' │ 'benchmark-dom-mutation-attributes.html' │ 'window.workload()' │  10   │   22.4   │ '22, 22, 23, 23, 21, 26, 18, 20, 29, 20' │
      └─────────┴────────────────────────────────────────┴──────────────────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15
      
      
After
    console.log
      ┌─────────┬────────────────────────────────┬───────┬────────────────────┬────────────────────┐
      │ (index) │             title              │ times │      duration      │     durations      │
      ├─────────┼────────────────────────────────┼───────┼────────────────────┼────────────────────┤
      │    0    │ 'append 70 x 70 x 70 elements' │   3   │ 1320.3333333333333 │ '1366, 1299, 1296' │
      └─────────┴────────────────────────────────┴───────┴────────────────────┴────────────────────┘

      at test/benchmark/replay-fast-forward.test.ts:139:17

    console.log
      ┌─────────┬────────────────────────────────────────────────┬───────┬────────────────────┬─────────────────┐
      │ (index) │                     title                      │ times │      duration      │    durations    │
      ├─────────┼────────────────────────────────────────────────┼───────┼────────────────────┼─────────────────┤
      │    0    │ 'append 1000 elements and reverse their order' │   3   │ 206.66666666666666 │ '205, 205, 210' │
      └─────────┴────────────────────────────────────────────────┴───────┴────────────────────┴─────────────────┘

      at test/benchmark/replay-fast-forward.test.ts:139:17

    console.log
      ┌─────────┬─────────────────────────────────────────────┬───────┬────────────────────┬────────────────────┐
      │ (index) │                    title                    │ times │      duration      │     durations      │
      ├─────────┼─────────────────────────────────────────────┼───────┼────────────────────┼────────────────────┤
      │    0    │ 'real events recorded on bugs.chromium.org' │   3   │ 1741.6666666666667 │ '1787, 1716, 1722' │
      └─────────┴─────────────────────────────────────────────┴───────┴────────────────────┴────────────────────┘

      at test/benchmark/replay-fast-forward.test.ts:139:17


console.log
      ┌─────────┬────────────────────────────────────────────────────────┬───────────────────────────────────────────┬─────────────────────┬───────┬──────────┬────────────────────────────────────────────────────┐
      │ (index) │                         title                          │                   html                    │        eval         │ times │ duration │                     durations                      │
      ├─────────┼────────────────────────────────────────────────────────┼───────────────────────────────────────────┼─────────────────────┼───────┼──────────┼────────────────────────────────────────────────────┤
      │    0    │ 'create 1000x 1 DOM nodes with deeply nested children' │ 'benchmark-dom-mutation-deep-nested.html' │ 'window.workload()' │  10   │  377.4   │ '385, 369, 398, 366, 373, 369, 376, 410, 359, 369' │
      └─────────┴────────────────────────────────────────────────────────┴───────────────────────────────────────────┴─────────────────────┴───────┴──────────┴────────────────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:55:02.488Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬────────────────────────────┬───────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────────────────────────┐
      │ (index) │           title            │             html              │        eval         │ times │ duration │                durations                 │
      ├─────────┼────────────────────────────┼───────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────────────────────────┤
      │    0    │ 'create 1000x10 DOM nodes' │ 'benchmark-dom-mutation.html' │ 'window.workload()' │  10   │   65.2   │ '69, 67, 65, 64, 64, 64, 62, 65, 67, 65' │
      └─────────┴────────────────────────────┴───────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:55:12.615Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬─────────────────────────────────────────────────────────┬──────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬───────────────────────────────────────────────┐
      │ (index) │                          title                          │                     html                     │        eval         │ times │ duration │                   durations                   │
      ├─────────┼─────────────────────────────────────────────────────────┼──────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼───────────────────────────────────────────────┤
      │    0    │ 'create 1000x10x2 DOM nodes and remove a bunch of them' │ 'benchmark-dom-mutation-add-and-remove.html' │ 'window.workload()' │  10   │  103.6   │ '97, 104, 99, 121, 100, 107, 117, 99, 95, 97' │
      └─────────┴─────────────────────────────────────────────────────────┴──────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴───────────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:55:16.543Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬──────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────┐
      │ (index) │                              title                               │                         html                          │        eval         │ times │ duration │      durations       │
      ├─────────┼──────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────┤
      │    0    │ 'create 1000 DOM nodes and append into its previous looped node' │ 'benchmark-dom-mutation-multiple-descendant-add.html' │ 'window.workload()' │   5   │   28.2   │ '27, 30, 28, 28, 28' │
      └─────────┴──────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:55:21.232Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬───────────────────────────────────────────────────────┬────────────────────────────────────────────┬─────────────────────┬───────┬──────────┬───────────────────────────┐
      │ (index) │                         title                         │                    html                    │        eval         │ times │ duration │         durations         │
      ├─────────┼───────────────────────────────────────────────────────┼────────────────────────────────────────────┼─────────────────────┼───────┼──────────┼───────────────────────────┤
      │    0    │ 'create 10000 DOM nodes and move it to new container' │ 'benchmark-dom-mutation-add-and-move.html' │ 'window.workload()' │   5   │  106.2   │ '107, 117, 102, 103, 102' │
      └─────────┴───────────────────────────────────────────────────────┴────────────────────────────────────────────┴─────────────────────┴───────┴──────────┴───────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
      profile:  /Users/jonasbadalic/code/rrweb/packages/rrweb/temp/profile-2024-05-30T22:55:23.714Z.json

      at test/benchmark/dom-mutation.test.ts:201:15

    console.log
      ┌─────────┬────────────────────────────────────────┬──────────────────────────────────────────┬─────────────────────┬───────┬──────────┬──────────────────────────────────────────┐
      │ (index) │                 title                  │                   html                   │        eval         │ times │ duration │                durations                 │
      ├─────────┼────────────────────────────────────────┼──────────────────────────────────────────┼─────────────────────┼───────┼──────────┼──────────────────────────────────────────┤
      │    0    │ 'modify attributes on 10000 DOM nodes' │ 'benchmark-dom-mutation-attributes.html' │ 'window.workload()' │  10   │   23.5   │ '22, 30, 21, 23, 32, 20, 23, 18, 20, 26' │
      └─────────┴────────────────────────────────────────┴──────────────────────────────────────────┴─────────────────────┴───────┴──────────┴──────────────────────────────────────────┘

      at test/benchmark/dom-mutation.test.ts:194:15

    console.log
