### PR TITLE
No neg lookbehind

### DIFF
--- a/.changeset/no-neg-lookbehind.md
+++ b/.changeset/no-neg-lookbehind.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Replay: Replace negative lookbehind in regexes from css parser as it causes issues with Safari 16

--- a/.changeset/silent-plants-perform.md
+++ b/.changeset/silent-plants-perform.md
@@ -1,5 +1,5 @@
 ---
-'rrweb': patch
+"rrweb": patch
 ---
 
 Return early for child same origin frames

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -432,8 +432,8 @@ export function parse(css: string, options: ParserOptions = {}): Stylesheet {
       whitespace();
     }
 
-    // Use match logic from https://github.com/NxtChg/pieces/blob/3eb39c8287a97632e9347a24f333d52d916bc816/js/css_parser/css_parse.js#L46C1-L47C1
-    const m = match(/^(((?<!\\)"(?:\\"|[^"])*"|(?<!\\)'(?:\\'|[^'])*'|[^{])+)/);
+    // originally from https://github.com/NxtChg/pieces/blob/3eb39c8287a97632e9347a24f333d52d916bc816/js/css_parser/css_parse.js#L46C1-L47C1
+    const m = match(/^(([^\\]"(?:\\"|[^"])*"|[^\\]'(?:\\'|[^'])*'|[^{])+)/);
     if (!m) {
       return;
     }
@@ -869,8 +869,8 @@ export function parse(css: string, options: ParserOptions = {}): Stylesheet {
         name +
         '\\s*((?:' +
         [
-          '(?<!\\\\)"(?:\\\\"|[^"])*"',
-          "(?<!\\\\)'(?:\\\\'|[^'])*'",
+          '[^\\\\]"(?:\\\\"|[^"])*"', // consume any quoted parts (checking that the double quote isn't itself escaped)
+          "[^\\\\]'(?:\\\\'|[^'])*'", // same but for single quotes
           '[^;]',
         ].join('|') +
         ')+);',

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -424,6 +424,17 @@ export function parse(css: string, options: ParserOptions = {}): Stylesheet {
    * Parse selector.
    */
 
+  // originally from https://github.com/NxtChg/pieces/blob/3eb39c8287a97632e9347a24f333d52d916bc816/js/css_parser/css_parse.js#L46C1-L47C1
+  const selectorMatcher = new RegExp(
+    '^((' +
+      [
+        /[^\\]"(?:\\"|[^"])*"/.source, // consume any quoted parts (checking that the double quote isn't itself escaped)
+        /[^\\]'(?:\\'|[^'])*'/.source, // same but for single quotes
+        '[^{]',
+      ].join('|') +
+      ')+)',
+  );
+
   function selector() {
     whitespace();
     while (css[0] == '}') {
@@ -432,8 +443,7 @@ export function parse(css: string, options: ParserOptions = {}): Stylesheet {
       whitespace();
     }
 
-    // originally from https://github.com/NxtChg/pieces/blob/3eb39c8287a97632e9347a24f333d52d916bc816/js/css_parser/css_parse.js#L46C1-L47C1
-    const m = match(/^(([^\\]"(?:\\"|[^"])*"|[^\\]'(?:\\'|[^'])*'|[^{])+)/);
+    const m = match(selectorMatcher);
     if (!m) {
       return;
     }
@@ -869,8 +879,8 @@ export function parse(css: string, options: ParserOptions = {}): Stylesheet {
         name +
         '\\s*((?:' +
         [
-          '[^\\\\]"(?:\\\\"|[^"])*"', // consume any quoted parts (checking that the double quote isn't itself escaped)
-          "[^\\\\]'(?:\\\\'|[^'])*'", // same but for single quotes
+          /[^\\]"(?:\\"|[^"])*"/.source, // consume any quoted parts (checking that the double quote isn't itself escaped)
+          /[^\\]'(?:\\'|[^'])*'/.source, // same but for single quotes
           '[^;]',
         ].join('|') +
         ')+);',


### PR DESCRIPTION
Safari 16 doesn't support it

- this is a fixup for negative lookbehind which was recently added in  #1481
- instead I'm asserting the non-presence of a slash before a quote; which means these quoted bits can't be at the start of the content, which I think is okay.

A css construction that might now fail (I haven't tested this):

```
"my-quoted-css-rule" { color: blue; } 
```