### PR TITLE
Update vite-plugin-dts to version 3.9.1

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "puppeteer": "^20.9.0",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0",
     "typescript": "^4.7.3"
   },

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -72,7 +72,7 @@
   ],
   "devDependencies": {
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0",
     "typescript": "^4.7.3"
   },

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -46,7 +46,7 @@
     "rrweb": "^2.0.0-alpha.14",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
     "rrweb": "^2.0.0-alpha.14"

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -46,7 +46,7 @@
     "rrweb": "^2.0.0-alpha.14",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
     "rrweb": "^2.0.0-alpha.14"

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -48,7 +48,7 @@
     "rrweb": "^2.0.0-alpha.14",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0",
     "puppeteer": "^20.9.0"
   },

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -47,7 +47,7 @@
     "rrweb": "^2.0.0-alpha.14",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
     "rrweb": "^2.0.0-alpha.14"

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -46,7 +46,7 @@
     "rrweb": "^2.0.0-alpha.14",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
     "rrweb": "^2.0.0-alpha.14"

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -47,7 +47,7 @@
     "rrweb": "^2.0.0-alpha.14",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
     "rrweb": "^2.0.0-alpha.14"

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "puppeteer": "^20.9.0",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0",
     "typescript": "^4.7.3"
   },

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "puppeteer": "^20.9.0",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0",
     "typescript": "^4.7.3"
   },

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -47,7 +47,7 @@
     "eslint": "^8.15.0",
     "puppeteer": "^9.1.1",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0",
     "typescript": "^4.7.3"
   },

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -49,7 +49,8 @@
     "puppeteer": "^17.1.3",
     "typescript": "^4.9.0",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1",
+    "vitest": "^1.6.0"
   },
   "dependencies": {
     "rrweb-snapshot": "^2.0.0-alpha.14"

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -61,7 +61,7 @@
     "tslib": "^1.9.3",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1",
+    "vite-plugin-dts": "^3.9.1",
     "vitest": "^1.4.0"
   }
 }

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -77,7 +77,7 @@
     "tslib": "^2.3.1",
     "typescript": "^4.7.3",
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
     "@rrweb/types": "^2.0.0-alpha.14",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -47,7 +47,7 @@
   ],
   "devDependencies": {
     "vite": "^5.2.8",
-    "vite-plugin-dts": "^3.8.1"
+    "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
     "rrweb-snapshot": "^2.0.0-alpha.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,12 +3504,30 @@
     "@vitest/utils" "1.4.0"
     chai "^4.3.10"
 
+"@vitest/expect@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-1.6.0.tgz#0b3ba0914f738508464983f4d811bc122b51fb30"
+  integrity sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==
+  dependencies:
+    "@vitest/spy" "1.6.0"
+    "@vitest/utils" "1.6.0"
+    chai "^4.3.10"
+
 "@vitest/runner@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.4.0.tgz#907c2d17ad5975b70882c25ab7a13b73e5a28da9"
   integrity sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==
   dependencies:
     "@vitest/utils" "1.4.0"
+    p-limit "^5.0.0"
+    pathe "^1.1.1"
+
+"@vitest/runner@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.6.0.tgz#a6de49a96cb33b0e3ba0d9064a3e8d6ce2f08825"
+  integrity sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==
+  dependencies:
+    "@vitest/utils" "1.6.0"
     p-limit "^5.0.0"
     pathe "^1.1.1"
 
@@ -3522,6 +3540,15 @@
     pathe "^1.1.1"
     pretty-format "^29.7.0"
 
+"@vitest/snapshot@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.6.0.tgz#deb7e4498a5299c1198136f56e6e0f692e6af470"
+  integrity sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==
+  dependencies:
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    pretty-format "^29.7.0"
+
 "@vitest/spy@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.4.0.tgz#cf953c93ae54885e801cbe6b408a547ae613f26c"
@@ -3529,10 +3556,27 @@
   dependencies:
     tinyspy "^2.2.0"
 
+"@vitest/spy@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.6.0.tgz#362cbd42ccdb03f1613798fde99799649516906d"
+  integrity sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==
+  dependencies:
+    tinyspy "^2.2.0"
+
 "@vitest/utils@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.4.0.tgz#ea6297e0d329f9ff0a106f4e1f6daf3ff6aad3f0"
   integrity sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==
+  dependencies:
+    diff-sequences "^29.6.3"
+    estree-walker "^3.0.3"
+    loupe "^2.3.7"
+    pretty-format "^29.7.0"
+
+"@vitest/utils@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.6.0.tgz#5c5675ca7d6f546a7b4337de9ae882e6c57896a1"
+  integrity sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==
   dependencies:
     diff-sequences "^29.6.3"
     estree-walker "^3.0.3"
@@ -10583,6 +10627,11 @@ tinypool@^0.8.2:
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.3.tgz#e17d0a5315a7d425f875b05f7af653c225492d39"
   integrity sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==
 
+tinypool@^0.8.3:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
+  integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
+
 tinyspy@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
@@ -11092,10 +11141,21 @@ vite-node@1.4.0:
     picocolors "^1.0.0"
     vite "^5.0.0"
 
-vite-plugin-dts@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-3.8.1.tgz#a6bbdc9762acce21d0fee8812d1c73085b49dee5"
-  integrity sha512-zEYyQxH7lKto1VTKZHF3ZZeOPkkJgnMrePY4VxDHfDSvDjmYMMfWjZxYmNwW8QxbaItWJQhhXY+geAbyNphI7g==
+vite-node@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.6.0.tgz#2c7e61129bfecc759478fa592754fd9704aaba7f"
+  integrity sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    vite "^5.0.0"
+
+vite-plugin-dts@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-3.9.1.tgz#625ad388ec3956708ccec7960550a7b0a8e8909e"
+  integrity sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==
   dependencies:
     "@microsoft/api-extractor" "7.43.0"
     "@rollup/pluginutils" "^5.1.0"
@@ -11170,6 +11230,32 @@ vitest@^1.4.0:
     tinypool "^0.8.2"
     vite "^5.0.0"
     vite-node "1.4.0"
+    why-is-node-running "^2.2.2"
+
+vitest@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.6.0.tgz#9d5ad4752a3c451be919e412c597126cffb9892f"
+  integrity sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==
+  dependencies:
+    "@vitest/expect" "1.6.0"
+    "@vitest/runner" "1.6.0"
+    "@vitest/snapshot" "1.6.0"
+    "@vitest/spy" "1.6.0"
+    "@vitest/utils" "1.6.0"
+    acorn-walk "^8.3.2"
+    chai "^4.3.10"
+    debug "^4.3.4"
+    execa "^8.0.1"
+    local-pkg "^0.5.0"
+    magic-string "^0.30.5"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    std-env "^3.5.0"
+    strip-literal "^2.0.0"
+    tinybench "^2.5.1"
+    tinypool "^0.8.3"
+    vite "^5.0.0"
+    vite-node "1.6.0"
     why-is-node-running "^2.2.2"
 
 vue-template-compiler@^2.7.14:


### PR DESCRIPTION
This pull request updates the vite-plugin-dts package to version 3.9.1. This update ensures that the project is using the latest version of the package.