### PR TITLE
[Feature] Include takeFullSnapshot function in rrweb

### DIFF
--- a/.changeset/giant-rats-chew.md
+++ b/.changeset/giant-rats-chew.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Export takeFullSnapshot function for a recording process

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -24,11 +24,13 @@ export type { recordOptions, ReplayPlugin } from './types';
 
 const { addCustomEvent } = record;
 const { freezePage } = record;
+const { takeFullSnapshot } = record;
 
 export {
   record,
   addCustomEvent,
   freezePage,
+  takeFullSnapshot,
   Replayer,
   type playerConfig,
   type PlayerMachineState,


### PR DESCRIPTION
Added takeFullSnapshot function to allow retake a snapshot if user decide pause recording (avoid emit function) and after resume with an updated screen