### PR TITLE
fix: console assert only logs when arg 0 is falsy

### DIFF
--- a/.changeset/gold-experts-type.md
+++ b/.changeset/gold-experts-type.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/rrweb-plugin-console-record": patch
+---
+
+corrects behaviour of console.assert logging to only capture logs when the provided assertion is falsey

--- a/packages/plugins/rrweb-plugin-console-record/src/index.ts
+++ b/packages/plugins/rrweb-plugin-console-record/src/index.ts
@@ -189,6 +189,12 @@ function initLogObserver(
       (original: (...args: Array<unknown>) => void) => {
         return (...args: Array<unknown>) => {
           original.apply(this, args);
+
+          if (level === 'assert' && !!args[0]) {
+            // assert does not log if the first argument evaluates to true
+            return;
+          }
+
           if (inStack) {
             // If we are already in a stack this means something from the following code is calling a console method
             // likely a proxy method called from stringify. We don't want to log this as it will cause an infinite loop
@@ -199,7 +205,11 @@ function initLogObserver(
             const trace = ErrorStackParser.parse(new Error())
               .map((stackFrame: StackFrame) => stackFrame.toString())
               .splice(1); // splice(1) to omit the hijacked log function
-            const payload = args.map((s) =>
+
+            // assert does not log its first arg, that's only used for deciding whether to log
+            const argsForPayload = level === 'assert' ? args.slice(1) : args;
+
+            const payload = argsForPayload.map((s) =>
               stringify(s, logOptions.stringifyOptions),
             );
             logCount++;

--- a/packages/plugins/rrweb-plugin-console-record/test/__snapshots__/index.test.ts.snap
+++ b/packages/plugins/rrweb-plugin-console-record/test/__snapshots__/index.test.ts.snap
@@ -356,11 +356,10 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"assert\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:2:15\\"
+          \\"__puppeteer_evaluation_script__:3:15\\"
         ],
         \\"payload\\": [
-          \\"true\\",
-          \\"\\\\\\"assert\\\\\\"\\"
+          \\"\\\\\\"should log assert\\\\\\"\\"
         ]
       }
     }
@@ -371,21 +370,6 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"plugin\\": \\"rrweb/console@1\\",
       \\"payload\\": {
         \\"level\\": \\"count\\",
-        \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:3:15\\"
-        ],
-        \\"payload\\": [
-          \\"\\\\\\"count\\\\\\"\\"
-        ]
-      }
-    }
-  },
-  {
-    \\"type\\": 6,
-    \\"data\\": {
-      \\"plugin\\": \\"rrweb/console@1\\",
-      \\"payload\\": {
-        \\"level\\": \\"countReset\\",
         \\"trace\\": [
           \\"__puppeteer_evaluation_script__:4:15\\"
         ],
@@ -400,9 +384,24 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
     \\"data\\": {
       \\"plugin\\": \\"rrweb/console@1\\",
       \\"payload\\": {
-        \\"level\\": \\"debug\\",
+        \\"level\\": \\"countReset\\",
         \\"trace\\": [
           \\"__puppeteer_evaluation_script__:5:15\\"
+        ],
+        \\"payload\\": [
+          \\"\\\\\\"count\\\\\\"\\"
+        ]
+      }
+    }
+  },
+  {
+    \\"type\\": 6,
+    \\"data\\": {
+      \\"plugin\\": \\"rrweb/console@1\\",
+      \\"payload\\": {
+        \\"level\\": \\"debug\\",
+        \\"trace\\": [
+          \\"__puppeteer_evaluation_script__:6:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"debug\\\\\\"\\"
@@ -417,7 +416,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"dir\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:6:15\\"
+          \\"__puppeteer_evaluation_script__:7:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"dir\\\\\\"\\"
@@ -432,7 +431,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"dirxml\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:7:15\\"
+          \\"__puppeteer_evaluation_script__:8:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"dirxml\\\\\\"\\"
@@ -447,7 +446,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"group\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:8:15\\"
+          \\"__puppeteer_evaluation_script__:9:15\\"
         ],
         \\"payload\\": []
       }
@@ -460,7 +459,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"groupCollapsed\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:9:15\\"
+          \\"__puppeteer_evaluation_script__:10:15\\"
         ],
         \\"payload\\": []
       }
@@ -473,7 +472,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"info\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:10:15\\"
+          \\"__puppeteer_evaluation_script__:11:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"info\\\\\\"\\"
@@ -488,7 +487,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"log\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:11:15\\"
+          \\"__puppeteer_evaluation_script__:12:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"log\\\\\\"\\"
@@ -503,7 +502,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"table\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:12:15\\"
+          \\"__puppeteer_evaluation_script__:13:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"table\\\\\\"\\"
@@ -518,7 +517,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"time\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:13:15\\"
+          \\"__puppeteer_evaluation_script__:14:15\\"
         ],
         \\"payload\\": []
       }
@@ -531,7 +530,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"timeEnd\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:14:15\\"
+          \\"__puppeteer_evaluation_script__:15:15\\"
         ],
         \\"payload\\": []
       }
@@ -544,7 +543,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"timeLog\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:15:15\\"
+          \\"__puppeteer_evaluation_script__:16:15\\"
         ],
         \\"payload\\": []
       }
@@ -557,7 +556,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"trace\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:16:15\\"
+          \\"__puppeteer_evaluation_script__:17:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"trace\\\\\\"\\"
@@ -572,7 +571,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"warn\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:17:15\\"
+          \\"__puppeteer_evaluation_script__:18:15\\"
         ],
         \\"payload\\": [
           \\"\\\\\\"warn\\\\\\"\\"
@@ -587,7 +586,7 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"clear\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:18:15\\"
+          \\"__puppeteer_evaluation_script__:19:15\\"
         ],
         \\"payload\\": []
       }
@@ -600,10 +599,10 @@ exports[`rrweb-plugin-console-record > should record console messages 1`] = `
       \\"payload\\": {
         \\"level\\": \\"log\\",
         \\"trace\\": [
-          \\"__puppeteer_evaluation_script__:19:15\\"
+          \\"__puppeteer_evaluation_script__:20:15\\"
         ],
         \\"payload\\": [
-          \\"\\\\\\"TypeError: a message\\\\\\\\n    at __puppeteer_evaluation_script__:19:19\\\\\\\\nEnd of stack for Error object\\\\\\"\\"
+          \\"\\\\\\"TypeError: a message\\\\\\\\n    at __puppeteer_evaluation_script__:20:19\\\\\\\\nEnd of stack for Error object\\\\\\"\\"
         ]
       }
     }

--- a/packages/plugins/rrweb-plugin-console-record/test/index.test.ts
+++ b/packages/plugins/rrweb-plugin-console-record/test/index.test.ts
@@ -94,7 +94,10 @@ describe('rrweb-plugin-console-record', () => {
     await page.goto(`${serverUrl}test/html/log.html`);
 
     await page.evaluate(() => {
-      console.assert(0 === 0, 'assert');
+      // truthy assert does not log
+      console.assert(0 === 0, 'should not log assert');
+      // falsy assert does log
+      console.assert(false, 'should log assert');
       console.count('count');
       console.countReset('count');
       console.debug('debug');


### PR DESCRIPTION
fixes https://github.com/PostHog/posthog-js/issues/1280

when someone calls console.assert the console recorder always captures as if the log was shown in the console

but...

> The console.assert() static method writes an error message to the console if the assertion is false. If the assertion is true, nothing happens.

from https://developer.mozilla.org/en-US/docs/Web/API/console/assert_static

this changes the recorder to only capture when the assertion is false, and not to log the first argument, which brings the recorded logs into line with what the browser would do

technically this is a breaking change since folk could be depending on this incorrect behaviour, i chose not to wrap it in config allowing people to opt in to this new behaviour to keep the change simpler (but open to adding that if necessary)

my educated guess is that use of `console.assert` is pretty rare