### PR TITLE
feat: allow custom truncation suffix

### DIFF
--- a/.changeset/spotty-rocks-own.md
+++ b/.changeset/spotty-rocks-own.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/rrweb-plugin-console-record": patch
+---
+
+adds config to the console recorder plugin to allow a custom truncation marker instead of the default ..."

--- a/packages/plugins/rrweb-plugin-console-record/src/index.ts
+++ b/packages/plugins/rrweb-plugin-console-record/src/index.ts
@@ -7,6 +7,11 @@ export type StringifyOptions = {
   // limit of string length
   stringLengthLimit?: number;
   /**
+   * When truncating an entry you can provide a custom suffix.
+   * Defaults to "...".
+   */
+  truncationSuffix?: string;
+  /**
    * limit of number of keys in an object
    * if an object contains more keys than this limit, we would call its toString function directly
    */

--- a/packages/plugins/rrweb-plugin-console-record/src/stringify.ts
+++ b/packages/plugins/rrweb-plugin-console-record/src/stringify.ts
@@ -3,7 +3,7 @@
  *
  */
 
-import type { StringifyOptions } from './index';
+import type { StringifyOptions } from "./index";
 
 /**
  * transfer the node path in Event to string
@@ -74,13 +74,21 @@ function isObjTooDeep(obj: Record<string, unknown>, limit: number): boolean {
   return false;
 }
 
+function truncateString(str: string, options: StringifyOptions) {
+  if (options.stringLengthLimit && str.length > options.stringLengthLimit) {
+    str = `${str.slice(0, options.stringLengthLimit)}${options.truncationSuffix || "..."}`;
+  }
+  return str;
+}
+
 /**
  * stringify any js object
  * @param obj - the object to stringify
+ * @param stringifyOptions - options to alter behavior
  */
 export function stringify(
   obj: unknown,
-  stringifyOptions?: StringifyOptions,
+  stringifyOptions?: Partial<StringifyOptions>,
 ): string {
   const options: StringifyOptions = {
     numOfKeysLimit: 50,
@@ -148,6 +156,9 @@ export function stringify(
           ? value.stack + '\nEnd of stack for Error object'
           : value.name + ': ' + value.message;
       }
+      if (typeof value === 'string') {
+        return truncateString(value, options);
+      }
       return value;
     },
   );
@@ -185,10 +196,6 @@ export function stringify(
    * limit the toString() result according to option
    */
   function toString(_obj: object): string {
-    let str = _obj.toString();
-    if (options.stringLengthLimit && str.length > options.stringLengthLimit) {
-      str = `${str.slice(0, options.stringLengthLimit)}...`;
-    }
-    return str;
+    return truncateString(_obj.toString(), options);
   }
 }

--- a/packages/plugins/rrweb-plugin-console-record/src/stringify.ts
+++ b/packages/plugins/rrweb-plugin-console-record/src/stringify.ts
@@ -3,7 +3,7 @@
  *
  */
 
-import type { StringifyOptions } from "./index";
+import type { StringifyOptions } from './index';
 
 /**
  * transfer the node path in Event to string
@@ -76,7 +76,9 @@ function isObjTooDeep(obj: Record<string, unknown>, limit: number): boolean {
 
 function truncateString(str: string, options: StringifyOptions) {
   if (options.stringLengthLimit && str.length > options.stringLengthLimit) {
-    str = `${str.slice(0, options.stringLengthLimit)}${options.truncationSuffix || "..."}`;
+    str = `${str.slice(0, options.stringLengthLimit)}${
+      options.truncationSuffix || '...'
+    }`;
   }
   return str;
 }

--- a/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
+++ b/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
@@ -6,7 +6,7 @@ import { stringify } from '../src/stringify';
 import { describe, it, expect } from 'vitest';
 
 describe('console record plugin', () => {
-  const aLongString = "a".repeat(100);
+  const aLongString = 'a'.repeat(100);
 
   it('can stringify bigint', () => {
     expect(stringify(BigInt(1))).toEqual('"1n"');
@@ -14,13 +14,20 @@ describe('console record plugin', () => {
 
   it('does not truncate by default', () => {
     expect(stringify(aLongString)).toEqual(`"${aLongString}"`);
-  })
+  });
 
   it('truncates when a length limit is provided', () => {
-    expect(stringify(aLongString, { stringLengthLimit: 10 })).toEqual(`"${"a".repeat(10)}..."`);
-  })
+    expect(stringify(aLongString, { stringLengthLimit: 10 })).toEqual(
+      `"${'a'.repeat(10)}..."`,
+    );
+  });
 
   it('truncates with specified suffix when a length limit is provided', () => {
-    expect(stringify(aLongString, { stringLengthLimit: 10, truncationSuffix: '...[truncated]' })).toEqual(`"${"a".repeat(10)}...[truncated]"`);
-  })
+    expect(
+      stringify(aLongString, {
+        stringLengthLimit: 10,
+        truncationSuffix: '...[truncated]',
+      }),
+    ).toEqual(`"${'a'.repeat(10)}...[truncated]"`);
+  });
 });

--- a/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
+++ b/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
@@ -9,4 +9,16 @@ describe('console record plugin', () => {
   it('can stringify bigint', () => {
     expect(stringify(BigInt(1))).toEqual('"1n"');
   });
+
+  it('does not truncate by default', () => {
+    expect(stringify('a'.repeat(100))).toEqual('"' + "a".repeat(100) + '"');
+  })
+
+  it('truncates when a length limit is provided', () => {
+    expect(stringify('a'.repeat(100), { stringLengthLimit: 10 })).toEqual('"' + "a".repeat(10) + '..."');
+  })
+
+  it('truncates with specified suffix when a length limit is provided', () => {
+    expect(stringify('a'.repeat(100), { stringLengthLimit: 10, truncationSuffix: '...[truncated]' })).toEqual('"' + "a".repeat(10) + '...[truncated]"');
+  })
 });

--- a/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
+++ b/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
@@ -6,19 +6,21 @@ import { stringify } from '../src/stringify';
 import { describe, it, expect } from 'vitest';
 
 describe('console record plugin', () => {
+  const aLongString = "a".repeat(100);
+
   it('can stringify bigint', () => {
     expect(stringify(BigInt(1))).toEqual('"1n"');
   });
 
   it('does not truncate by default', () => {
-    expect(stringify('a'.repeat(100))).toEqual('"' + "a".repeat(100) + '"');
+    expect(stringify(aLongString)).toEqual(`"${aLongString}"`);
   })
 
   it('truncates when a length limit is provided', () => {
-    expect(stringify('a'.repeat(100), { stringLengthLimit: 10 })).toEqual('"' + "a".repeat(10) + '..."');
+    expect(stringify(aLongString, { stringLengthLimit: 10 })).toEqual(`"${"a".repeat(10)}..."`);
   })
 
   it('truncates with specified suffix when a length limit is provided', () => {
-    expect(stringify('a'.repeat(100), { stringLengthLimit: 10, truncationSuffix: '...[truncated]' })).toEqual('"' + "a".repeat(10) + '...[truncated]"');
+    expect(stringify(aLongString, { stringLengthLimit: 10, truncationSuffix: '...[truncated]' })).toEqual(`"${"a".repeat(10)}...[truncated]"`);
   })
 });

--- a/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
+++ b/packages/plugins/rrweb-plugin-console-record/test/stringify.test.ts
@@ -6,7 +6,7 @@ import { stringify } from '../src/stringify';
 import { describe, it, expect } from 'vitest';
 
 describe('console record plugin', () => {
-  const aLongString = 'a'.repeat(100);
+  const aLongString = 'a'.repeat(100) + 'b';
 
   it('can stringify bigint', () => {
     expect(stringify(BigInt(1))).toEqual('"1n"');


### PR DESCRIPTION
when adding https://github.com/rrweb-io/rrweb/pull/1530 I realised that there's code in the console plugin for truncation that we're copying so our users have to download twice (not much but every little helps)

the only difference is we use (and some code expects) a different truncation marker

so, this 

* lets you add a custom truncation marker 
* and actively truncates strings not just objects that are being toString-ed