### PR TITLE
Export `isBlocked` alongside rrweb.record

### DIFF
--- a/packages/record/src/index.ts
+++ b/packages/record/src/index.ts
@@ -1,3 +1,38 @@
-import { record } from 'rrweb';
+import { record as rrwebRecord, type recordOptions } from 'rrweb';
+import { type listenerHandler, type eventWithTime } from '@rrweb/types';
 
-export { record };
+let currentOptions: recordOptions<eventWithTime> | null = null;
+
+function record(
+  options: recordOptions<eventWithTime> = {},
+): listenerHandler | undefined {
+  // save what options were used
+  currentOptions = options;
+  return rrwebRecord(options);
+}
+
+/*
+ * a public version of utils.isBlocked which can be used to check a node after a recording is started
+ */
+function isBlocked(
+  node: Node,
+  options?: recordOptions<eventWithTime>,
+): boolean {
+  if (options === undefined) {
+    if (currentOptions === null) {
+      throw new Error(
+        'Either call after rrweb.record, or else pass in your recording config as the second argument',
+      );
+    } else {
+      options = currentOptions;
+    }
+  }
+  return utils.isBlocked(
+    node,
+    options.blockClass || 'rr-block',
+    options.blockSelector || null,
+    true,
+  );
+}
+
+export { record, isBlocked };


### PR DESCRIPTION
This is a speculative PR as I'm wondering whether we shouldn't be leaving this file well enough alone until we migrate rrweb/record/index.ts on top of it.

Goal here is to expose `isBlocked` to the recording website.  

There's also a question as to whether the entirity of the `record.utils` modulue should be exposed on the record side.