### PR TITLE
fix: Handle exceptions thrown from postcss when calling adaptCssForReplay

### DIFF
--- a/.changeset/angry-turtles-provide.md
+++ b/.changeset/angry-turtles-provide.md
@@ -1,0 +1,5 @@
+---
+"rrweb-snapshot": patch
+---
+
+Handle exceptions thrown from postcss when calling adaptCssForReplay

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -63,7 +63,7 @@ function getTagName(n: elementNode): string {
 export function adaptCssForReplay(cssText: string, cache: BuildCache): string {
   const cachedStyle = cache?.stylesWithHoverClass.get(cssText);
   if (cachedStyle) return cachedStyle;
-  
+
   let result = cssText;
   try {
     const ast: { css: string } = postcss([

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -63,12 +63,18 @@ function getTagName(n: elementNode): string {
 export function adaptCssForReplay(cssText: string, cache: BuildCache): string {
   const cachedStyle = cache?.stylesWithHoverClass.get(cssText);
   if (cachedStyle) return cachedStyle;
+  
+  let result = cssText;
+  try {
+    const ast: { css: string } = postcss([
+      mediaSelectorPlugin,
+      pseudoClassPlugin,
+    ]).process(cssText);
+    result = ast.css;
+  } catch (error) {
+    console.warn('Failed to adapt css for replay', error);
+  }
 
-  const ast: { css: string } = postcss([
-    mediaSelectorPlugin,
-    pseudoClassPlugin,
-  ]).process(cssText);
-  const result = ast.css;
   cache?.stylesWithHoverClass.set(cssText, result);
   return result;
 }

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -3,7 +3,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { beforeEach, describe, expect as _expect, it } from 'vitest';
+import { beforeEach, describe, expect as _expect, it, vi } from 'vitest';
 import {
   adaptCssForReplay,
   buildNodeWithSN,
@@ -11,6 +11,7 @@ import {
 } from '../src/rebuild';
 import { NodeType } from '../src/types';
 import { createMirror, Mirror, normalizeCssString } from '../src/utils';
+import postcss from 'postcss';
 
 const expect = _expect as unknown as {
   <T = unknown>(actual: T): {
@@ -243,5 +244,13 @@ ul li.specified c.\\:hover img {
     expect(adaptCssForReplay(should_not_modify, cache)).toMatchCss(
       should_not_modify,
     );
+  });
+
+  it('handles exceptions from postcss when calling adaptCssForReplay', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // trigger CssSyntaxError by passing invalid css
+    const cssText = 'a{';
+    adaptCssForReplay(cssText, cache);
+    expect(consoleWarnSpy).toHaveBeenLastCalledWith('Failed to adapt css for replay', expect.any(Error));
   });
 });

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -247,10 +247,15 @@ ul li.specified c.\\:hover img {
   });
 
   it('handles exceptions from postcss when calling adaptCssForReplay', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
     // trigger CssSyntaxError by passing invalid css
     const cssText = 'a{';
     adaptCssForReplay(cssText, cache);
-    expect(consoleWarnSpy).toHaveBeenLastCalledWith('Failed to adapt css for replay', expect.any(Error));
+    expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      'Failed to adapt css for replay',
+      expect.any(Error),
+    );
   });
 });


### PR DESCRIPTION
This PR adds a `try/catch` around `postcss().process()` so that exceptions won't cause playback to crash. I was encountering issues where invalid CSS was being passed to `postcss` which would result in [CssSyntaxError](https://postcss.org/api/#csssyntaxerror-column). I am still investigating why invalid CSS is passed to [adaptCssForReplay](https://postcss.org/api/#csssyntaxerror-column) in the first place, but for now this change should at least make sure any exceptions from `postcss` are at least handled and logged. I am currently using `warn` to log the exceptions but am happy to switch that to something else if need be. 

Related discussion in rrweb slack: https://rrweb.slack.com/archives/C01BYDC5C93/p1727975312250899