### PR TITLE
fix: angular wrapped mutationobserver detection

### DIFF
--- a/.changeset/moody-experts-build.md
+++ b/.changeset/moody-experts-build.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/record": patch
+---
+
+correctly detect when angular has wrapped mutation observer"

--- a/.changeset/moody-experts-build.md
+++ b/.changeset/moody-experts-build.md
@@ -2,4 +2,4 @@
 "@rrweb/record": patch
 ---
 
-correctly detect when angular has wrapped mutation observer"
+Correctly detect when angular has wrapped mutation observer

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -80,11 +80,7 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
       ),
   );
 
-  if (
-    isUntaintedAccessors &&
-    isUntaintedMethods &&
-    !isAngularZonePresent()
-  ) {
+  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent()) {
     untaintedBasePrototype[key] = defaultObj.prototype as BasePrototypeCache[T];
     return defaultObj.prototype as BasePrototypeCache[T];
   }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -30,8 +30,8 @@ const untaintedBasePrototype: Partial<BasePrototypeCache> = {};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isFunction = (x: unknown): x is (...args: any[]) => any => {
-    return typeof x === 'function'
-}
+  return typeof x === 'function';
+};
 
 /*
  When angular patches things they pass the above `isNativeFunction` check
@@ -40,12 +40,12 @@ const isFunction = (x: unknown): x is (...args: any[]) => any => {
  doesn't like sharing a mutation observer
  */
 export const isAngularZonePatchedFunction = (x: unknown): boolean => {
-    if (!isFunction(x)) {
-        return false
-    }
-    const prototypeKeys = Object.getOwnPropertyNames(x.prototype || {})
-    return prototypeKeys.some((key) => key.indexOf('__zone'))
-}
+  if (!isFunction(x)) {
+    return false;
+  }
+  const prototypeKeys = Object.getOwnPropertyNames(x.prototype || {});
+  return prototypeKeys.some((key) => key.indexOf('__zone'));
+};
 
 export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   key: T,
@@ -82,7 +82,11 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
       ),
   );
 
-  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePatchedFunction(defaultObj)) {
+  if (
+    isUntaintedAccessors &&
+    isUntaintedMethods &&
+    !isAngularZonePatchedFunction(defaultObj)
+  ) {
     untaintedBasePrototype[key] = defaultObj.prototype as BasePrototypeCache[T];
     return defaultObj.prototype as BasePrototypeCache[T];
   }


### PR DESCRIPTION
When Angular wraps MutationObserver and rrweb tracks mutations you get trapped in a fight with Angular's changedetection and performance suffers. We had multiple reports at posthog of performance degrading with recording active - even to the point of freezing the page entirely

We discovered that the checks for whether to load mutation observer from an iFrame were not correctly detecting the "taint" of angular wrapping the mutation observer.

It turns out detecting whether `Zone` is on the global object is a good enough proxy for Angular having tainted something

(there is some hand-waving here since you can configure zone.js to use a different global object name, but my guess is most people don't, and anyone with enough tech savvy to do that on purpose can also run the recorder outside of the angular zone)

This is confirmed as fixing performance issues in posthog-js v 1.187.1

You can see a wrapped MutationObserver from angular in this screenshot

<img width="523" alt="Screenshot 2024-11-28 at 19 05 39" src="https://github.com/user-attachments/assets/8989aa60-ffd6-4526-9f45-38ff0add524a">

a posthog customer provided this repro https://github.com/typedb/angular-posthog-freeze
with that when session recording started the page froze immediately
with this fix it does not

