### PR TITLE
Fix for [Bug]: hidden inputs are not masked when maskAllInputs is enabled #1609

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1284,6 +1284,7 @@ function snapshot(
           textarea: true,
           select: true,
           password: true,
+          hidden: true,
         }
       : maskAllInputs === false
       ? {

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -47,6 +47,7 @@ export type MaskInputOptions = Partial<{
   textarea: boolean;
   select: boolean;
   password: boolean;
+  hidden: boolean;
 }>;
 
 export type SlimDOMOptions = Partial<{

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -155,6 +155,7 @@ function record<T = eventWithTime>(
           textarea: true,
           select: true,
           password: true,
+          hidden: true,
         }
       : _maskInputOptions !== undefined
       ? _maskInputOptions

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -2952,8 +2952,23 @@ exports[`record integration tests > can record form interactions 1`] = `
                       },
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"textContent\\": \\"\\\\n      \\",
                         \\"id\\": 63
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"input\\",
+                        \\"attributes\\": {
+                          \\"type\\": \\"hidden\\",
+                          \\"value\\": \\"123456\\"
+                        },
+                        \\"childNodes\\": [],
+                        \\"id\\": 64
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"id\\": 65
                       }
                     ],
                     \\"id\\": 18
@@ -2961,7 +2976,7 @@ exports[`record integration tests > can record form interactions 1`] = `
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 64
+                    \\"id\\": 66
                   },
                   {
                     \\"type\\": 2,
@@ -2971,15 +2986,15 @@ exports[`record integration tests > can record form interactions 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 66
+                        \\"id\\": 68
                       }
                     ],
-                    \\"id\\": 65
+                    \\"id\\": 67
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 67
+                    \\"id\\": 69
                   }
                 ],
                 \\"id\\": 16
@@ -4936,8 +4951,23 @@ exports[`record integration tests > can use maskInputOptions to configure which 
                       },
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"textContent\\": \\"\\\\n      \\",
                         \\"id\\": 63
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"input\\",
+                        \\"attributes\\": {
+                          \\"type\\": \\"hidden\\",
+                          \\"value\\": \\"123456\\"
+                        },
+                        \\"childNodes\\": [],
+                        \\"id\\": 64
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"id\\": 65
                       }
                     ],
                     \\"id\\": 18
@@ -4945,7 +4975,7 @@ exports[`record integration tests > can use maskInputOptions to configure which 
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 64
+                    \\"id\\": 66
                   },
                   {
                     \\"type\\": 2,
@@ -4955,15 +4985,15 @@ exports[`record integration tests > can use maskInputOptions to configure which 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 66
+                        \\"id\\": 68
                       }
                     ],
-                    \\"id\\": 65
+                    \\"id\\": 67
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 67
+                    \\"id\\": 69
                   }
                 ],
                 \\"id\\": 16
@@ -6763,8 +6793,23 @@ exports[`record integration tests > should mask inputs via function call 1`] = `
                       },
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"textContent\\": \\"\\\\n      \\",
                         \\"id\\": 63
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"input\\",
+                        \\"attributes\\": {
+                          \\"type\\": \\"hidden\\",
+                          \\"value\\": \\"******\\"
+                        },
+                        \\"childNodes\\": [],
+                        \\"id\\": 64
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"id\\": 65
                       }
                     ],
                     \\"id\\": 18
@@ -6772,7 +6817,7 @@ exports[`record integration tests > should mask inputs via function call 1`] = `
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 64
+                    \\"id\\": 66
                   },
                   {
                     \\"type\\": 2,
@@ -6782,15 +6827,15 @@ exports[`record integration tests > should mask inputs via function call 1`] = `
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 66
+                        \\"id\\": 68
                       }
                     ],
-                    \\"id\\": 65
+                    \\"id\\": 67
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 67
+                    \\"id\\": 69
                   }
                 ],
                 \\"id\\": 16
@@ -10466,8 +10511,23 @@ exports[`record integration tests > should not record input values if maskAllInp
                       },
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"textContent\\": \\"\\\\n      \\",
                         \\"id\\": 63
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"input\\",
+                        \\"attributes\\": {
+                          \\"type\\": \\"hidden\\",
+                          \\"value\\": \\"******\\"
+                        },
+                        \\"childNodes\\": [],
+                        \\"id\\": 64
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"id\\": 65
                       }
                     ],
                     \\"id\\": 18
@@ -10475,7 +10535,7 @@ exports[`record integration tests > should not record input values if maskAllInp
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 64
+                    \\"id\\": 66
                   },
                   {
                     \\"type\\": 2,
@@ -10485,15 +10545,15 @@ exports[`record integration tests > should not record input values if maskAllInp
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 66
+                        \\"id\\": 68
                       }
                     ],
-                    \\"id\\": 65
+                    \\"id\\": 67
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 67
+                    \\"id\\": 69
                   }
                 ],
                 \\"id\\": 16
@@ -13580,8 +13640,23 @@ exports[`record integration tests > should record input userTriggered values if 
                       },
                       {
                         \\"type\\": 3,
-                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"textContent\\": \\"\\\\n      \\",
                         \\"id\\": 63
+                      },
+                      {
+                        \\"type\\": 2,
+                        \\"tagName\\": \\"input\\",
+                        \\"attributes\\": {
+                          \\"type\\": \\"hidden\\",
+                          \\"value\\": \\"123456\\"
+                        },
+                        \\"childNodes\\": [],
+                        \\"id\\": 64
+                      },
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"\\\\n    \\",
+                        \\"id\\": 65
                       }
                     ],
                     \\"id\\": 18
@@ -13589,7 +13664,7 @@ exports[`record integration tests > should record input userTriggered values if 
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n  \\\\n    \\",
-                    \\"id\\": 64
+                    \\"id\\": 66
                   },
                   {
                     \\"type\\": 2,
@@ -13599,15 +13674,15 @@ exports[`record integration tests > should record input userTriggered values if 
                       {
                         \\"type\\": 3,
                         \\"textContent\\": \\"SCRIPT_PLACEHOLDER\\",
-                        \\"id\\": 66
+                        \\"id\\": 68
                       }
                     ],
-                    \\"id\\": 65
+                    \\"id\\": 67
                   },
                   {
                     \\"type\\": 3,
                     \\"textContent\\": \\"\\\\n    \\\\n    \\\\n\\\\n\\",
-                    \\"id\\": 67
+                    \\"id\\": 69
                   }
                 ],
                 \\"id\\": 16

--- a/packages/rrweb/test/html/form.html
+++ b/packages/rrweb/test/html/form.html
@@ -34,6 +34,7 @@
         <input type="password" />
       </label>
       <textarea>pre value</textarea>
+      <input type="hidden" value="123456">
     </form>
   </body>
 </html>

--- a/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
+++ b/packages/rrweb/test/record/__snapshots__/cross-origin-iframes.test.ts.snap
@@ -1438,9 +1438,26 @@ exports[`cross origin iframes > form.html > should map input events correctly 1`
                           },
                           {
                             \\"type\\": 3,
-                            \\"textContent\\": \\"\\\\n    \\",
+                            \\"textContent\\": \\"\\\\n      \\",
                             \\"rootId\\": 11,
                             \\"id\\": 75
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"input\\",
+                            \\"attributes\\": {
+                              \\"type\\": \\"hidden\\",
+                              \\"value\\": \\"123456\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"rootId\\": 11,
+                            \\"id\\": 76
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 77
                           }
                         ],
                         \\"rootId\\": 11,
@@ -1450,7 +1467,7 @@ exports[`cross origin iframes > form.html > should map input events correctly 1`
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
                         \\"rootId\\": 11,
-                        \\"id\\": 76
+                        \\"id\\": 78
                       }
                     ],
                     \\"rootId\\": 11,
@@ -2451,9 +2468,26 @@ exports[`cross origin iframes > form.html > should map scroll events correctly 1
                           },
                           {
                             \\"type\\": 3,
-                            \\"textContent\\": \\"\\\\n    \\",
+                            \\"textContent\\": \\"\\\\n      \\",
                             \\"rootId\\": 11,
                             \\"id\\": 75
+                          },
+                          {
+                            \\"type\\": 2,
+                            \\"tagName\\": \\"input\\",
+                            \\"attributes\\": {
+                              \\"type\\": \\"hidden\\",
+                              \\"value\\": \\"123456\\"
+                            },
+                            \\"childNodes\\": [],
+                            \\"rootId\\": 11,
+                            \\"id\\": 76
+                          },
+                          {
+                            \\"type\\": 3,
+                            \\"textContent\\": \\"\\\\n    \\",
+                            \\"rootId\\": 11,
+                            \\"id\\": 77
                           }
                         ],
                         \\"rootId\\": 11,
@@ -2463,7 +2497,7 @@ exports[`cross origin iframes > form.html > should map scroll events correctly 1
                         \\"type\\": 3,
                         \\"textContent\\": \\"\\\\n  \\\\n\\\\n\\",
                         \\"rootId\\": 11,
-                        \\"id\\": 76
+                        \\"id\\": 78
                       }
                     ],
                     \\"rootId\\": 11,


### PR DESCRIPTION
Fix for https://github.com/rrweb-io/rrweb/issues/1609

Extend `maskAllInputs` options to include hidden input.
