### PR TITLE
fix(snapshot): Change to ignore all `link[rel="modulepreload"]` (#228)

### DIFF
--- a/.changeset/short-hounds-confess.md
+++ b/.changeset/short-hounds-confess.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Change to ignore all link[rel="modulepreload"] instead of including only those with `as="script"`

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -269,7 +269,7 @@ function buildNode(
             continue;
           } else if (
             tagName === 'link' &&
-            (n.attributes.rel === 'preload' ||
+            ((n.attributes.rel === 'preload' && n.attributes.as === 'script') ||
               n.attributes.rel === 'modulepreload')
           ) {
             // ignore

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -7,7 +7,12 @@ import {
   type legacyAttributes,
 } from '@rrweb/types';
 import { type tagMap, type BuildCache } from './types';
-import { isElement, Mirror, isNodeMetaEqual } from './utils';
+import {
+  isElement,
+  Mirror,
+  isNodeMetaEqual,
+  extractFileExtension,
+} from './utils';
 import postcss from 'postcss';
 
 const tagMap: tagMap = {
@@ -265,15 +270,14 @@ function buildNode(
           } else if (
             tagName === 'link' &&
             (n.attributes.rel === 'preload' ||
-              n.attributes.rel === 'modulepreload') &&
-            n.attributes.as === 'script'
+              n.attributes.rel === 'modulepreload')
           ) {
             // ignore
           } else if (
             tagName === 'link' &&
             n.attributes.rel === 'prefetch' &&
             typeof n.attributes.href === 'string' &&
-            n.attributes.href.endsWith('.js')
+            extractFileExtension(n.attributes.href) === 'js'
           ) {
             // ignore
           } else if (

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -819,7 +819,7 @@ function slimDOMExcluded(
       (sn.tagName === 'script' ||
         // (module)preload link
         (sn.tagName === 'link' &&
-          (sn.attributes.rel === 'preload' ||
+          ((sn.attributes.rel === 'preload' && sn.attributes.as === 'script') ||
             sn.attributes.rel === 'modulepreload')) ||
         // prefetch link
         (sn.tagName === 'link' &&

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -820,8 +820,7 @@ function slimDOMExcluded(
         // (module)preload link
         (sn.tagName === 'link' &&
           (sn.attributes.rel === 'preload' ||
-            sn.attributes.rel === 'modulepreload') &&
-          sn.attributes.as === 'script') ||
+            sn.attributes.rel === 'modulepreload')) ||
         // prefetch link
         (sn.tagName === 'link' &&
           sn.attributes.rel === 'prefetch' &&


### PR DESCRIPTION
... removes requirement to have `as="script"` attribute as it is optional (also `modulepreload` implies script).

Also fixes `prefetch` to extract file extension instead of checking end of string since there can be URL parameters.