### PR TITLE
Fix/workaround iframe parent

### DIFF
--- a/.changeset/brave-planes-begin.md
+++ b/.changeset/brave-planes-begin.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Workaround for avoid the replayer from crashing when there's an error when trying to attach a document to a non-iframe

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1516,7 +1516,7 @@ export class Replayer {
         console.warn(
           '[Replayer] Skipping invalid document append to a non-iframe parent.',
           mutation,
-          parent
+          parent,
         );
         return;
       }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -173,7 +173,7 @@ export class Replayer {
     | styleSheetRuleData
     | styleDeclarationData
   )[] = [];
-  
+
   // Similar to the reason for constructedStyleMutations.
   private adoptedStyleSheets: adoptedStyleSheetData[] = [];
 

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -173,7 +173,7 @@ export class Replayer {
     | styleSheetRuleData
     | styleDeclarationData
   )[] = [];
-
+  
   // Similar to the reason for constructedStyleMutations.
   private adoptedStyleSheets: adoptedStyleSheetData[] = [];
 
@@ -1507,6 +1507,18 @@ export class Replayer {
           return this.newDocumentQueue.push(mutation);
         }
         return queue.push(mutation);
+      }
+
+      if (
+        mutation.node.type === NodeType.Document &&
+        parent?.nodeName?.toLowerCase() !== 'iframe'
+      ) {
+        console.warn(
+          '[Replayer] Skipping invalid document append to a non-iframe parent.',
+          mutation,
+          parent
+        );
+        return;
       }
 
       if (mutation.node.isShadow) {


### PR DESCRIPTION
This is a workaround to avoid the replayer crashing when there's an error when trying to attach a #document to a non-iframe.

The replayer has a bug in which all the recording looks blank. This has been reported a couple of times:
https://github.com/rrweb-io/rrweb/issues/1414
https://github.com/rrweb-io/rrweb/issues/1619

It is happening because the replayer is trying to appendChild(#document) onto a non-iframe. The workaround prevents it from doing it and prevents the replay from going blank. Still, this is a workaround and further investigation is needed to check if the event is corrupted or if there's a mismatch in the order 






 