### PR TITLE
fix: untainted prototype access in Angular

### DIFF
--- a/.changeset/tall-poems-develop.md
+++ b/.changeset/tall-poems-develop.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/utils": patch
+---
+
+safer access to iframes in safari for untainted prototypes

--- a/.changeset/tall-poems-develop.md
+++ b/.changeset/tall-poems-develop.md
@@ -2,4 +2,4 @@
 "@rrweb/utils": patch
 ---
 
-safer access to iframes in safari for untainted prototypes
+load unpatched versions of things from Angular zone when present

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ESLint Annotation
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: eslint_report.json
       - name: Annotate Code Linting Results

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -80,9 +80,11 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
       ),
   );
 
-  const isUntainted = isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent();
+  const isUntainted =
+    isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent();
   // we're going to default to what we do have
-  let impl: BasePrototypeCache[T] = defaultObj.prototype as BasePrototypeCache[T]
+  let impl: BasePrototypeCache[T] =
+    defaultObj.prototype as BasePrototypeCache[T];
   // but if it is tainted
   if (!isUntainted) {
     // try to load a fresh copy from a sandbox iframe
@@ -96,7 +98,7 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
         const candidate = (win as any)[key].prototype as BasePrototypeCache[T];
         if (candidate) {
-          impl = candidate
+          impl = candidate;
         }
       }
     } finally {
@@ -107,7 +109,7 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   }
 
   untaintedBasePrototype[key] = impl;
-    return impl
+  return impl;
 }
 
 const untaintedAccessorCache: Record<

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -66,7 +66,9 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   if (untaintedBasePrototype[key])
     return untaintedBasePrototype[key] as BasePrototypeCache[T];
 
-  const defaultObj = angularZoneUnpatchedAlternative(key) || globalThis[key] as TypeofPrototypeOwner;
+  const defaultObj =
+    angularZoneUnpatchedAlternative(key) ||
+    (globalThis[key] as TypeofPrototypeOwner);
   const defaultPrototype = defaultObj.prototype as BasePrototypeCache[T];
 
   // use list of testable accessors to check if the prototype is tainted
@@ -95,8 +97,7 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
       ),
   );
 
-  const isUntainted =
-    isUntaintedAccessors && isUntaintedMethods;
+  const isUntainted = isUntaintedAccessors && isUntaintedMethods;
   // we're going to default to what we do have
   let impl: BasePrototypeCache[T] =
     defaultObj.prototype as BasePrototypeCache[T];


### PR DESCRIPTION
we're seeing multiple reports of issues with the mutation observer in Safari

this is most often in relation to Angular apps 

considering we recently improved detection of need to load untainted observers when using Angular

when testing locally I can always see that Safari gives a mutation observer from an iframe - but I never see that mutation observer notify of any mutations. 

this PR moves back to the approach that it turns out rrweb had in V1

The Angular zone stores unpatched things that it has patched in a discoverable location. This checks for that and if it is present uses it. 

This means that in practice Angular won't trigger safari to load a mutation observer from an iframe and so (in testing) reliably captures mutations in safari for angular apps