### PR TITLE
readme: Update CDN link for replayer

### DIFF
--- a/packages/rrweb-player/README.md
+++ b/packages/rrweb-player/README.md
@@ -19,7 +19,7 @@ rrweb-player can also be included with `<script>`：
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/style.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/index.umd.cjs"></script>
+<script src="https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/index.js"></script>
 ```
 
 Or installed by using NPM：


### PR DESCRIPTION
There is no file under: https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/index.umd.cjs

but there is for: https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/index.js