### PR TITLE
fix for loading iframes with custom web components in chrome

### DIFF
--- a/.changeset/nice-planes-dress.md
+++ b/.changeset/nice-planes-dress.md
@@ -1,0 +1,5 @@
+---
+"rrweb-snapshot": minor
+---
+
+fix for iframe loads in chrome - specifically iframes with custom web components

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -308,6 +308,7 @@ export function needMaskingText(
 }
 
 // https://stackoverflow.com/a/36155560
+// https://stackoverflow.com/a/69694808 (for handling blank frames in chrome)
 function onceIframeLoaded(
   iframeEl: HTMLIFrameElement,
   listener: () => unknown,
@@ -342,16 +343,15 @@ function onceIframeLoaded(
   }
   // check blank frame for Chrome
   const blankUrl = 'about:blank';
-  if (
-    win.location.href !== blankUrl ||
-    iframeEl.src === blankUrl ||
-    iframeEl.src === ''
+  if ((iframeEl.src === blankUrl ||
+    (iframeEl.src !== blankUrl && win.location.href !== blankUrl)) &&
+    readyState === 'complete'
   ) {
     // iframe was already loaded, make sure we wait to trigger the listener
     // till _after_ the mutation that found this iframe has had time to process
     setTimeout(listener, 0);
 
-    return iframeEl.addEventListener('load', listener); // keep listing for future loads
+    return iframeEl.addEventListener('load', listener); // keep listening for future loads
   }
   // use default listener
   iframeEl.addEventListener('load', listener);

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -343,8 +343,9 @@ function onceIframeLoaded(
   }
   // check blank frame for Chrome
   const blankUrl = 'about:blank';
-  if ((iframeEl.src === blankUrl ||
-    (iframeEl.src !== blankUrl && win.location.href !== blankUrl)) &&
+  if (
+    (iframeEl.src === blankUrl ||
+      (iframeEl.src !== blankUrl && win.location.href !== blankUrl)) &&
     readyState === 'complete'
   ) {
     // iframe was already loaded, make sure we wait to trigger the listener


### PR DESCRIPTION
In chrome, custom web components in iframes are not loading when the script for creating the custom element is in the body tag of the iframe instead of the head tag.

Issue:

https://github.com/user-attachments/assets/5466b4ce-41d0-45ef-9e93-c99d471b0336


Fix:

https://github.com/user-attachments/assets/485e9c45-6526-4525-9747-fba4e7f0f6bd

