### PR TITLE
fix: address security risks in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Tests
+    permissions: read-all
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Tests
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: lts/*
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -5,7 +5,8 @@ on: [push, pull_request_target]
 jobs:
   eslint_check_upload:
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read
     name: ESLint Check and Report Upload
 
     steps:
@@ -55,7 +56,8 @@ jobs:
   prettier_check:
     # In the forked PR, it's hard to format code and push to the branch directly, so the action only check the format correctness.
     if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != 'rrweb-io/rrweb'
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     name: Format Check
     steps:

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -5,6 +5,7 @@ on: [push, pull_request_target]
 jobs:
   eslint_check_upload:
     runs-on: ubuntu-latest
+    permissions: read-all
     name: ESLint Check and Report Upload
 
     steps:
@@ -36,6 +37,8 @@ jobs:
   annotation:
     # Skip the annotation action in push events
     if: github.event_name == 'pull_request_target'
+    permissions:
+      checks: write
     needs: eslint_check_upload
     runs-on: ubuntu-latest
     name: ESLint Annotation
@@ -52,6 +55,7 @@ jobs:
   prettier_check:
     # In the forked PR, it's hard to format code and push to the branch directly, so the action only check the format correctness.
     if: github.event_name != 'push' && github.event.pull_request.head.repo.full_name != 'rrweb-io/rrweb'
+    permissions: read-all
     runs-on: ubuntu-latest
     name: Format Check
     steps:
@@ -73,6 +77,8 @@ jobs:
     # Skip the format code action in forked PRs
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'rrweb-io/rrweb'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     name: Format Code
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The recent [pull request](https://github.com/rrweb-io/rrweb/pull/1646) mentions [I don't understand what dangers there might be with cache: yarn but I guess we'll find out!](https://github.com/rrweb-io/rrweb/pull/1646#issuecomment-2634649223).

It turns out, this adds a lot of danger. An attacker can compromise the NPM token and the Chrome extension release secrets fairly easily by leveraging a technique known as GitHub Actions cache poisoning.

This happens because the `style-check.yml` workflow runs on `pull_request_target`. I've updated the workflows to do a few things:

* Remove cache consumption in release job
* Tighten `GITHUB_TOKEN` permissions in other workflows that consume the cache

Ideally, you should move away from running user-controlled code from forks on `pull_request_target`, but that requires a more substantial overhaul to the repository's CI. The changes here will make it impossible to directly compromise the release secrets.

Some background on cache poisoning:

* https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/
* https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/