### PR TITLE
Safer Media play/pause when target is not in fact a MediaElement

### DIFF
--- a/.changeset/gorgeous-eels-rescue.md
+++ b/.changeset/gorgeous-eels-rescue.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Safer Media play/pause when target is not in fact a MediaElement

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -1027,6 +1027,7 @@ function initMediaInteractionObserver({
         const target = getEventTarget(event);
         if (
           !target ||
+          !(target instanceof HTMLMediaElement) ||
           isBlocked(target as Node, blockClass, blockSelector, true)
         ) {
           return;

--- a/packages/rrweb/src/replay/media/index.ts
+++ b/packages/rrweb/src/replay/media/index.ts
@@ -54,7 +54,14 @@ export class MediaManager {
     this.mediaMap.forEach((_mediaState, target) => {
       this.syncTargetWithState(target);
       if (options.pause) {
-        target.pause();
+        try {
+          target.pause();
+        } catch (error) {
+          this.warn(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
+            `Failed to sync media element: ${error.message || error}`,
+          );
+        }
       }
     });
   }
@@ -104,7 +111,14 @@ export class MediaManager {
 
       target.currentTime = seekToTime;
     } else {
-      target.pause();
+      try {
+        target.pause();
+      } catch (error) {
+        this.warn(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
+          `Failed to pause during seek: ${error.message || error}`,
+        );
+      }
       target.currentTime = mediaState.currentTimeAtLastInteraction;
     }
   }


### PR DESCRIPTION
Squarespace dispatches media events on non-media elements. These cause an error upon replay.

Found in the wild at https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/scripts/416.b27e99ad04cb589ced2b.js