### PR TITLE
Adds configuration of postmessage target origin for security purposes

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -99,6 +99,7 @@ function record<T = eventWithTime>(
     keepIframeSrcFn = () => false,
     ignoreCSSAttributes = new Set([]),
     errorHandler,
+    postMessageTargetOrigin = '*',
   } = options;
 
   registerErrorHandler(errorHandler);
@@ -226,7 +227,7 @@ function record<T = eventWithTime>(
         origin: window.location.origin,
         isCheckout,
       };
-      window.parent.postMessage(message, '*');
+      window.parent.postMessage(message, postMessageTargetOrigin);
     }
 
     if (e.type === EventType.FullSnapshot) {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -74,6 +74,7 @@ export type recordOptions<T> = {
   mousemoveWait?: number;
   keepIframeSrcFn?: KeepIframeSrcFn;
   errorHandler?: ErrorHandler;
+  postMessageTargetOrigin?: string;
 };
 
 export type observerParam = {


### PR DESCRIPTION
When recordCrossOriginIframes is true, instead of just posting messages to a target origin of '\*', allow users to specify a new config option postMessageTargetOrigin which is used in place of '\*', defaults to '\*'