### PR TITLE
fix: prevent unnecessary error throwing in stringifyRule

### DIFF
--- a/.changeset/pink-queens-shave.md
+++ b/.changeset/pink-queens-shave.md
@@ -1,0 +1,5 @@
+---
+"rrweb-snapshot": patch
+---
+
+Prevent unnecessary error throwing in stringifyRule that was nullifying csstext of style elements when serializing nodes

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -144,7 +144,7 @@ export function stringifyRule(rule: CSSRule, sheetHref: string | null): string {
     } catch (error) {
       importStringified = rule.cssText;
     }
-    if (rule.styleSheet.href) {
+    if (rule?.styleSheet?.href) {
       // url()s within the imported stylesheet are relative to _that_ sheet's href
       return absolutifyURLs(importStringified, rule.styleSheet.href);
     }


### PR DESCRIPTION
When a css import rule was being stringified (in `stringifyRule`) and the rule didn't have a `styleSheet` property at time of processing, an error would be thrown and passed up to `stringifyStyleSheet` where it was caught. Once caught, it would set `null` for the `attributes._cssText` property of the serializedNode. When watching the replay, these style elements would be empty instead of populated with the correct cssText.