### PR TITLE
fix: CI hang forever in the yarn [4/4] Building fresh packages...

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: PUPPETEER_DOWNLOAD_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public" yarn install --frozen-lockfile
 
       - name: Build Project
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build:all
@@ -39,10 +39,12 @@ jobs:
       - name: Check bundle sizes
         uses: preactjs/compressed-size-action@v2
         with:
-          install-script: "yarn install --frozen-lockfile"
-          build-script: "build:all"
-          compression: "none"
-          pattern: "**/dist/*.{js,cjs,mjs,css}"
+          install-script: 'yarn install --frozen-lockfile'
+          build-script: 'build:all'
+          compression: 'none'
+          pattern: '**/dist/*.{js,cjs,mjs,css}'
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Upload diff images to GitHub
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: lts/*
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
       - name: Build Packages
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build:all
       - name: Eslint Check
@@ -71,7 +71,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
       - name: Prettier Check
         run: yarn prettier --check '**/*.{ts,md}'
 
@@ -93,7 +93,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: PUPPETEER_SKIP_DOWNLOAD=true yarn install --frozen-lockfile
       - name: Prettify Code
         run: yarn prettier --write '**/*.{ts,md}'
       - name: Commit Changes


### PR DESCRIPTION
I'm not exactly sure why the CI is stuck at yarn [4/4] Building fresh packages step forever now but not before
<img width="892" alt="image" src="https://github.com/user-attachments/assets/2f4cb808-c830-4f72-a226-76690ccd694d" />

After I apply the workaround in https://github.com/puppeteer/puppeteer/issues/12094#issuecomment-2079409511, the CI starts to work.