### PR TITLE
Don't allow video autoplay to automatically unfreeze page

### DIFF
--- a/.changeset/chilly-jeans-fail.md
+++ b/.changeset/chilly-jeans-fail.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Don't allow video/audio autoplay to automatically unfreeze page

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -209,15 +209,16 @@ function record<T = eventWithTime>(
       e.type !== EventType.FullSnapshot &&
       !(
         e.type === EventType.IncrementalSnapshot &&
-          [IncrementalSource.Mutation,
-           IncrementalSource.MediaInteraction, // often automatic e.g. background video loop
-           IncrementalSource.StyleSheetRule,
-           IncrementalSource.CanvasMutation,
-           IncrementalSource.Font,
-           IncrementalSource.Log,
-           IncrementalSource.StyleDeclaration,
-           IncrementalSource.AdoptedStyleSheet,
-          ].includes(e.data.source)
+        [
+          IncrementalSource.Mutation,
+          IncrementalSource.MediaInteraction, // often automatic e.g. background video loop
+          IncrementalSource.StyleSheetRule,
+          IncrementalSource.CanvasMutation,
+          IncrementalSource.Font,
+          IncrementalSource.Log,
+          IncrementalSource.StyleDeclaration,
+          IncrementalSource.AdoptedStyleSheet,
+        ].includes(e.data.source)
       )
     ) {
       // we've got a user initiated event so first we need to apply

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -209,7 +209,15 @@ function record<T = eventWithTime>(
       e.type !== EventType.FullSnapshot &&
       !(
         e.type === EventType.IncrementalSnapshot &&
-        e.data.source === IncrementalSource.Mutation
+          [IncrementalSource.Mutation,
+           IncrementalSource.MediaInteraction, // often automatic e.g. background video loop
+           IncrementalSource.StyleSheetRule,
+           IncrementalSource.CanvasMutation,
+           IncrementalSource.Font,
+           IncrementalSource.Log,
+           IncrementalSource.StyleDeclaration,
+           IncrementalSource.AdoptedStyleSheet,
+          ].includes(e.data.source)
       )
     ) {
       // we've got a user initiated event so first we need to apply


### PR DESCRIPTION
If it's a 'real' playback, there should be a mount or a keyboard event which will serve to unfreeze the page. Also add other non-user events to the list (we really should have an `isUserEvent` function)