### PR TITLE
fix: move a console log to the warn method so it can be suppressed 

### DIFF
--- a/.changeset/tiny-singers-pump.md
+++ b/.changeset/tiny-singers-pump.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Use the provided logger from player config instead of directly calling console.warn"

--- a/.changeset/tiny-singers-pump.md
+++ b/.changeset/tiny-singers-pump.md
@@ -3,4 +3,4 @@
 "rrweb": patch
 ---
 
-Use the provided logger from player config instead of directly calling console.warn"
+Use the provided logger from player config instead of directly calling console.warn

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -432,9 +432,6 @@ function buildNode(
       }
       return doc.createTextNode(n.textContent);
     case NodeType.CDATA:
-      if (n.textContent.trim() === '') {
-        return null;
-      }
       return doc.createCDATASection(n.textContent);
     case NodeType.Comment:
       return doc.createComment(n.textContent);

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -432,6 +432,9 @@ function buildNode(
       }
       return doc.createTextNode(n.textContent);
     case NodeType.CDATA:
+      if (n.textContent.trim() === '') {
+        return null;
+      }
       return doc.createCDATASection(n.textContent);
     case NodeType.Comment:
       return doc.createComment(n.textContent);

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -263,7 +263,7 @@ export class Replayer {
               this.virtualDom.mirror,
             );
           } catch (e) {
-            console.warn(e);
+            this.warn(e);
           }
 
         this.virtualDom.destroyTree();


### PR DESCRIPTION
noticed this while doing something else
this call to `console.warn` is direct so it doesn't obey the provided config
let's make it play nicely