### PR TITLE
fix (rrdom): Fix edge case where oldChild can become detach causing the recursive function to end early

### DIFF
--- a/.changeset/new-plants-exercise.md
+++ b/.changeset/new-plants-exercise.md
@@ -1,0 +1,5 @@
+---
+"rrdom": patch
+---
+
+Fix early termination of recursive loop in diffChilren when a node mismatch is found

--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -525,6 +525,24 @@ function diffChildren(
   let oldChild = oldTree.firstChild;
   let newChild = newTree.firstChild;
   while (oldChild !== null && newChild !== null) {
+    // For mismatched node types (e.g., Element vs Text), we create a new node and insert it before the old one.
+    // This preserves the oldChild reference needed for the recursive diff loop, which would break if we replaced the node directly.
+    const isMismatch = !sameNodeType(oldChild, newChild);
+
+    if (isMismatch) {
+      const newNode = createOrGetNode(newChild, replayer.mirror, rrnodeMirror);
+
+      try {
+        oldTree.insertBefore(newNode, oldChild);
+      } catch (e) {
+        console.warn(e);
+      }
+
+      diff(newNode, newChild, replayer, rrnodeMirror);
+      newChild = newChild.nextSibling;
+      continue;
+    }
+
     diff(oldChild, newChild, replayer, rrnodeMirror);
     oldChild = oldChild.nextSibling;
     newChild = newChild.nextSibling;


### PR DESCRIPTION
Fix an edge case in diffChildren: when we replace an old child via [oldTree.parentNode?.replaceChild(calibratedOldTree, oldTree);](https://github.com/rrweb-io/rrweb/blob/4db9782d1278a2b7235ed48162ccedf0e0952113/packages/rrdom/src/diff.ts#L145C1-L145C66) its nextSibling pointer is lost, causing the diff loop to exit early and inadvertently remove subsequent elements and styles.