### PR TITLE
Add emitFromIframe option to support iframe in iframe

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -89,6 +89,7 @@ function record<T = eventWithTime>(
     recordDOM = true,
     recordCanvas = false,
     recordCrossOriginIframes = false,
+    emitFromIframe = false,
     recordAfter = options.recordAfter === 'DOMContentLoaded'
       ? options.recordAfter
       : 'load',
@@ -103,7 +104,9 @@ function record<T = eventWithTime>(
 
   registerErrorHandler(errorHandler);
 
-  const inEmittingFrame = recordCrossOriginIframes
+  const inEmittingFrame = emitFromIframe
+    ? true
+    : recordCrossOriginIframes
     ? window.parent === window
     : true;
 

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -65,6 +65,7 @@ export type recordOptions<T> = {
   recordDOM?: boolean;
   recordCanvas?: boolean;
   recordCrossOriginIframes?: boolean;
+  emitFromIframe?: boolean;
   recordAfter?: 'DOMContentLoaded' | 'load';
   userTriggeredOnInput?: boolean;
   collectFonts?: boolean;


### PR DESCRIPTION
Thank you for maintaining rrweb and supporting the modern web dev tooling ecosystem

## Description
This PR introduces a new `emitFromIframe` boolean in rrweb's `recordOptions` that allows iframe-in-iframe monitoring when hosted in a parent that doesn't have rrweb.

## Problem
Consider a "host website" (which doesn't have rrweb) which hosts a "parent iframe" (which has rrweb) which nests another "child iframe" (which also has rrweb).

Currently, the `recordCrossOriginIframes` option would need to be enabled in rrweb in both parent and child iframes in order to monitor iframe-in-iframe traffic correctly. However we cannot monitor the parent iframe as the `recordCrossOriginIframes` option is ALSO used to pass all events to the host website since the parent iframe is not the top level page. i.e: The `recordCrossOriginIframes` is used for both receiving events from a child iframe and passing those events without recording, to the host website.

Thus the parent iframe will emit events to the host website since `recordCrossOriginIframes` is true and the host website will ignore these events as it doesn't have rrweb.

## Solution

Adding a `emitFromIframe` option allows the parent iframe to record events directly without passing events to the host website while using `recordCrossOriginIframes` to collect events from child iframes.

## Status
This is a proof-of-concept but it should already work in production. I would like to get feedback on whether this is something that aligns with the rrweb team's roadmap before investing more effort in adding documentation and tests.