### PR TITLE
Rrdom to html

### DIFF
--- a/packages/rrdom/src/escape.ts
+++ b/packages/rrdom/src/escape.ts
@@ -1,0 +1,16 @@
+// for serializing a virtual DOM to html
+
+function escapeHtmlText(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/ /g, '&nbsp;') // unicode version is correct, but output the html escape syntax for consistency with what chrome outputs
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeHtmlAttr(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/ /g, '&nbsp;') // unicode version is correct, but output the html escape syntax for consistency with what chrome outputs
+    .replace(/"/g, '&quot;');
+}

--- a/packages/rrweb-cutter/src/cut-session.ts
+++ b/packages/rrweb-cutter/src/cut-session.ts
@@ -1,8 +1,7 @@
-import { NodeType } from 'rrweb-snapshot';
-import {
+import { NodeType, MediaInteractions } from '@rrweb/types';
+import type {
   adoptedStyleSheetData,
   eventWithTime,
-  MediaInteractions,
   styleDeclarationData,
   styleSheetRuleData,
 } from '@rrweb/types';
@@ -15,7 +14,7 @@ import {
 } from 'rrdom';
 import type { IRRNode, RRElement } from 'rrdom';
 import { IncrementalSource, EventType, SyncReplayer } from 'rrweb';
-import { playerConfig } from 'rrweb/typings/types';
+import type { playerConfig } from '@rrweb/replay';
 import cloneDeep from 'lodash.clonedeep';
 import snapshot from './snapshot';
 export type CutterConfig = {

--- a/packages/rrweb-cutter/src/prune-branches.ts
+++ b/packages/rrweb-cutter/src/prune-branches.ts
@@ -1,5 +1,5 @@
-import { serializedNodeWithId } from 'rrweb-snapshot';
 import type {
+  serializedNodeWithId,
   addedNodeMutation,
   eventWithTime,
   mousePosition,

--- a/packages/rrweb-cutter/src/snapshot.ts
+++ b/packages/rrweb-cutter/src/snapshot.ts
@@ -1,5 +1,6 @@
-import type { serializedNodeWithId, attributes } from 'rrweb-snapshot';
-import { elementNode, NodeType, serializedNode } from 'rrweb-snapshot';
+import type { elementNode, serializedNode, serializedNodeWithId, attributes } from '@rrweb/types';
+import { NodeType } from '@rrweb/types';
+
 import type {
   IRRComment,
   IRRDocument,


### PR DESCRIPTION
Provide a method of converting rrdom to HTML. Useful for rendering FullSnapshot + Mutation Events to a HTML state that can be rendered statically without having to invoke puppeteer server side.

Also useful in the context of this cutter/trim branch.