### PR TITLE
Add recording of shadow DOM nodes which have been created with the { mode: 'closed' } flag

### DIFF
--- a/.changeset/closed-shadow-root.md
+++ b/.changeset/closed-shadow-root.md
@@ -1,0 +1,7 @@
+---
+"rrweb": patch
+"rrweb-snapshot": patch
+"utils": patch
+---
+
+Add recording of shadow DOM nodes which have been created with the { mode: 'closed' } flag

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -21,6 +21,10 @@ type BypassOptions = Omit<
   sampling: SamplingStrategy;
 };
 
+type ElementWithShadowRoot = Element & {
+  __rrClosedShadowRoot: ShadowRoot;
+};
+
 export class ShadowDomManager {
   private shadowDoms = new WeakSet<ShadowRoot>();
   private mutationCb: mutationCallBack;
@@ -133,9 +137,13 @@ export class ShadowDomManager {
             // For the shadow dom elements in the document, monitor their dom mutations.
             // For shadow dom elements that aren't in the document yet,
             // we start monitoring them once their shadow dom host is appended to the document.
-            const shadowRootEl = dom.shadowRoot(this);
-            if (shadowRootEl && inDom(this))
-              manager.addShadowRoot(shadowRootEl, doc);
+            if (sRoot && inDom(this)) {
+              manager.addShadowRoot(sRoot, doc);
+            }
+            if (option.mode === 'closed') {
+              // FIXME: this exposes a closed root
+              (this as ElementWithShadowRoot).__rrClosedShadowRoot = sRoot;
+            }
             return sRoot;
           };
         },

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.record_integration_tests.should_record_closed_shadow_DOM_after_monkeypatching.snap.json
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.record_integration_tests.should_record_closed_shadow_DOM_after_monkeypatching.snap.json
@@ -1,0 +1,115 @@
+[
+  {
+    "type": 0,
+    "data": {}
+  },
+  {
+    "type": 1,
+    "data": {}
+  },
+  {
+    "type": 4,
+    "data": {
+      "href": "about:blank",
+      "width": 1920,
+      "height": 1080
+    }
+  },
+  {
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [],
+                "id": 3
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 5
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "script",
+                    "attributes": {},
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "SCRIPT_PLACEHOLDER",
+                        "id": 7
+                      }
+                    ],
+                    "id": 6
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n    \n    \n\n",
+                    "id": 8
+                  }
+                ],
+                "id": 4
+              }
+            ],
+            "id": 2
+          }
+        ],
+        "compatMode": "BackCompat",
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
+    }
+  },
+  {
+    "type": 3,
+    "data": {
+      "source": 0,
+      "texts": [],
+      "attributes": [],
+      "removes": [],
+      "adds": [
+        {
+          "parentId": 4,
+          "nextId": null,
+          "node": {
+            "type": 2,
+            "tagName": "div",
+            "attributes": {},
+            "childNodes": [],
+            "id": 9,
+            "isShadowHost": true
+          }
+        },
+        {
+          "parentId": 9,
+          "nextId": null,
+          "node": {
+            "type": 2,
+            "tagName": "input",
+            "attributes": {},
+            "childNodes": [],
+            "id": 10,
+            "isShadow": true
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -320,13 +320,15 @@ export async function assertSnapshot(
 
   expect(snapshots).toBeDefined();
   if (useOwnFile) {
+    // e.g. 'mutation.test.ts > mutation > add elements at once'
+    const long_fname = expect.getState().currentTestName.split('/').pop();
+    const file = long_fname.split(' > ')[0].replace('.test.ts', '');
     if (typeof useOwnFile !== 'string') {
-      // e.g. 'mutation.test.ts > mutation > add elements at once'
-      useOwnFile = expect.getState().currentTestName.split('/').pop();
+      useOwnFile = long_fname.substring(long_fname.indexOf(' > ') + 3);
     }
     useOwnFile = useOwnFile.replace(/ > /g, '.').replace(/\s/g, '_');
 
-    const fname = `./__snapshots__/${useOwnFile}.snap.json`;
+    const fname = `./__${file}.snapshots__/${useOwnFile}.json`;
     expect(stringifySnapshots(snapshots)).toMatchFileSnapshot(fname);
   } else {
     expect(stringifySnapshots(snapshots)).toMatchSnapshot();

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -301,6 +301,7 @@ function stringifyDomSnapshot(mhtml: string): string {
 
 export async function assertSnapshot(
   snapshotsOrPage: eventWithTime[] | puppeteer.Page,
+  useOwnFile: boolean | string = false,
 ) {
   let snapshots: eventWithTime[];
   if (!Array.isArray(snapshotsOrPage)) {
@@ -318,7 +319,18 @@ export async function assertSnapshot(
   }
 
   expect(snapshots).toBeDefined();
-  expect(stringifySnapshots(snapshots)).toMatchSnapshot();
+  if (useOwnFile) {
+    if (typeof useOwnFile !== 'string') {
+      // e.g. 'mutation.test.ts > mutation > add elements at once'
+      useOwnFile = expect.getState().currentTestName.split('/').pop();
+    }
+    useOwnFile = useOwnFile.replace(/ > /g, '.').replace(/\s/g, '_');
+
+    const fname = `./__snapshots__/${useOwnFile}.snap.json`;
+    expect(stringifySnapshots(snapshots)).toMatchFileSnapshot(fname);
+  } else {
+    expect(stringifySnapshots(snapshots)).toMatchSnapshot();
+  }
 }
 
 export function replaceLast(str: string, find: string, replace: string) {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -204,6 +204,9 @@ export function styleSheets(n: ShadowRoot): StyleSheetList {
 
 export function shadowRoot(n: Node): ShadowRoot | null {
   if (!n || !('shadowRoot' in n)) return null;
+  if ('__rrClosedShadowRoot' in n) {
+    return n.__rrClosedShadowRoot as ShadowRoot;
+  }
   return getUntaintedAccessor('Element', n as Element, 'shadowRoot');
 }
 


### PR DESCRIPTION
Leverage monkeypatching on `addShadowRoot` to save a reference to the mode:closed shadow roots, and record them just like open ones