### PR TITLE
Trying to expunge postcss from record build output

### DIFF
--- a/packages/record/src/index.ts
+++ b/packages/record/src/index.ts
@@ -1,3 +1,3 @@
-import { record } from 'rrweb';
+import record from 'rrweb/record';
 
 export { record };

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -34,7 +34,6 @@
   "main": "./dist/rrweb.umd.cjs",
   "module": "./dist/rrweb.js",
   "unpkg": "./dist/rrweb.umd.cjs",
-  "typings": "dist/rrweb.d.ts",
   "exports": {
     ".": {
       "import": {
@@ -46,8 +45,21 @@
         "default": "./dist/rrweb.cjs"
       }
     },
-    "./dist/style.css": "./dist/style.css"
+    "./dist/style.css": "./dist/style.css",
+    "./record":  {
+      "import": "./dist/rrweb-record.js"
+    },
+    "./replay":  {
+      "import": "./dist/rrweb-replay.js"
+    }
   },
+"typesVersions": {
+  "*": {
+    "record": ["dist/rrweb-record.d.ts"],
+    "replay": ["dist/rrweb-replay.d.ts"],
+    "*": ["dist/rrweb.d.ts"]
+  }
+},
   "files": [
     "dist",
     "package.json"

--- a/packages/rrweb/vite.config.js
+++ b/packages/rrweb/vite.config.js
@@ -1,4 +1,8 @@
 import config from '../../vite.config.default';
 
 // export default config('src/index.ts', 'rrweb', { outputDir: 'dist/main' });
-export default config('src/index.ts', 'rrweb');
+export default config({
+  'rrweb': 'src/index.ts',
+  'rrweb-record': 'src/record/index.ts',
+  'rrweb-replay': 'src/replay/index.ts'
+}, 'rrweb');


### PR DESCRIPTION
Re #1742

See changes, trying to output record.js without postcss included

Thought that the `record` package would import from new `rrweb-record.js` output after these changes, but that doesn't appear to be happening.

I'm getting a some weird new files in the output, and these are the ones including postcss :
```
rrweb/packages/rrweb$ grep postcss -l dist/*
grep: dist/assets: Is a directory
dist/base64-arraybuffer.es5-D-OFpZ9a.cjs
dist/base64-arraybuffer.es5-D-OFpZ9a.cjs.map
dist/base64-arraybuffer.es5-D-OFpZ9a.umd.cjs
dist/base64-arraybuffer.es5-D-OFpZ9a.umd.cjs.map
dist/base64-arraybuffer.es5-D-OFpZ9a.umd.min.cjs
dist/base64-arraybuffer.es5-D-OFpZ9a.umd.min.cjs.map
dist/base64-arraybuffer.es5-DwKE5w4P.js
dist/base64-arraybuffer.es5-DwKE5w4P.js.map
```