### PR TITLE
feat: Add option to add CSP to the replay iframe

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -618,12 +618,12 @@ export class Replayer {
     // hide iframe before first meta event
     this.iframe.style.display = 'none';
     this.iframe.setAttribute('sandbox', attributes.join(' '));
-    
+
     // Apply CSP if configured
     if (this.config.csp) {
       this.iframe.setAttribute('csp', this.config.csp);
     }
-    
+
     this.disableInteract();
     this.wrapper.appendChild(this.iframe);
     if (this.iframe.contentWindow && this.iframe.contentDocument) {
@@ -1542,8 +1542,8 @@ export class Replayer {
       const targetDoc = mutation.node.rootId
         ? mirror.getNode(mutation.node.rootId)
         : this.usingVirtualDom
-        ? this.virtualDom
-        : this.iframe.contentDocument;
+          ? this.virtualDom
+          : this.iframe.contentDocument;
       if (isSerializedIframe<typeof parent>(parent, mirror)) {
         this.attachDocumentToIframe(
           mutation,

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -618,6 +618,12 @@ export class Replayer {
     // hide iframe before first meta event
     this.iframe.style.display = 'none';
     this.iframe.setAttribute('sandbox', attributes.join(' '));
+    
+    // Apply CSP if configured
+    if (this.config.csp) {
+      this.iframe.setAttribute('csp', this.config.csp);
+    }
+    
     this.disableInteract();
     this.wrapper.appendChild(this.iframe);
     if (this.iframe.contentWindow && this.iframe.contentDocument) {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -196,6 +196,7 @@ export type playerConfig = {
     warn: (...args: Parameters<typeof console.warn>) => void;
   };
   plugins?: ReplayPlugin[];
+  csp?: string;
 };
 
 export type missingNode = {


### PR DESCRIPTION
This PR adds support to add a Content-Security-Policy to the iframe. This is if users want to further tighten the security of the iframe by being able to block images, videos, objects, iframes and more. 

Let me know if you have any questions! 