### PR TITLE
fix: ensure iframe cleanup in getUntaintedPrototype on error or early return

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -85,8 +85,9 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
     return defaultObj.prototype as BasePrototypeCache[T];
   }
 
+  let iframeEl: HTMLIFrameElement | undefined;
   try {
-    const iframeEl = document.createElement('iframe');
+    iframeEl = document.createElement('iframe');
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
     if (!win) return defaultObj.prototype as BasePrototypeCache[T];
@@ -94,14 +95,16 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     const untaintedObject = (win as any)[key]
       .prototype as BasePrototypeCache[T];
-    // cleanup
-    document.body.removeChild(iframeEl);
 
     if (!untaintedObject) return defaultPrototype;
 
     return (untaintedBasePrototype[key] = untaintedObject);
   } catch {
     return defaultPrototype;
+  } finally {
+    if (iframeEl?.parentNode) {
+      iframeEl.parentNode.removeChild(iframeEl);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1627

The `getUntaintedPrototype` function creates a temporary iframe to get clean prototypes, but fails to remove it when:
- `contentWindow` is null (early return)
- An exception is thrown

This adds a `finally` block to ensure the iframe is always cleaned up.