### PR TITLE
Update prepublish task outputs in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -12,10 +12,9 @@
     "prepublish": {
       "dependsOn": ["^prepublish", "//#references:update"],
       "outputs": [
-        "lib/**",
-        "es/**",
+        "build/**",
+        "umd/**",
         "dist/**",
-        "typings/**",
         ".svelte-kit/**",
         "types/**"
       ]


### PR DESCRIPTION
Removed old output paths and added new ones for build (rrvideo) and umd (all packages).