### PR TITLE
fix(replay): preserve class attribute text in hoverElements to avoid breaking CSS attribute selectors

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2259,10 +2259,7 @@ export class Replayer {
       if (currentEl.classList) {
         const cls = currentEl.getAttribute('class') || '';
         if (!/(^|\s):hover(\s|$)/.test(cls)) {
-          currentEl.setAttribute(
-            'class',
-            cls ? cls + ' :hover' : ':hover',
-          );
+          currentEl.setAttribute('class', cls ? cls + ' :hover' : ':hover');
         }
       }
       currentEl = currentEl.parentElement;

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2237,16 +2237,33 @@ export class Replayer {
   }
 
   private hoverElements(el: Element) {
+    // Use getAttribute/setAttribute instead of classList to preserve
+    // the original class attribute text. classList operations normalize
+    // the attribute by deduplicating tokens (e.g. "a b a" becomes "a b"),
+    // which breaks CSS attribute selectors like [class*="b a"].
     (this.lastHoveredRootNode || this.iframe.contentDocument)
       ?.querySelectorAll('.\\:hover')
       .forEach((hoveredEl) => {
-        hoveredEl.classList.remove(':hover');
+        const cls = hoveredEl.getAttribute('class') || '';
+        // Remove ':hover' token(s) while preserving surrounding whitespace.
+        const newCls = cls.replace(/(^|\s+):hover(?=\s|$)/g, '').trim();
+        if (newCls) {
+          hoveredEl.setAttribute('class', newCls);
+        } else {
+          hoveredEl.removeAttribute('class');
+        }
       });
     this.lastHoveredRootNode = el.getRootNode() as Document | ShadowRoot;
     let currentEl: Element | null = el;
     while (currentEl) {
       if (currentEl.classList) {
-        currentEl.classList.add(':hover');
+        const cls = currentEl.getAttribute('class') || '';
+        if (!/(^|\s):hover(\s|$)/.test(cls)) {
+          currentEl.setAttribute(
+            'class',
+            cls ? cls + ' :hover' : ':hover',
+          );
+        }
       }
       currentEl = currentEl.parentElement;
     }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2237,16 +2237,28 @@ export class Replayer {
   }
 
   private hoverElements(el: Element) {
+    // Use getAttribute/setAttribute instead of classList to preserve the
+    // original class attribute text. classList operations normalize the
+    // attribute by deduplicating tokens (e.g. "a b a" becomes "a b"),
+    // which breaks CSS attribute selectors like [class*="b a"].
     (this.lastHoveredRootNode || this.iframe.contentDocument)
       ?.querySelectorAll('.\\:hover')
       .forEach((hoveredEl) => {
-        hoveredEl.classList.remove(':hover');
+        const cls = hoveredEl.getAttribute('class') || '';
+        // Remove only the appended ' :hover' token, leaving the rest intact.
+        hoveredEl.setAttribute('class', cls.replace(/ ?:hover/g, ''));
       });
     this.lastHoveredRootNode = el.getRootNode() as Document | ShadowRoot;
     let currentEl: Element | null = el;
     while (currentEl) {
       if (currentEl.classList) {
-        currentEl.classList.add(':hover');
+        const cls = currentEl.getAttribute('class');
+        if (cls === null || !cls.split(/\s+/).includes(':hover')) {
+          currentEl.setAttribute(
+            'class',
+            cls ? cls + ' :hover' : ':hover',
+          );
+        }
       }
       currentEl = currentEl.parentElement;
     }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2254,10 +2254,7 @@ export class Replayer {
       if (currentEl.classList) {
         const cls = currentEl.getAttribute('class');
         if (cls === null || !cls.split(/\s+/).includes(':hover')) {
-          currentEl.setAttribute(
-            'class',
-            cls ? cls + ' :hover' : ':hover',
-          );
+          currentEl.setAttribute('class', cls ? cls + ' :hover' : ':hover');
         }
       }
       currentEl = currentEl.parentElement;

--- a/packages/rrweb/test/events/hover-duplicate-class-tokens.ts
+++ b/packages/rrweb/test/events/hover-duplicate-class-tokens.ts
@@ -1,0 +1,141 @@
+import { EventType, IncrementalSource } from '@rrweb/types';
+import type { eventWithTime } from '../../../types/src';
+
+/**
+ * Fixture: element with duplicate class tokens and a CSS attribute selector.
+ *
+ * The element has class="ui middle aligned center aligned grid" which
+ * contains the token "aligned" twice. A CSS rule uses
+ * [class*="center aligned"] to target it. When the replayer adds `:hover`
+ * via classList.add(), the browser's DOMTokenList normalizes the class
+ * attribute by deduplicating tokens, turning it into
+ * "ui middle aligned center grid :hover", which breaks the selector.
+ */
+const events: eventWithTime[] = [
+  // Meta event
+  {
+    type: EventType.Meta,
+    data: {
+      href: '',
+      width: 1600,
+      height: 900,
+    },
+    timestamp: 0,
+  },
+  // FullSnapshot
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: 0, // Document
+        childNodes: [
+          { type: 1, name: 'html', publicId: '', systemId: '', id: 2 },
+          {
+            type: 2, // Element
+            tagName: 'html',
+            attributes: { lang: 'en' },
+            childNodes: [
+              {
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 101,
+                    type: 2,
+                    tagName: 'style',
+                    attributes: {},
+                    childNodes: [
+                      {
+                        id: 102,
+                        type: 3,
+                        isStyle: true,
+                        textContent:
+                          '.ui[class*="center aligned"].grid { justify-content: center; text-align: center; }',
+                      },
+                    ],
+                  },
+                ],
+                id: 4,
+              },
+              { type: 3, textContent: '\n  ', id: 13 },
+              {
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  { type: 3, textContent: '\n    ', id: 15 },
+                  {
+                    type: 2,
+                    tagName: 'div',
+                    attributes: {
+                      // This class attribute intentionally contains "aligned"
+                      // twice, which is how Semantic UI's grid works.
+                      class: 'ui middle aligned center aligned grid',
+                      style:
+                        'width: 400px; height: 100px; border: 1px solid #000;',
+                    },
+                    childNodes: [
+                      {
+                        type: 2,
+                        tagName: 'div',
+                        attributes: {
+                          class: 'column',
+                          style: 'width: 200px;',
+                        },
+                        childNodes: [
+                          { type: 3, textContent: 'Centered content', id: 19 },
+                        ],
+                        id: 18,
+                      },
+                    ],
+                    id: 16,
+                  },
+                ],
+                id: 14,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: { left: 0, top: 0 },
+    },
+    timestamp: 10,
+  },
+  // Mouse move to the grid element to trigger hover
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseMove,
+      positions: [
+        {
+          x: 50,
+          y: 50,
+          id: 16,
+          timeOffset: 0,
+        },
+      ],
+    },
+    timestamp: 500,
+  },
+  // Mouse move away (to body) to remove hover
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseMove,
+      positions: [
+        {
+          x: 0,
+          y: 0,
+          id: 14,
+          timeOffset: 0,
+        },
+      ],
+    },
+    timestamp: 1000,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/replay/hover-class-preservation.test.ts
+++ b/packages/rrweb/test/replay/hover-class-preservation.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { vi } from 'vitest';
+import { launchPuppeteer, waitForRAF } from '../utils';
+import type * as puppeteer from 'puppeteer';
+import hoverDuplicateClassTokensEvents from '../events/hover-duplicate-class-tokens';
+
+interface ISuite {
+  code: string;
+  browser: puppeteer.Browser;
+  page: puppeteer.Page;
+}
+
+describe('replayer', function () {
+  vi.setConfig({ testTimeout: 20_000, hookTimeout: 30_000 });
+
+  let code: ISuite['code'];
+  let browser: ISuite['browser'];
+  let page: ISuite['page'];
+
+  beforeAll(async () => {
+    browser = await launchPuppeteer();
+
+    const bundlePath = path.resolve(__dirname, '../../dist/rrweb.umd.cjs');
+    code = fs.readFileSync(bundlePath, 'utf8');
+  });
+
+  beforeEach(async () => {
+    page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.evaluate(code);
+
+    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
+  });
+
+  afterEach(async () => {
+    await page.close();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  describe('hover with duplicate class tokens', () => {
+    it('should preserve duplicate class tokens when adding :hover', async () => {
+      await page.evaluate(
+        `var events = ${JSON.stringify(hoverDuplicateClassTokensEvents)}`,
+      );
+
+      // Pause at 550ms — after the mouse has moved over the grid element (at 500ms).
+      // The replayer should have added ":hover" to the element's class attribute.
+      await page.evaluate(`
+        const { Replayer } = rrweb;
+        window.__replayer = new Replayer(events);
+        window.__replayer.pause(550);
+      `);
+
+      await waitForRAF(page);
+      await waitForRAF(page);
+
+      const replayerIframe = await page.$('iframe');
+      const replayerFrame = await replayerIframe!.contentFrame()!;
+
+      // Check the raw class attribute — it should still contain "center aligned"
+      // as a substring (i.e. duplicate "aligned" tokens are preserved).
+      const classAttr = await replayerFrame!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el?.getAttribute('class') ?? '';
+      });
+
+      // The class should contain the original "center aligned" substring.
+      // Before the fix, classList.add(':hover') would normalize
+      // "ui middle aligned center aligned grid" to
+      // "ui middle aligned center grid :hover", losing the duplicate.
+      expect(classAttr).toContain('center aligned');
+      expect(classAttr).toContain(':hover');
+
+      // The CSS attribute selector should still match — verify computed style.
+      const justifyContent = await replayerFrame!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el ? getComputedStyle(el).justifyContent : '';
+      });
+
+      expect(justifyContent).toBe('center');
+    });
+
+    it('should restore original class attribute when :hover is removed', async () => {
+      await page.evaluate(
+        `var events = ${JSON.stringify(hoverDuplicateClassTokensEvents)}`,
+      );
+
+      // Pause at 1050ms — after the mouse moved away from the grid to body (at 1000ms).
+      await page.evaluate(`
+        const { Replayer } = rrweb;
+        window.__replayer = new Replayer(events);
+        window.__replayer.pause(1050);
+      `);
+
+      await waitForRAF(page);
+      await waitForRAF(page);
+
+      const replayerIframe = await page.$('iframe');
+      const replayerFrame = await replayerIframe!.contentFrame()!;
+
+      // After hover removal, the class attribute should be exactly the original.
+      const classAttr = await replayerFrame!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el?.getAttribute('class') ?? '';
+      });
+
+      expect(classAttr).toBe('ui middle aligned center aligned grid');
+      expect(classAttr).not.toContain(':hover');
+
+      // The CSS attribute selector should still match.
+      const justifyContent = await replayerFrame!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el ? getComputedStyle(el).justifyContent : '';
+      });
+
+      expect(justifyContent).toBe('center');
+    });
+
+    it('should not break hover for elements without duplicate class tokens', async () => {
+      await page.evaluate(
+        `var events = ${JSON.stringify(hoverDuplicateClassTokensEvents)}`,
+      );
+
+      // Pause at 550ms — hover is on the grid element (id 16) and its
+      // ancestors (body id 14, html id 3). The body has no class tokens.
+      await page.evaluate(`
+        const { Replayer } = rrweb;
+        window.__replayer = new Replayer(events);
+        window.__replayer.pause(550);
+      `);
+
+      await waitForRAF(page);
+      await waitForRAF(page);
+
+      const replayerIframe = await page.$('iframe');
+      const replayerFrame = await replayerIframe!.contentFrame()!;
+
+      // Body should have :hover since it's an ancestor of the hovered element.
+      const bodyClass = await replayerFrame!.evaluate(() => {
+        return document.body?.getAttribute('class') ?? '';
+      });
+
+      expect(bodyClass).toContain(':hover');
+    });
+  });
+});

--- a/packages/rrweb/test/replay/hover-class-preservation.test.ts
+++ b/packages/rrweb/test/replay/hover-class-preservation.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { vi } from 'vitest';
+import { launchPuppeteer, waitForRAF } from '../utils';
+import type * as puppeteer from 'puppeteer';
+import hoverDuplicateClassTokensEvents from '../events/hover-duplicate-class-tokens';
+
+interface ISuite {
+  code: string;
+  browser: puppeteer.Browser;
+  page: puppeteer.Page;
+}
+
+describe('replayer', function () {
+  vi.setConfig({ testTimeout: 20_000, hookTimeout: 30_000 });
+
+  let code: ISuite['code'];
+  let browser: ISuite['browser'];
+  let page: ISuite['page'];
+
+  beforeAll(async () => {
+    browser = await launchPuppeteer();
+
+    const bundlePath = path.resolve(__dirname, '../../dist/rrweb.umd.cjs');
+    code = fs.readFileSync(bundlePath, 'utf8');
+  });
+
+  beforeEach(async () => {
+    page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.evaluate(code);
+
+    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
+  });
+
+  afterEach(async () => {
+    await page.close();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  describe('hover with duplicate class tokens', () => {
+    it('should preserve duplicate class tokens when adding :hover', async () => {
+      await page.evaluate(
+        `var events = ${JSON.stringify(hoverDuplicateClassTokensEvents)}`,
+      );
+
+      // Pause at 550ms — after the mouse has moved over the grid element (at 500ms).
+      // The replayer should have added ":hover" to the element's class attribute.
+      await page.evaluate(`
+        const { Replayer } = rrweb;
+        window.__replayer = new Replayer(events);
+        window.__replayer.pause(550);
+      `);
+
+      await waitForRAF(page);
+      await waitForRAF(page);
+
+      const replayerIframe = await page.$('iframe');
+      const contentDocument = await replayerIframe!.contentFrame()!;
+
+      // Check the raw class attribute — it should still contain "center aligned"
+      // as a substring (i.e. duplicate "aligned" tokens are preserved).
+      const classAttr = await contentDocument!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el?.getAttribute('class') ?? '';
+      });
+
+      // The class should contain the original "center aligned" substring.
+      // Before the fix, classList.add(':hover') would normalize
+      // "ui middle aligned center aligned grid" to
+      // "ui middle aligned center grid :hover", losing the duplicate.
+      expect(classAttr).toContain('center aligned');
+      expect(classAttr).toContain(':hover');
+
+      // The CSS attribute selector should still match — verify computed style.
+      const justifyContent = await contentDocument!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el ? getComputedStyle(el).justifyContent : '';
+      });
+
+      expect(justifyContent).toBe('center');
+    });
+
+    it('should restore original class attribute when :hover is removed', async () => {
+      await page.evaluate(
+        `var events = ${JSON.stringify(hoverDuplicateClassTokensEvents)}`,
+      );
+
+      // Pause at 1050ms — after the mouse moved away from the grid to body (at 1000ms).
+      await page.evaluate(`
+        const { Replayer } = rrweb;
+        window.__replayer = new Replayer(events);
+        window.__replayer.pause(1050);
+      `);
+
+      await waitForRAF(page);
+      await waitForRAF(page);
+
+      const replayerIframe = await page.$('iframe');
+      const contentDocument = await replayerIframe!.contentFrame()!;
+
+      // After hover removal, the class attribute should be exactly the original.
+      const classAttr = await contentDocument!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el?.getAttribute('class') ?? '';
+      });
+
+      expect(classAttr).toBe('ui middle aligned center aligned grid');
+      expect(classAttr).not.toContain(':hover');
+
+      // The CSS attribute selector should still match.
+      const justifyContent = await contentDocument!.evaluate(() => {
+        const el = document.querySelector('.ui.grid');
+        return el ? getComputedStyle(el).justifyContent : '';
+      });
+
+      expect(justifyContent).toBe('center');
+    });
+
+    it('should not break hover for elements without duplicate class tokens', async () => {
+      await page.evaluate(
+        `var events = ${JSON.stringify(hoverDuplicateClassTokensEvents)}`,
+      );
+
+      // Pause at 550ms — hover is on the grid element (id 16) and its
+      // ancestors (body id 14, html id 3). The body has no class tokens.
+      await page.evaluate(`
+        const { Replayer } = rrweb;
+        window.__replayer = new Replayer(events);
+        window.__replayer.pause(550);
+      `);
+
+      await waitForRAF(page);
+      await waitForRAF(page);
+
+      const replayerIframe = await page.$('iframe');
+      const contentDocument = await replayerIframe!.contentFrame()!;
+
+      // Body should have :hover since it's an ancestor of the hovered element.
+      const bodyClass = await contentDocument!.evaluate(() => {
+        return document.body?.getAttribute('class') ?? '';
+      });
+
+      expect(bodyClass).toContain(':hover');
+    });
+  });
+});


### PR DESCRIPTION
This pull request addresses an issue with how hover states are applied to elements with duplicate class tokens, specifically to preserve CSS attribute selector behavior. The main fix is to avoid using `classList` for hover state manipulation, which would otherwise normalize and deduplicate class tokens, potentially breaking selectors such as `[class*="center aligned"]`. New tests are added to verify correct behavior in these scenarios.

**Hover state handling improvements:**

* Updated `Replayer`'s `hoverElements` method to use `getAttribute` and `setAttribute` for adding/removing `:hover` instead of `classList`, ensuring duplicate class tokens are preserved and selectors like `[class*="center aligned"]` continue to work.

**Test additions and coverage:**

* Added a fixture `hover-duplicate-class-tokens.ts` to simulate an element with duplicate class tokens and a CSS attribute selector, reproducing the issue where class normalization breaks selector matching.
* Introduced a new test suite `hover-class-preservation.test.ts` that verifies:
  - Duplicate class tokens are preserved when `:hover` is added.
  - The original class attribute is restored when `:hover` is removed.
  - Hover handling works for elements without duplicate class tokens.