### PR TITLE
Fix: Ignore media interactions for unsupported media elements during replay

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1302,6 +1302,9 @@ export class Replayer {
         if (!target) {
           return this.debugNodeNotFound(d, d.id);
         }
+        if (!this.mediaManager.isSupportedMediaElement(target)) {
+          return this.debugNodeNotFound(d, d.id);
+        }
         const mediaEl = target as HTMLMediaElement | RRMediaElement;
         const { events } = this.service.state.context;
 

--- a/packages/rrweb/src/replay/media/index.ts
+++ b/packages/rrweb/src/replay/media/index.ts
@@ -285,9 +285,7 @@ export class MediaManager {
     this.syncTargetWithState(target);
   }
 
-  public isSupportedMediaElement(
-    node: Node | { nodeName: string },
-  ): boolean {
+  public isSupportedMediaElement(node: Node | { nodeName: string }): boolean {
     return ['AUDIO', 'VIDEO'].includes(node.nodeName);
   }
 

--- a/packages/rrweb/src/replay/media/index.ts
+++ b/packages/rrweb/src/replay/media/index.ts
@@ -285,7 +285,9 @@ export class MediaManager {
     this.syncTargetWithState(target);
   }
 
-  public isSupportedMediaElement(node: Node): node is HTMLMediaElement {
+  public isSupportedMediaElement(
+    node: Node | { nodeName: string },
+  ): boolean {
     return ['AUDIO', 'VIDEO'].includes(node.nodeName);
   }
 


### PR DESCRIPTION
## Summary
- Adds a check to verify the target is a supported media element (AUDIO/VIDEO) before processing media interactions during replay
- Prevents errors when media interaction events reference non-media elements

This was identified when lottie player interactions are captured in a replay, they trigger the `pause` event which does not exist and throws an error during replay - test webpage to reproduce attached 

[repro.html](https://github.com/user-attachments/files/25923965/repro.html)
