### PR TITLE
fix: treat querySelector/querySelectorAll as methods in untainted pro…

### DIFF
--- a/.changeset/sharp-lies-hear.md
+++ b/.changeset/sharp-lies-hear.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/utils": patch
+---
+
+Move native Element querySelector and querySelector checks to testableMethods since they are methods

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,14 +21,14 @@ const testableAccessors = {
     'ownerDocument',
   ] as const,
   ShadowRoot: ['host', 'styleSheets'] as const,
-  Element: ['shadowRoot', 'querySelector', 'querySelectorAll'] as const,
+  Element: ['shadowRoot'] as const,
   MutationObserver: [] as const,
 } as const;
 
 const testableMethods = {
   Node: ['contains', 'getRootNode'] as const,
   ShadowRoot: ['getSelection'],
-  Element: [],
+  Element: ['querySelector', 'querySelectorAll'],
   MutationObserver: ['constructor'],
 } as const;
 
@@ -218,14 +218,14 @@ export function shadowRoot(n: Node): ShadowRoot | null {
 }
 
 export function querySelector(n: Element, selectors: string): Element | null {
-  return getUntaintedAccessor('Element', n, 'querySelector')(selectors);
+  return getUntaintedMethod('Element', n, 'querySelector')(selectors);
 }
 
 export function querySelectorAll(
   n: Element,
   selectors: string,
 ): NodeListOf<Element> {
-  return getUntaintedAccessor('Element', n, 'querySelectorAll')(selectors);
+  return getUntaintedMethod('Element', n, 'querySelectorAll')(selectors);
 }
 
 export function mutationObserverCtor(): (typeof MutationObserver)['prototype']['constructor'] {


### PR DESCRIPTION
…totype check

issue:
`querySelector` and `querySelectorAll` were listed under `testableAccessors` = the checks always failed = we're always creating/removing iframes to try and get the untainted versions when it's not necessary

fix:
move both `querySelector` and `querySelectorAll` into `testableMethods`