### PR TITLE
fix(replay): fix playback stopping when skipping backwards with virtual DOM

### DIFF
--- a/.changeset/fix-virtual-dom-backward-skip.md
+++ b/.changeset/fix-virtual-dom-backward-skip.md
@@ -1,0 +1,5 @@
+---
+'rrweb': patch
+---
+
+Fix playback stopping when skipping backwards with useVirtualDom enabled

--- a/.changeset/fix-virtual-dom-backward-skip.md
+++ b/.changeset/fix-virtual-dom-backward-skip.md
@@ -1,5 +1,5 @@
 ---
-'rrweb': patch
+"rrweb": patch
 ---
 
 Fix playback stopping when skipping backwards with useVirtualDom enabled

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -266,10 +266,8 @@ export class Replayer {
             console.warn(e);
           }
 
-        this.virtualDom.destroyTree();
-        this.usingVirtualDom = false;
-
         // If these legacy missing nodes haven't been resolved, they should be converted to real Nodes.
+        // This must happen before destroyTree() which resets the virtual DOM mirror.
         if (Object.keys(this.legacy_missingNodeRetryMap).length) {
           for (const key in this.legacy_missingNodeRetryMap) {
             try {
@@ -291,6 +289,9 @@ export class Replayer {
             }
           }
         }
+
+        this.virtualDom.destroyTree();
+        this.usingVirtualDom = false;
 
         this.constructedStyleMutations.forEach((data) => {
           this.applyStyleSheetMutation(data);


### PR DESCRIPTION
## Summary

When `useVirtualDom` is enabled (the default), skipping backwards in a replay could cause playback to stop entirely.

`destroyTree()` was called before legacy missing nodes were resolved, resetting the virtual DOM mirror. Subsequent `createOrGetNode()` and `diff()` calls used the empty mirror, producing nodes with `-1` IDs that were never added to the real DOM mirror.

The fix moves `destroyTree()` after the legacy missing nodes loop so the virtual DOM mirror is still available when converting legacy nodes.

This may also fix #1358.

## Future improvement

The style mutation application (`constructedStyleMutations` and `adoptedStyleSheets`) in the Flush handler is not wrapped in try/catch. An exception there would propagate up and prevent `timer.start()` from executing, also stopping playback. Adding try/catch (matching the pattern used elsewhere in the handler) would improve resilience.

## Disclosure

Claude was used to help with this change but it was manually verified.

## Test plan

- [x] Manually tested with a real-world recording from the [OpenTelemetry demo app](https://github.com/open-telemetry/opentelemetry-demo) that previously exhibited this bug
- [ ] Existing test suite passes