### PR TITLE
[build] Fix fork PR comment lookup

### DIFF
--- a/.github/workflows/pr-checks-privileged.yml
+++ b/.github/workflows/pr-checks-privileged.yml
@@ -35,20 +35,30 @@ jobs:
           script: |
             const run = context.payload.workflow_run;
             if (run.pull_requests && run.pull_requests.length > 0) {
-              return run.pull_requests[0].number;
+              return String(run.pull_requests[0].number);
             }
+
+            const headOwner = run.head_repository?.owner?.login;
+            if (!headOwner || !run.head_branch) {
+              core.setFailed('Could not determine PR head reference');
+              return;
+            }
+
             // Fallback for fork PRs (pull_requests is empty for forks)
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: `${run.head_repository.full_name}:${run.head_branch}`,
+              head: `${headOwner}:${run.head_branch}`,
               state: 'open',
             });
-            if (prs.length === 0) {
+
+            const match = prs.find((pr) => pr.head.sha === run.head_sha) ?? prs[0];
+            if (!match) {
               core.setFailed('Could not determine PR number');
               return;
             }
-            return prs[0].number;
+
+            return String(match.number);
           result-encoding: string
 
       - name: Render bundle size comment


### PR DESCRIPTION
## Summary
- fix fork PR resolution in `.github/workflows/pr-checks-privileged.yml` by querying `head` as `owner:branch` instead of `owner/repo:branch`
- return string PR numbers consistently and disambiguate matches by `head.sha`
- address the exact failure that prevented bundle-size comments from being posted on fork PRs like #1808

## Validation
- yarn prettier --check /tmp/rrweb-pr1808-fix.OKwiWw/.github/workflows/pr-checks-privileged.yml
- verified via GitHub API that `head=Juice10:codex/bundle-size-comment-bloat` resolves PR #1808 while `head=Juice10/rrweb:codex/bundle-size-comment-bloat` does not
- inspected the failed workflow_run logs from March 19, 2026 to confirm the old fallback was still running on `master`

This PR only changes CI workflow code, so full repo lint/test was not rerun here.