### PR TITLE
[build] Keep annotate job green on lint findings

### DIFF
--- a/.github/workflows/pr-checks-privileged.yml
+++ b/.github/workflows/pr-checks-privileged.yml
@@ -83,3 +83,4 @@ jobs:
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'
+          fail-on-error: false


### PR DESCRIPTION
## Summary
- configure the privileged ESLint annotation step not to fail the workflow job when lint findings exist
- keep the `ESLint Report Analysis` annotations/check feedback, while avoiding a noisy red privileged workflow for ordinary lint output

## Why
- the privileged workflow is acting as a reporting relay for annotations, not as the primary lint status surface
- when this job exits non-zero on ordinary lint findings, the whole privileged workflow looks infra-broken even though it successfully downloaded the report and posted annotations
- the dedicated `ESLint Report Analysis` check should remain the canonical failure signal for actual ESLint errors

## Details
- set `fail-on-error: false` for `ataylorme/eslint-annotate-action`
- per the action docs, the created check still fails on ESLint errors even when the step itself stays green

## Validation
- yarn prettier --check /tmp/rrweb-pr-annotate.vqT7Xd/.github/workflows/pr-checks-privileged.yml
- confirmed from the action docs that `fail-on-error: false` preserves the failing check while preventing the action step from exiting non-zero

This PR only changes CI workflow code, so full repo lint/test was not rerun here.