### PR TITLE
fix: always use native Proxy

### DIFF
--- a/.changeset/brown-colts-join.md
+++ b/.changeset/brown-colts-join.md
@@ -1,0 +1,6 @@
+---
+"rrweb": patch
+"@rrweb/utils": patch
+---
+
+protect against overwritten Proxy and make sure we always use native Proxy

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -16,7 +16,7 @@ import {
   isBlocked,
   legacy_isTouchEvent,
   StyleSheetMirror,
-  nowTimestamp,
+  nowTimestamp
 } from '../utils';
 import { patch } from '@rrweb/utils';
 import type { observerParam, MutationBufferParam } from '../types';
@@ -52,10 +52,12 @@ import type {
 } from '@rrweb/types';
 import MutationBuffer from './mutation';
 import { callbackWrapper } from './error-handler';
-import dom, { mutationObserverCtor } from '@rrweb/utils';
+import dom, { mutationObserverCtor, getUntaintedProxy } from '@rrweb/utils';
 
 export const mutationBuffers: MutationBuffer[] = [];
 
+const Proxy = getUntaintedProxy();
+ 
 // Event.path is non-standard and used in some older browsers
 type NonStandardEvent = Omit<Event, 'composedPath'> & {
   path: EventTarget[];

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -13,7 +13,7 @@ import type {
 import type { Mirror, SlimDOMOptions } from 'rrweb-snapshot';
 import { isShadowRoot, IGNORED_NODE, classMatchesRegex } from 'rrweb-snapshot';
 import { RRNode, RRIFrameElement, BaseRRNode } from 'rrdom';
-import dom from '@rrweb/utils';
+import dom, { getUntaintedProxy } from '@rrweb/utils';
 
 export function on(
   type: string,
@@ -54,7 +54,9 @@ export let _mirror: DeprecatedMirror = {
     console.error(DEPARTED_MIRROR_ACCESS_WARNING);
   },
 };
+
 if (typeof window !== 'undefined' && window.Proxy && window.Reflect) {
+  const Proxy = getUntaintedProxy();
   _mirror = new Proxy(_mirror, {
     get(target, prop, receiver) {
       if (prop === 'map') {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -232,6 +232,29 @@ export function mutationObserverCtor(): (typeof MutationObserver)['prototype']['
   return getUntaintedPrototype('MutationObserver').constructor;
 }
 
+// Some libraries (i.e. jsPDF v1.1.135) override window.Proxy with their own implementation
+// Try to pull a clean implementation from a newly created iframe
+export function getUntaintedProxy(): ProxyConstructor {
+  let Proxy = window.Proxy;
+  try {
+    if (
+      typeof window.Proxy !== 'function' ||
+      !window.Proxy?.toString().includes('[native code]')
+    ) {
+      const cleanFrame = document.createElement('iframe');
+      cleanFrame.style.display = 'none';
+      document.documentElement.appendChild(cleanFrame);
+      Proxy =
+        (cleanFrame.contentWindow as Window & { Proxy: typeof Proxy })?.Proxy ||
+        window.Proxy;
+      document.documentElement.removeChild(cleanFrame);
+    }
+  } catch (err) {
+    console.debug('Unable to get untainted Proxy from iframe', err);
+  }
+  return Proxy;
+}
+
 // copy from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts
 export function patch(
   source: { [key: string]: any },


### PR DESCRIPTION
specific site was running into loading errors/crashing when recording, turn outs it's using a very old version of a 3rd party library (jspdf) that overwrites Proxy. whenever we ran `new Proxy`, it would result in a bunch of errors and cause the site to stop loading. this PR is to protect against overwritten Proxy and make sure we always use native Proxy 🫡