### PR TITLE
fix(snapshot): use link.sheet for CSS capture on WebKit

### DIFF
--- a/.changeset/shiny-socks-pull.md
+++ b/.changeset/shiny-socks-pull.md
@@ -1,0 +1,5 @@
+---
+'rrweb-snapshot': patch
+---
+
+Fix inline stylesheet capture on WebKit by reading CSS rules from `HTMLLinkElement.sheet` before falling back to `document.styleSheets`.

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -587,10 +587,14 @@ function serializeElementNode(
   }
   // remote css
   if (tagName === 'link' && inlineStylesheet) {
-    //TODO: maybe replace this `.styleSheets` with original one
-    const stylesheet = Array.from(doc.styleSheets).find((s) => {
-      return s.href === (n as HTMLLinkElement).href;
-    });
+    // Try the element's .sheet first (works on WebKit even when
+    // document.styleSheets hasn't been updated yet), then fall back
+    // to searching document.styleSheets by href.
+    const stylesheet =
+      (n as HTMLLinkElement).sheet ||
+      Array.from(doc.styleSheets).find((s) => {
+        return s.href === (n as HTMLLinkElement).href;
+      });
     let cssText: string | null = null;
     if (stylesheet) {
       cssText = stringifyStylesheet(stylesheet);


### PR DESCRIPTION
## Problem

When `inlineStylesheet` is enabled, rrweb searches `document.styleSheets` to find the `CSSStyleSheet` for each `<link>` element and inline its rules as `_cssText`.

On WebKit (Safari), at `readyState: "interactive"`, external stylesheets loaded via `<link>` are **not yet listed** in `document.styleSheets` — only inline `<style>` elements appear. This means full snapshots taken at page load capture `_cssText: ""` for all external stylesheets, producing unstyled replays.

However, `HTMLLinkElement.sheet` **is** already populated at this point on WebKit.

## Fix

Check `link.sheet` before falling back to `document.styleSheets.find()`:

```typescript
const stylesheet =
  (n as HTMLLinkElement).sheet ||
  Array.from(doc.styleSheets).find((s) => {
    return s.href === (n as HTMLLinkElement).href;
  });
```

## Testing

Verified with Angular apps across Chrome, Firefox, and Safari (Playwright WebKit)