### PR TITLE
fix(utils): use Zone.js unpatched MutationObserver on Safari

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -51,6 +51,22 @@ export const isAngularZonePresent = (): boolean => {
   return !!(globalThis as { Zone?: unknown }).Zone;
 };
 
+// When Angular Zone.js is present, it stores the original unpatched globals
+// under a symbol key. Use this to get the native MutationObserver (etc.)
+// without the iframe fallback, which breaks on Safari.
+// See: https://github.com/PostHog/posthog-js/pull/1687
+function angularZoneUnpatchedAlternative<T extends keyof BasePrototypeCache>(
+  key: T,
+): (typeof globalThis)[T] | undefined {
+  const Zone = (globalThis as { Zone?: { __symbol__?: (k: string) => string } })
+    .Zone;
+  const symbol = Zone?.__symbol__?.(key);
+  if (symbol && (globalThis as Record<string, unknown>)[symbol]) {
+    return (globalThis as Record<string, unknown>)[symbol] as (typeof globalThis)[T];
+  }
+  return undefined;
+}
+
 export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   key: T,
 ): BasePrototypeCache[T] {
@@ -89,6 +105,19 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent()) {
     untaintedBasePrototype[key] = defaultObj.prototype as BasePrototypeCache[T];
     return defaultObj.prototype as BasePrototypeCache[T];
+  }
+
+  // Try Zone.js's stored original before the iframe fallback.
+  // The iframe approach breaks on Safari where a MutationObserver from an
+  // iframe's contentWindow silently never fires callbacks when observing
+  // the parent document.
+  const zoneAlternative = angularZoneUnpatchedAlternative(key);
+  if (zoneAlternative) {
+    const proto = (zoneAlternative as TypeofPrototypeOwner)
+      .prototype as BasePrototypeCache[T];
+    if (proto) {
+      return (untaintedBasePrototype[key] = proto);
+    }
   }
 
   try {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -62,7 +62,9 @@ function angularZoneUnpatchedAlternative<T extends keyof BasePrototypeCache>(
     .Zone;
   const symbol = Zone?.__symbol__?.(key);
   if (symbol && (globalThis as Record<string, unknown>)[symbol]) {
-    return (globalThis as Record<string, unknown>)[symbol] as (typeof globalThis)[T];
+    return (globalThis as Record<string, unknown>)[
+      symbol
+    ] as (typeof globalThis)[T];
   }
   return undefined;
 }


### PR DESCRIPTION
## Problem

When Angular's Zone.js is present, it monkey-patches `MutationObserver`. rrweb's `getUntaintedPrototype` detects the patched version and falls back to creating a hidden iframe, then uses `iframe.contentWindow.MutationObserver` to get an unpatched observer.

On Safari/WebKit, a `MutationObserver` obtained from an iframe's `contentWindow` **silently never fires callbacks** when observing nodes in the parent document. This means rrweb captures zero DOM mutations — full snapshots work, but all incremental changes are lost.

## Fix

Zone.js stores original unpatched globals under `globalThis[Zone.__symbol__(key)]`. Before attempting the iframe fallback, check if Zone.js has stored the native `MutationObserver` and use it directly.

```typescript
const zoneAlternative = angularZoneUnpatchedAlternative(key);
if (zoneAlternative) {
  return zoneAlternative.prototype;
}
```

This is the same approach used by PostHog: https://github.com/PostHog/posthog-js/pull/1687

## Testing

Verified with Angular apps (Zone.js present) across Chrome, Firefox, and Safari (Playwright WebKit). After the fix, Safari sessions capture 146+ mutations where previously they captured zero.