### PR TITLE
[codex] Add asset event types

### DIFF
--- a/.changeset/asset-event-types.md
+++ b/.changeset/asset-event-types.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/types": patch
+---
+
+Add public asset event type aliases for the 2.0 event contract.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,7 @@ export enum EventType {
   Meta,
   Custom,
   Plugin,
+  Asset,
 }
 
 export type domContentLoadedEvent = {
@@ -57,6 +58,15 @@ export type pluginEvent<T = unknown> = {
     plugin: string;
     payload: T;
   };
+};
+
+export type assetEvent = {
+  type: EventType.Asset;
+  data: assetParam;
+};
+
+export type assetEventWithTime = assetEvent & {
+  timestamp: number;
 };
 
 export enum IncrementalSource {
@@ -163,7 +173,8 @@ export type eventWithoutTime =
   | incrementalSnapshotEvent
   | metaEvent
   | customEvent
-  | pluginEvent;
+  | pluginEvent
+  | assetEvent;
 
 /**
  * @deprecated intended for internal use
@@ -382,16 +393,23 @@ export enum CanvasContext {
   WebGL2,
 }
 
+export type SerializedCssTextArg = {
+  rr_type: 'CssText';
+  cssTexts: string[];
+};
+
+export type SerializedBlobArg = {
+  rr_type: 'Blob';
+  data: Array<CanvasArg>;
+  type?: string;
+};
+
 export type SerializedCanvasArg =
   | {
       rr_type: 'ArrayBuffer';
       base64: string; // base64
     }
-  | {
-      rr_type: 'Blob';
-      data: Array<CanvasArg>;
-      type?: string;
-    }
+  | SerializedBlobArg
   | {
       rr_type: string;
       src: string; // url of image
@@ -607,6 +625,22 @@ export type customElementParam = {
 };
 
 export type customElementCallback = (c: customElementParam) => void;
+
+export type assetParam =
+  | {
+      url: string;
+      payload: SerializedCanvasArg | SerializedCssTextArg;
+      timestamp?: number;
+    }
+  | {
+      url: string;
+      failed: {
+        status?: number;
+        message: string;
+      };
+    };
+
+export type assetCallback = (d: assetParam, timestamp?: number | true) => void;
 
 /**
  *  @deprecated

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -395,7 +395,7 @@ export enum CanvasContext {
 
 export type SerializedCssTextArg = {
   rr_type: 'CssText';
-  cssTexts: string[];
+  cssTexts: string[]; // usually just a single item
 };
 
 export type SerializedBlobArg = {


### PR DESCRIPTION
## Summary

- Extract the minimal public asset-event type contract from #1475 for the 2.0 event surface
- Add `EventType.Asset`, `assetEvent`, `assetEventWithTime`, `assetParam`, and `assetCallback` to `@rrweb/types`
- Factor `SerializedBlobArg` and add `SerializedCssTextArg` so the asset payload type can reference stylesheet payloads without pulling in the broader asset runtime

## Why

Adding a new event kind after 2.0 can break consumers with exhaustive event handling. This lands only the compatibility-sensitive type surface before the stable release, without pulling in #1475 runtime behavior or the broader `captureAssets` API.

## Not included

- No `captureAssetsParam` or `recordOptions.captureAssets`
- No runtime asset manager behavior
- No snapshot/rebuild manager API
- No docs, package versions, lockfile, or #1475 branch drift

## Validation

- `git diff --check`
- Subagent ran focused compile/Prettier checks for the changed type surface
- Full repo `yarn` checks were not runnable in this Codex shell because `yarn`, `npm`, `npx`, and `corepack` are unavailable in PATH and the project rejects `pnpm`
