### PR TITLE
[codex] Tree-shake postcss from record bundle

### DIFF
--- a/.changeset/record-tree-shake-postcss.md
+++ b/.changeset/record-tree-shake-postcss.md
@@ -1,0 +1,7 @@
+---
+"@rrweb/record": patch
+"rrweb": patch
+"rrweb-snapshot": patch
+---
+
+Tree-shake replay-only `postcss` code from the `@rrweb/record` bundle.

--- a/docs/adr/0001-record-source-boundary-resolver.md
+++ b/docs/adr/0001-record-source-boundary-resolver.md
@@ -1,0 +1,3 @@
+# Use a record-local source-boundary resolver
+
+`@rrweb/record` needs to build without replay-only `rrweb-snapshot` code such as `postcss`, but adding public snapshot/rebuild subpath exports would expand the package API and create compatibility obligations. We will keep the public package API unchanged and add a resolver scoped to the `@rrweb/record` build that maps selected bare package imports to local source entrypoints, restoring Rollup's module visibility for tree-shaking.

--- a/docs/superpowers/plans/2026-05-19-record-tree-shaking.md
+++ b/docs/superpowers/plans/2026-05-19-record-tree-shaking.md
@@ -1,0 +1,361 @@
+# Record Tree-Shaking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `@rrweb/record` without bundling replay-only `postcss` code from `rrweb-snapshot`.
+
+**Architecture:** Keep the public package API unchanged. Add a resolver scoped to `packages/record/vite.config.ts` so the record build sees local source module boundaries for `rrweb`, `rrweb-snapshot`, and `rrdom`; mark `rrweb-snapshot` as side-effect-free so Rollup can drop unused rebuild modules.
+
+**Tech Stack:** Yarn workspaces, Turbo, Vite 6, Rollup plugin hooks, Vitest, TypeScript.
+
+---
+
+## File Structure
+
+- Modify `packages/record/test/record.test.ts`: add build-output assertions for `postcss` absence and `dist/record.js` size.
+- Modify `packages/rrweb-snapshot/package.json`: add `"sideEffects": false`.
+- Modify `packages/record/vite.config.ts`: add an inline exact-bare-import `resolveId` plugin for record's build.
+- Modify `packages/rrweb/src/entries/record.ts`: replace default-import-then-export with direct named re-export.
+
+## Task 1: Confirm The Baseline
+
+**Files:**
+- Read: `packages/record/dist/record.js`
+- Modify: none
+
+- [ ] **Step 1: Build the current record package before implementation changes**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record build
+```
+
+Expected: build succeeds and writes `packages/record/dist/record.js`. In this workspace, the measured baseline build succeeded before implementation changes.
+
+- [ ] **Step 2: Record the current ESM bundle size**
+
+Run:
+
+```bash
+wc -c packages/record/dist/record.js
+```
+
+Expected: output is `397373 packages/record/dist/record.js`. This is the baseline byte count for Task 2's test constant.
+
+- [ ] **Step 3: Confirm the current bundle contains `postcss`**
+
+Run:
+
+```bash
+rg -n "postcss" packages/record/dist
+```
+
+Expected: at least one match in a built JavaScript artifact. In this workspace, `postcss` appears in `packages/record/dist/record.js` and `packages/record/dist/record.umd.min.cjs` before the fix.
+
+## Task 2: Add Failing Bundle Regression Tests
+
+**Files:**
+- Modify: `packages/record/test/record.test.ts`
+
+- [ ] **Step 1: Replace the test file with build-output checks**
+
+```ts
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { record } from '../src/index';
+
+const distDir = path.resolve(__dirname, '../dist');
+const recordJsPath = path.join(distDir, 'record.js');
+
+// Measured before the tree-shaking fix: 397373 bytes.
+// The fixed ESM bundle must stay at least 200 KiB smaller.
+const BASELINE_RECORD_JS_BYTES = 397373;
+const MAX_RECORD_JS_BYTES = BASELINE_RECORD_JS_BYTES - 200 * 1024;
+
+function requireBuiltRecordBundle() {
+  if (!existsSync(recordJsPath)) {
+    throw new Error(
+      'Missing packages/record/dist/record.js. Run `yarn workspace @rrweb/record build` before running this test.',
+    );
+  }
+}
+
+function emittedJavaScriptFiles() {
+  if (!existsSync(distDir)) {
+    throw new Error(
+      'Missing packages/record/dist. Run `yarn workspace @rrweb/record build` before running this test.',
+    );
+  }
+  return readdirSync(distDir)
+    .filter((file) => file.endsWith('.js') || file.endsWith('.cjs'))
+    .map((file) => path.join(distDir, file));
+}
+
+describe('record', () => {
+  it('should be a function', () => {
+    expect(typeof record).toBe('function');
+  });
+
+  it('does not bundle replay-only postcss code', () => {
+    requireBuiltRecordBundle();
+
+    for (const file of emittedJavaScriptFiles()) {
+      expect(readFileSync(file, 'utf-8')).not.toContain('postcss');
+    }
+  });
+
+  it('keeps the ESM record bundle at least 200 KiB below the baseline size', () => {
+    requireBuiltRecordBundle();
+
+    expect(statSync(recordJsPath).size).toBeLessThanOrEqual(
+      MAX_RECORD_JS_BYTES,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails for the current implementation**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record test
+```
+
+Expected: the new `postcss` assertion fails, or the size assertion fails, because the implementation change has not been made yet.
+
+## Task 3: Mark rrweb-snapshot As Side-Effect-Free
+
+**Files:**
+- Modify: `packages/rrweb-snapshot/package.json`
+
+- [ ] **Step 1: Add the package metadata**
+
+Insert `"sideEffects": false` after the `"files"` array.
+
+```json
+  "files": [
+    "umd",
+    "dist",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "author": "yanzhen@smartx.com",
+```
+
+- [ ] **Step 2: Validate JSON syntax**
+
+Run:
+
+```bash
+node -e "JSON.parse(require('node:fs').readFileSync('packages/rrweb-snapshot/package.json', 'utf8')); console.log('ok')"
+```
+
+Expected: prints `ok`.
+
+## Task 4: Add The Record-Local Source Resolver
+
+**Files:**
+- Modify: `packages/record/vite.config.ts`
+
+- [ ] **Step 1: Replace the config with an inline exact-import resolver**
+
+```ts
+import path from 'path';
+import type { Plugin } from 'vite';
+import config from '../../vite.config.default';
+
+const sourceEntryByPackageName = new Map([
+  ['rrweb', path.resolve(__dirname, '../rrweb/src/entries/record.ts')],
+  [
+    'rrweb-snapshot',
+    path.resolve(__dirname, '../rrweb-snapshot/src/index.ts'),
+  ],
+  ['rrdom', path.resolve(__dirname, '../rrdom/src/index.ts')],
+]);
+
+function resolveLocalSourceEntries(): Plugin {
+  return {
+    name: 'resolve-local-source-entries',
+    enforce: 'pre',
+    resolveId(source) {
+      return sourceEntryByPackageName.get(source) || null;
+    },
+  };
+}
+
+export default config(path.resolve(__dirname, 'src/index.ts'), 'rrwebRecord', {
+  plugins: [resolveLocalSourceEntries()],
+});
+```
+
+- [ ] **Step 2: Run TypeScript checking for the record package**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record check-types
+```
+
+Expected: TypeScript check succeeds.
+
+## Task 5: Make The rrweb Record Entry A Direct Re-Export
+
+**Files:**
+- Modify: `packages/rrweb/src/entries/record.ts`
+
+- [ ] **Step 1: Replace default-import-then-export with a direct named re-export**
+
+```ts
+export { default as record } from '../record';
+```
+
+- [ ] **Step 2: Type-check rrweb**
+
+Run:
+
+```bash
+yarn workspace rrweb check-types
+```
+
+Expected: TypeScript check succeeds.
+
+## Task 6: Build And Set The Final Size Threshold
+
+**Files:**
+- Modify: `packages/record/test/record.test.ts`
+
+- [ ] **Step 1: Build the fixed record package**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record build
+```
+
+Expected: build succeeds and writes `packages/record/dist/record.js`.
+
+- [ ] **Step 2: Measure the fixed ESM bundle size**
+
+Run:
+
+```bash
+wc -c packages/record/dist/record.js
+```
+
+Expected: output is at least `204800` bytes smaller than the baseline from Task 1.
+
+- [ ] **Step 3: Update the test comment with measured before and after sizes**
+
+Use the exact byte count printed in Step 2 in a new comment line above the threshold constants. Keep `BASELINE_RECORD_JS_BYTES` equal to `397373`. For example, if Step 2 prints `180245 packages/record/dist/record.js`, the threshold block becomes:
+
+```ts
+// Measured before the tree-shaking fix: 397373 bytes.
+// Measured after the tree-shaking fix: 180245 bytes.
+// The fixed ESM bundle must stay at least 200 KiB smaller.
+const BASELINE_RECORD_JS_BYTES = 397373;
+const MAX_RECORD_JS_BYTES = BASELINE_RECORD_JS_BYTES - 200 * 1024;
+```
+
+## Task 7: Verify The Regression Tests Pass
+
+**Files:**
+- Test: `packages/record/test/record.test.ts`
+
+- [ ] **Step 1: Run the focused record tests**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record test
+```
+
+Expected: all tests in `packages/record/test/record.test.ts` pass.
+
+- [ ] **Step 2: Confirm `postcss` is absent from emitted record JavaScript**
+
+Run:
+
+```bash
+rg -n "postcss" packages/record/dist --glob '*.{js,cjs}'
+```
+
+Expected: no matches and exit code `1`.
+
+## Task 8: Run Final Verification
+
+**Files:**
+- Test: `packages/rrweb-snapshot/package.json`
+- Test: `packages/record/vite.config.ts`
+- Test: `packages/rrweb/src/entries/record.ts`
+- Test: `packages/record/test/record.test.ts`
+
+- [ ] **Step 1: Check rrweb-snapshot types**
+
+Run:
+
+```bash
+yarn workspace rrweb-snapshot check-types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 2: Rebuild record**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record build
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Run record tests**
+
+Run:
+
+```bash
+yarn workspace @rrweb/record test
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Review the final diff**
+
+Run:
+
+```bash
+git diff -- packages/rrweb-snapshot/package.json packages/record/vite.config.ts packages/rrweb/src/entries/record.ts packages/record/test/record.test.ts
+```
+
+Expected: diff only contains the planned implementation and test changes.
+
+## Task 9: Commit The Implementation
+
+**Files:**
+- Stage: `packages/rrweb-snapshot/package.json`
+- Stage: `packages/record/vite.config.ts`
+- Stage: `packages/rrweb/src/entries/record.ts`
+- Stage: `packages/record/test/record.test.ts`
+
+- [ ] **Step 1: Stage implementation files only**
+
+Run:
+
+```bash
+git add packages/rrweb-snapshot/package.json packages/record/vite.config.ts packages/rrweb/src/entries/record.ts packages/record/test/record.test.ts
+```
+
+Expected: staged diff excludes the pre-existing `packages/rrweb-player/.svelte-kit/ambient.d.ts` change.
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git commit -m "fix: tree-shake postcss from record bundle"
+```
+
+Expected: commit succeeds.

--- a/docs/superpowers/plans/2026-05-19-record-tree-shaking.md
+++ b/docs/superpowers/plans/2026-05-19-record-tree-shaking.md
@@ -20,6 +20,7 @@
 ## Task 1: Confirm The Baseline
 
 **Files:**
+
 - Read: `packages/record/dist/record.js`
 - Modify: none
 
@@ -56,6 +57,7 @@ Expected: at least one match in a built JavaScript artifact. In this workspace, 
 ## Task 2: Add Failing Bundle Regression Tests
 
 **Files:**
+
 - Modify: `packages/record/test/record.test.ts`
 
 - [ ] **Step 1: Replace the test file with build-output checks**
@@ -129,6 +131,7 @@ Expected: the new `postcss` assertion fails, or the size assertion fails, becaus
 ## Task 3: Mark rrweb-snapshot As Side-Effect-Free
 
 **Files:**
+
 - Modify: `packages/rrweb-snapshot/package.json`
 
 - [ ] **Step 1: Add the package metadata**
@@ -158,6 +161,7 @@ Expected: prints `ok`.
 ## Task 4: Add The Record-Local Source Resolver
 
 **Files:**
+
 - Modify: `packages/record/vite.config.ts`
 
 - [ ] **Step 1: Replace the config with an inline exact-import resolver**
@@ -169,10 +173,7 @@ import config from '../../vite.config.default';
 
 const sourceEntryByPackageName = new Map([
   ['rrweb', path.resolve(__dirname, '../rrweb/src/entries/record.ts')],
-  [
-    'rrweb-snapshot',
-    path.resolve(__dirname, '../rrweb-snapshot/src/index.ts'),
-  ],
+  ['rrweb-snapshot', path.resolve(__dirname, '../rrweb-snapshot/src/index.ts')],
   ['rrdom', path.resolve(__dirname, '../rrdom/src/index.ts')],
 ]);
 
@@ -204,6 +205,7 @@ Expected: TypeScript check succeeds.
 ## Task 5: Make The rrweb Record Entry A Direct Re-Export
 
 **Files:**
+
 - Modify: `packages/rrweb/src/entries/record.ts`
 
 - [ ] **Step 1: Replace default-import-then-export with a direct named re-export**
@@ -225,6 +227,7 @@ Expected: TypeScript check succeeds.
 ## Task 6: Build And Set The Final Size Threshold
 
 **Files:**
+
 - Modify: `packages/record/test/record.test.ts`
 
 - [ ] **Step 1: Build the fixed record package**
@@ -262,6 +265,7 @@ const MAX_RECORD_JS_BYTES = BASELINE_RECORD_JS_BYTES - 200 * 1024;
 ## Task 7: Verify The Regression Tests Pass
 
 **Files:**
+
 - Test: `packages/record/test/record.test.ts`
 
 - [ ] **Step 1: Run the focused record tests**
@@ -287,6 +291,7 @@ Expected: no matches and exit code `1`.
 ## Task 8: Run Final Verification
 
 **Files:**
+
 - Test: `packages/rrweb-snapshot/package.json`
 - Test: `packages/record/vite.config.ts`
 - Test: `packages/rrweb/src/entries/record.ts`
@@ -335,6 +340,7 @@ Expected: diff only contains the planned implementation and test changes.
 ## Task 9: Commit The Implementation
 
 **Files:**
+
 - Stage: `packages/rrweb-snapshot/package.json`
 - Stage: `packages/record/vite.config.ts`
 - Stage: `packages/rrweb/src/entries/record.ts`

--- a/docs/superpowers/specs/2026-05-19-record-tree-shaking-design.md
+++ b/docs/superpowers/specs/2026-05-19-record-tree-shaking-design.md
@@ -1,0 +1,80 @@
+# Record Tree-Shaking Design
+
+## Context
+
+`rrweb-snapshot` contains both record-time snapshot code and replay-time rebuild code. The rebuild path imports `postcss`, which is large and unnecessary for `@rrweb/record` consumers. Because `rrweb-snapshot` currently publishes a single barrel bundle, consumers that import record-only APIs can still end up with replay-only code in their output.
+
+The goal is to reimplement the behavior targeted by rrweb PR #1784 without copying that implementation. The implementation should use the current repository structure and keep the change low risk.
+
+## Goals
+
+- Build `@rrweb/record` without bundling `postcss`.
+- Preserve the current public API for `rrweb`, `rrweb-snapshot`, `rrdom`, and `@rrweb/record`.
+- Keep the implementation narrow and easy to review.
+- Add tests that catch both the direct dependency regression and the bundle-size impact.
+
+## Non-Goals
+
+- Do not add new public `rrweb-snapshot` subpath exports.
+- Do not split `rrweb-snapshot` into separate published snapshot and rebuild packages.
+- Do not refactor snapshot/rebuild utilities unless the narrow build fix cannot pass verification without it.
+- Do not inspect or copy the PR #1784 implementation.
+
+## Proposed Approach
+
+Use a source-boundary build fix for `packages/record`.
+
+1. Mark `rrweb-snapshot` as side-effect-free in `packages/rrweb-snapshot/package.json`.
+2. Add a Vite/Rollup `resolveId` plugin to `packages/record/vite.config.ts`.
+3. During the record package build, redirect bare imports of `rrweb`, `rrweb-snapshot`, and `rrdom` to their local source entry files instead of their pre-built package entrypoints.
+4. Change `packages/rrweb/src/entries/record.ts` to directly re-export the named `record` export from the record module.
+5. Extend `packages/record/test/record.test.ts` so it verifies the built record output does not contain `postcss` and records a significant file-size drop signal.
+
+## Architecture
+
+The public packages keep their existing import paths. The special behavior is limited to the `@rrweb/record` build config.
+
+The record package currently imports `record` through `rrweb`. That package import can resolve to the pre-built `rrweb` bundle, which hides source module boundaries from Rollup. The custom resolver restores those boundaries by mapping:
+
+- `rrweb` to `packages/rrweb/src/entries/record.ts`
+- `rrweb-snapshot` to `packages/rrweb-snapshot/src/index.ts`
+- `rrdom` to `packages/rrdom/src/index.ts`
+
+The resolver should match only exact bare imports. It should not rewrite subpath imports such as `rrweb/foo` unless a future change explicitly adds that case.
+
+The resolver should live inline in `packages/record/vite.config.ts`. It is a record-package build concern, not a shared monorepo helper.
+
+Once Rollup sees source modules, `"sideEffects": false` on `rrweb-snapshot` allows unused rebuild modules to be removed when record consumers do not use rebuild exports. This should use plain `"sideEffects": false`, not a narrower allowlist. PR #1834's `rebuild.ts` changes do not add import-time side effects; its DOM work and sandbox checks happen only when exported functions are called.
+
+The `rrweb` record entry should use a direct named re-export. This gives Rollup a simpler export graph than a default import followed by a re-export.
+
+## Testing
+
+Keep the existing smoke test that `record` is a function.
+
+Add a build-output regression test for `@rrweb/record`:
+
+- Inspect emitted `.js` and `.cjs` files in `packages/record/dist`.
+- Assert no emitted `.js` or `.cjs` file contains the string `postcss`.
+- Use `packages/record/dist/record.js` as the canonical size signal.
+- Measure the current `dist/record.js` size locally before changing implementation files, then assert the fixed `dist/record.js` size is at least 200KB smaller than that baseline.
+
+The implementation should encode that baseline-derived threshold as a constant in the test, with a comment documenting the measured before/after sizes. The test should compare durable built artifacts, not transient visualizer output or source maps. It should not run the build itself; if `dist/record.js` is missing, it should fail with a clear message telling the developer to run `yarn workspace @rrweb/record build` first.
+
+## Verification
+
+Run focused verification after implementation:
+
+```sh
+yarn workspace rrweb-snapshot check-types
+yarn workspace @rrweb/record build
+yarn workspace @rrweb/record test
+```
+
+## Risks
+
+The resolver must be scoped to the record build. Applying it globally could change other package builds unexpectedly.
+
+The file-size threshold must be strict enough to catch regressions but not so strict that unrelated output formatting or dependency updates cause noise. It should focus on the main JavaScript bundle and leave source maps out of the assertion.
+
+Marking `rrweb-snapshot` as side-effect-free assumes its module-level code does not intentionally perform observable side effects on import. That matches the intended package usage for tree-shaking and remains compatible with PR #1834's `rebuild.ts` changes, but verification should include existing snapshot and record tests.

--- a/packages/record/test/record.test.ts
+++ b/packages/record/test/record.test.ts
@@ -1,8 +1,54 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { record } from '../src/index';
+
+const distDir = path.resolve(__dirname, '../dist');
+const recordJsPath = path.join(distDir, 'record.js');
+
+// Measured before the tree-shaking fix: 397373 bytes.
+// Measured after the tree-shaking fix: 161287 bytes.
+// The fixed ESM bundle must stay at least 200 KiB smaller.
+const BASELINE_RECORD_JS_BYTES = 397373;
+const MAX_RECORD_JS_BYTES = BASELINE_RECORD_JS_BYTES - 200 * 1024;
+
+function requireBuiltRecordBundle() {
+  if (!existsSync(recordJsPath)) {
+    throw new Error(
+      'Missing packages/record/dist/record.js. Run `yarn workspace @rrweb/record build` before running this test.',
+    );
+  }
+}
+
+function emittedJavaScriptFiles() {
+  if (!existsSync(distDir)) {
+    throw new Error(
+      'Missing packages/record/dist. Run `yarn workspace @rrweb/record build` before running this test.',
+    );
+  }
+  return readdirSync(distDir)
+    .filter((file) => file.endsWith('.js') || file.endsWith('.cjs'))
+    .map((file) => path.join(distDir, file));
+}
 
 describe('record', () => {
   it('should be a function', () => {
     expect(typeof record).toBe('function');
+  });
+
+  it('does not bundle replay-only postcss code', () => {
+    requireBuiltRecordBundle();
+
+    for (const file of emittedJavaScriptFiles()) {
+      expect(readFileSync(file, 'utf-8')).not.toContain('postcss');
+    }
+  });
+
+  it('keeps the ESM record bundle at least 200 KiB below the baseline size', () => {
+    requireBuiltRecordBundle();
+
+    expect(statSync(recordJsPath).size).toBeLessThanOrEqual(
+      MAX_RECORD_JS_BYTES,
+    );
   });
 });

--- a/packages/record/vite.config.ts
+++ b/packages/record/vite.config.ts
@@ -4,10 +4,7 @@ import config from '../../vite.config.default';
 
 const sourceEntryByPackageName = new Map([
   ['rrweb', path.resolve(__dirname, '../rrweb/src/entries/record.ts')],
-  [
-    'rrweb-snapshot',
-    path.resolve(__dirname, '../rrweb-snapshot/src/index.ts'),
-  ],
+  ['rrweb-snapshot', path.resolve(__dirname, '../rrweb-snapshot/src/index.ts')],
   ['rrdom', path.resolve(__dirname, '../rrdom/src/index.ts')],
 ]);
 

--- a/packages/record/vite.config.ts
+++ b/packages/record/vite.config.ts
@@ -1,4 +1,26 @@
 import path from 'path';
+import type { Plugin } from 'vite';
 import config from '../../vite.config.default';
 
-export default config(path.resolve(__dirname, 'src/index.ts'), 'rrwebRecord');
+const sourceEntryByPackageName = new Map([
+  ['rrweb', path.resolve(__dirname, '../rrweb/src/entries/record.ts')],
+  [
+    'rrweb-snapshot',
+    path.resolve(__dirname, '../rrweb-snapshot/src/index.ts'),
+  ],
+  ['rrdom', path.resolve(__dirname, '../rrdom/src/index.ts')],
+]);
+
+function resolveLocalSourceEntries(): Plugin {
+  return {
+    name: 'resolve-local-source-entries',
+    enforce: 'pre',
+    resolveId(source) {
+      return sourceEntryByPackageName.get(source) || null;
+    },
+  };
+}
+
+export default config(path.resolve(__dirname, 'src/index.ts'), 'rrwebRecord', {
+  plugins: [resolveLocalSourceEntries()],
+});

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -48,6 +48,7 @@
     "dist",
     "package.json"
   ],
+  "sideEffects": false,
   "author": "yanzhen@smartx.com",
   "license": "MIT",
   "bugs": {

--- a/packages/rrweb/src/entries/record.ts
+++ b/packages/rrweb/src/entries/record.ts
@@ -1,3 +1,1 @@
-import record from '../record';
-
-export { record };
+export { default as record } from '../record';


### PR DESCRIPTION
## Summary
- Marks `rrweb-snapshot` as side-effect-free so unused rebuild modules can be dropped.
- Resolves `rrweb`, `rrweb-snapshot`, and `rrdom` to local source entrypoints during the `@rrweb/record` build.
- Adds regression coverage that record bundles do not contain `postcss` and that `dist/record.js` stays at least 200 KiB below the measured baseline.

## Why
`@rrweb/record` imports through pre-built package barrels, which hides module boundaries from Rollup and keeps replay-only `rrweb-snapshot` rebuild code, including `postcss`, in record-time bundles. The record build now sees the source module graph and can drop replay-only code without changing the public package API.

## Validation
- `yarn workspace rrweb-snapshot check-types`
- `yarn workspace @rrweb/record build`
- `yarn workspace @rrweb/record test`
- `rg -n "postcss" packages/record/dist --glob '*.{js,cjs}'` found no matches

Bundle size check:
- Before: `packages/record/dist/record.js` was 397373 bytes
- After: `packages/record/dist/record.js` is 161287 bytes
- Reduction: 236086 bytes
