### PR TITLE
fix: post bundle size comments for fork prs

### DIFF
--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -32,6 +32,8 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build Packages
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build:all
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Eslint Check
         run: yarn turbo run lint
       - name: Save Code Linting Report JSON
@@ -74,7 +76,7 @@ jobs:
       # --- Base branch ---
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
       - name: Download PR bundle sizes
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pr-checks-privileged.yml
+++ b/.github/workflows/pr-checks-privileged.yml
@@ -37,15 +37,27 @@ jobs:
             if (run.pull_requests && run.pull_requests.length > 0) {
               return run.pull_requests[0].number;
             }
-            // Fallback for fork PRs (pull_requests is empty for forks)
+
+            // Fallback for fork PRs (pull_requests is empty for forks).
+            // The Pulls API expects the head filter as "owner:branch", not
+            // "owner/repo:branch".
+            const headOwner =
+              run.head_repository?.owner?.login ||
+              run.head_repository?.owner?.name;
+            if (!headOwner) {
+              core.setFailed('Could not determine workflow run head owner');
+              return;
+            }
+
+            const head = `${headOwner}:${run.head_branch}`;
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: `${run.head_repository.full_name}:${run.head_branch}`,
+              head,
               state: 'open',
             });
             if (prs.length === 0) {
-              core.setFailed('Could not determine PR number');
+              core.setFailed(`Could not determine PR number for head ${head}`);
               return;
             }
             return prs[0].number;


### PR DESCRIPTION
## Summary

- fix fork PR lookup in the privileged bundle-size comment workflow by using `owner:branch`
- pin base bundle measurement to the exact PR base SHA
- align PR/base build environment for bundle measurements

## Why

PR #1835 is a fork PR from `Juice10:codex/record-tree-shaking-postcss`. Its unprivileged `ESLint Check` workflow successfully built and uploaded the bundle-size artifacts, but the follow-up `PR Checks (privileged)` workflow failed before posting the sticky bundle-size comment.

The failed privileged run showed `Find PR number` still querying the Pulls API with `Juice10/rrweb:codex/record-tree-shaking-postcss`. That format returns no PRs. The Pulls API `head` filter expects `owner:branch`, so the same lookup succeeds with `Juice10:codex/record-tree-shaking-postcss` and resolves PR #1835.

This also fixes the bundle comparison inputs while we are in the workflow: the base bundle is now built from the exact PR base SHA instead of a moving base branch ref, and the PR/base builds use equivalent `PUPPETEER_SKIP_DOWNLOAD` settings.

## Validation

- `/opt/homebrew/bin/gh api` confirmed `Juice10:codex/record-tree-shaking-postcss` resolves PR #1835 while `Juice10/rrweb:...` does not
- `/Users/justin/.codex/worktrees/fc26/rrweb/node_modules/.bin/prettier --check .github/workflows/eslint-check.yml .github/workflows/pr-checks-privileged.yml`

Split out from PR #1835 so the record tree-shaking PR does not carry CI workflow changes.
