### PR TITLE
[codex] Add @rrweb/browser-client package

### DIFF
--- a/.changeset/add-browser-client.md
+++ b/.changeset/add-browser-client.md
@@ -1,0 +1,6 @@
+---
+"@rrweb/browser-client": patch
+"@rrweb/utils": patch
+---
+
+Add the rrweb browser client package and move `nowTimestamp` into `@rrweb/utils` so the client can avoid importing through `rrweb/utils`.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,6 +15,7 @@
       "@rrweb/types",
       "@rrweb/packer",
       "@rrweb/utils",
+      "@rrweb/browser-client",
       "@rrweb/web-extension",
       "rrvideo",
       "@rrweb/rrweb-plugin-console-record",

--- a/packages/browser-client/.env.example
+++ b/packages/browser-client/.env.example
@@ -1,0 +1,3 @@
+VITE_RRWEB_BROWSER_CLIENT_SERVER_URL=http://localhost:8787/recordings/{recordingId}/events/ws
+VITE_RRWEB_BROWSER_CLIENT_API_BASE_URL=http://localhost:8787
+VITE_TEST_API_KEY=public_key_rr_XXXX

--- a/packages/browser-client/README.md
+++ b/packages/browser-client/README.md
@@ -21,7 +21,6 @@ import rrwebBrowserClient, {
 } from '@rrweb/browser-client';
 
 start({
-  serverUrl: 'https://api.rrweb.com/recordings/{recordingId}/events/ws',
   publicApiKey: 'public_key_rr_...',
   includePii: false,
   meta: {
@@ -40,17 +39,18 @@ The default export exposes the same methods:
 
 ```js
 rrwebBrowserClient.start({
-  serverUrl: 'https://api.rrweb.com/recordings/{recordingId}/events/ws',
   publicApiKey: 'public_key_rr_...',
 });
 ```
 
 ## Options
 
-- `serverUrl`: events endpoint. Include `{recordingId}` in the URL, or the client will add it as a query parameter. `http` and `https` URLs are converted to `ws` and `wss` for the WebSocket connection, and the HTTP fallback posts to the same endpoint without a trailing `/ws`. See [Recording endpoint proxying](https://rrweb.com/docs/cloud/ingest-proxying) when routing events through your own domain.
+- `serverUrl`: optional events endpoint. Defaults to `https://api.rrweb.com/recordings/{recordingId}/events/ws`. Include `{recordingId}` in custom URLs, or the client will add it as a query parameter. `http` and `https` URLs are converted to `ws` and `wss` for the WebSocket connection, and the HTTP fallback posts to the same endpoint without a trailing `/ws`. See [Recording endpoint proxying](https://rrweb.com/docs/cloud/ingest-proxying) when routing events through your own domain.
 - `publicApiKey`: public write-only API key sent with WebSocket and HTTP fallback requests. rrweb Cloud public keys use the `public_key_rr_...` format. See [API Keys](https://rrweb.com/docs/cloud/api-keys).
 - `includePii`: default `false`. When enabled, the client includes additional visitor metadata such as language, timezone, screen size, title, and referrer details. See [Pre-baked metadata](https://rrweb.com/docs/cloud/prebaked-meta).
-- `meta`: custom recording metadata sent before recorded events. See [Application Metadata](https://rrweb.com/docs/cloud/application-meta).
+- `meta`: custom recording metadata sent before recorded events. Built-in diagnostics such as `recordVersion`, `recordCommitHash`, `jsSource`, and `jsEntrypoint` are added automatically after custom metadata. See [Application Metadata](https://rrweb.com/docs/cloud/application-meta).
+- `jsSource`: optional source identifier for programmatic loaders. URL values are recorded without query strings or hashes.
+- `jsEntrypoint`: optional entrypoint label. Defaults to `programmatic` for direct `start()` calls and `script-tag` for script-tag autostart.
 - rrweb record options: other options are passed through to `record()` from rrweb, such as masking, blocking, sampling, and DOM capture options. See the [rrweb recording docs](https://rrweb.com/docs/packages/record/readme).
 
 ### Stylesheet Capture

--- a/packages/browser-client/README.md
+++ b/packages/browser-client/README.md
@@ -1,0 +1,83 @@
+# @rrweb/browser-client
+
+Browser client for recording rrweb sessions to an rrweb Cloud-compatible API. It wraps rrweb recording, streams events over WebSocket, and falls back to HTTP POST for buffered events.
+
+This README covers the npm/ESM package. For the hosted script snippet and broader rrweb Cloud setup, see the [JavaScript SDK guide](https://rrweb.com/docs/cloud/javascript-sdk).
+
+## Installation
+
+```bash
+npm install @rrweb/browser-client
+```
+
+## Quick Start
+
+```js
+import rrwebBrowserClient, {
+  start,
+  stop,
+  addMeta,
+  getRecordingId,
+} from '@rrweb/browser-client';
+
+start({
+  serverUrl: 'https://api.rrweb.com/recordings/{recordingId}/events/ws',
+  publicApiKey: 'public_key_rr_...',
+  includePii: false,
+  meta: {
+    userId: 'user-123',
+    environment: 'production',
+  },
+});
+
+addMeta({ plan: 'pro' });
+
+console.log('recording id', getRecordingId());
+stop(false);
+```
+
+The default export exposes the same methods:
+
+```js
+rrwebBrowserClient.start({
+  serverUrl: 'https://api.rrweb.com/recordings/{recordingId}/events/ws',
+  publicApiKey: 'public_key_rr_...',
+});
+```
+
+## Options
+
+- `serverUrl`: events endpoint. Include `{recordingId}` in the URL, or the client will add it as a query parameter. `http` and `https` URLs are converted to `ws` and `wss` for the WebSocket connection, and the HTTP fallback posts to the same endpoint without a trailing `/ws`. See [Recording endpoint proxying](https://rrweb.com/docs/cloud/ingest-proxying) when routing events through your own domain.
+- `publicApiKey`: public write-only API key sent with WebSocket and HTTP fallback requests. rrweb Cloud public keys use the `public_key_rr_...` format. See [API Keys](https://rrweb.com/docs/cloud/api-keys).
+- `includePii`: default `false`. When enabled, the client includes additional visitor metadata such as language, timezone, screen size, title, and referrer details. See [Pre-baked metadata](https://rrweb.com/docs/cloud/prebaked-meta).
+- `meta`: custom recording metadata sent before recorded events. See [Application Metadata](https://rrweb.com/docs/cloud/application-meta).
+- rrweb record options: other options are passed through to `record()` from rrweb, such as masking, blocking, sampling, and DOM capture options. See the [rrweb recording docs](https://rrweb.com/docs/packages/record/readme).
+
+### Stylesheet Capture
+
+`inlineStylesheet` is currently used for stylesheet capture compatibility. Once the `captureAssets` recording API lands from the assets branch, `captureAssets.stylesheets` should replace that compatibility path.
+
+## Recording Helpers
+
+- `getRecordingId()`: returns the current recording id, creating it before `start()` if needed. Recording ids are stored in `sessionStorage`, so separate tabs get separate recording contexts.
+- `addMeta(payload)`: adds or updates recording metadata after recording has started.
+- `addPageviewMeta(payload)`: adds metadata for the current page view.
+- `addCustomEvent(tag, payload)`: queues a custom rrweb event.
+- `stop(resetRecordingId)`: stops rrweb recording and closes the WebSocket. Pass `true` to clear the stored recording id before a future `start()`.
+
+## Further Reading
+
+- [JavaScript SDK guide](https://rrweb.com/docs/cloud/javascript-sdk)
+- [WebSocket event streaming](https://rrweb.com/docs/cloud/websocket-ingest)
+- [Application Metadata](https://rrweb.com/docs/cloud/application-meta)
+- [Replaying Guide](https://rrweb.com/docs/cloud/replaying-guide)
+
+## Local Dev/Test Env Vars
+
+Copy `.env.example` to `.env` in this package when running local integration tests.
+
+```bash
+VITE_RRWEB_BROWSER_CLIENT_SERVER_URL=http://localhost:8787/recordings/{recordingId}/events/ws
+VITE_RRWEB_BROWSER_CLIENT_API_BASE_URL=http://localhost:8787
+VITE_TEST_API_KEY=public_key_rr_XXXX
+```

--- a/packages/browser-client/buildMetadata.ts
+++ b/packages/browser-client/buildMetadata.ts
@@ -1,0 +1,36 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type PackageJson = {
+  version: string;
+};
+
+function readBrowserClientVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(__dirname, 'package.json'), 'utf8'),
+  ) as PackageJson;
+  return packageJson.version;
+}
+
+function readGitCommitHash(): string {
+  if (process.env.RRWEB_COMMIT_HASH) {
+    return process.env.RRWEB_COMMIT_HASH;
+  }
+  if (process.env.GITHUB_SHA) {
+    return process.env.GITHUB_SHA;
+  }
+  return execSync('git rev-parse HEAD', {
+    cwd: resolve(__dirname, '../..'),
+    encoding: 'utf8',
+  }).trim();
+}
+
+export function browserClientBuildDefines(): Record<string, string> {
+  return {
+    __RRWEB_BROWSER_CLIENT_VERSION__: JSON.stringify(
+      readBrowserClientVersion(),
+    ),
+    __RRWEB_BROWSER_CLIENT_COMMIT_HASH__: JSON.stringify(readGitCommitHash()),
+  };
+}

--- a/packages/browser-client/package.json
+++ b/packages/browser-client/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@rrweb/browser-client",
+  "version": "2.0.0-alpha.20",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "rrweb",
+    "@rrweb/browser-client",
+    "websocket"
+  ],
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "yarn turbo run prepublish",
+    "retest": "cross-env PUPPETEER_HEADLESS=true yarn retest:headful",
+    "retest:headful": "vitest run --exclude test/benchmark",
+    "build-and-test": "yarn build && yarn retest",
+    "test:headless": "cross-env PUPPETEER_HEADLESS=true yarn build-and-test",
+    "test:headful": "cross-env PUPPETEER_HEADLESS=false yarn build-and-test",
+    "test": "yarn test:headless",
+    "test:watch": "yarn build && cross-env PUPPETEER_HEADLESS=true yarn vitest --exclude test/benchmark",
+    "test:update": "yarn test:headless --update",
+    "retest:update": "cross-env PUPPETEER_HEADLESS=true yarn retest --update",
+    "check-types": "tsc -noEmit",
+    "prepublish": "tsc -noEmit && vite build",
+    "lint": "yarn eslint src/**/*.ts"
+  },
+  "homepage": "https://github.com/rrweb-io/rrweb/tree/main/packages/browser-client#readme",
+  "bugs": {
+    "url": "https://github.com/rrweb-io/rrweb/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rrweb-io/rrweb.git"
+  },
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/browser-client.cjs",
+  "module": "./dist/browser-client.js",
+  "unpkg": "./dist/browser-client.umd.cjs",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/browser-client.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/browser-client.cjs"
+      }
+    }
+  },
+  "files": [
+    "umd",
+    "dist",
+    "package.json"
+  ],
+  "devDependencies": {
+    "puppeteer": "^20.9.0",
+    "typescript": "^5.4.5",
+    "vite": "^6.0.1",
+    "vite-plugin-dts": "^3.9.1",
+    "vitest": "^1.4.0"
+  },
+  "dependencies": {
+    "@rrweb/record": "^2.0.0-alpha.20",
+    "@rrweb/types": "^2.0.0-alpha.20",
+    "@rrweb/utils": "^2.0.0-alpha.20",
+    "rrweb": "^2.0.0-alpha.20",
+    "websocket-ts": "^2.2.1"
+  },
+  "browserslist": [
+    "supports es6-class"
+  ]
+}

--- a/packages/browser-client/src/index.ts
+++ b/packages/browser-client/src/index.ts
@@ -13,11 +13,16 @@ import {
   WebsocketEvent,
 } from 'websocket-ts';
 
+declare const __RRWEB_BROWSER_CLIENT_VERSION__: string;
+declare const __RRWEB_BROWSER_CLIENT_COMMIT_HASH__: string;
+
 export type clientConfig = {
-  serverUrl: string;
+  serverUrl?: string;
   publicApiKey: string;
   autostart: boolean;
   includePii: boolean;
+  jsSource?: string;
+  jsEntrypoint?: string;
   meta?: nameValues;
 };
 
@@ -41,8 +46,10 @@ export type customEventWithTime = customEvent & {
   timestamp: number;
 };
 
+const defaultServerUrl =
+  'https://api.rrweb.com/recordings/{recordingId}/events/ws';
 let defaultClientConfig: clientConfig = {
-  serverUrl: 'ws://localhost:40000',
+  serverUrl: defaultServerUrl,
   publicApiKey: '',
   autostart: false,
   includePii: false,
@@ -58,6 +65,24 @@ let rrwebStopFn: listenerHandler | undefined;
 
 function isServerMessage(value: unknown): value is ServerMessage {
   return typeof value === 'object' && value !== null;
+}
+
+function sanitizeScriptSource(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    url.search = '';
+    url.hash = '';
+    return url.href;
+  } catch {
+    return value;
+  }
+}
+
+function scriptSourceFromElement(
+  script: HTMLScriptElement,
+): string | undefined {
+  return sanitizeScriptSource(script.src);
 }
 
 export function stop(resetRecordingId: boolean) {
@@ -247,8 +272,14 @@ async function postData(
 export function start(
   options: browserClientRecordOptions = defaultClientConfig,
 ) {
-  const { includePii, publicApiKey, ...recordOptions } = options;
-  let { serverUrl } = options;
+  const {
+    includePii,
+    publicApiKey,
+    jsSource: rawJsSource,
+    jsEntrypoint,
+    ...recordOptions
+  } = options;
+  let { serverUrl = defaultServerUrl } = options;
 
   if (recordOptions.slimDOMOptions === undefined) {
     recordOptions.slimDOMOptions = 'all';
@@ -340,6 +371,14 @@ export function start(
   }
   if (options.meta) {
     Object.assign(initialPayload, options.meta);
+  }
+  initialPayload.recordVersion = __RRWEB_BROWSER_CLIENT_VERSION__;
+  initialPayload.recordCommitHash = __RRWEB_BROWSER_CLIENT_COMMIT_HASH__;
+  initialPayload.jsEntrypoint = jsEntrypoint ?? 'programmatic';
+
+  const jsSource = sanitizeScriptSource(rawJsSource);
+  if (jsSource) {
+    initialPayload.jsSource = jsSource;
   }
 
   const metaEvent: customEventWithTime = {
@@ -501,6 +540,8 @@ if (document && document.currentScript) {
       );
     }
   }
+  config.jsSource ??= scriptSourceFromElement(self);
+  config.jsEntrypoint ??= self.dataset.rrwebEntrypoint || 'script-tag';
   if (truthyAttr.includes(self.getAttribute('includepii'))) {
     config.includePii = true;
   }
@@ -517,6 +558,7 @@ if (document && document.currentScript) {
           if (
             apiHost === 'rrweb.com' ||
             apiHost === 'www.rrweb.com' ||
+            apiHost === 'cdn.rrweb.com' ||
             apiHost === 'rrweb.io' ||
             apiHost.endsWith('.rrweb.io')
           ) {

--- a/packages/browser-client/src/index.ts
+++ b/packages/browser-client/src/index.ts
@@ -1,0 +1,546 @@
+import { record } from '@rrweb/record';
+
+import { EventType } from '@rrweb/types';
+import type { customEvent, eventWithTime, listenerHandler } from '@rrweb/types';
+import { nowTimestamp } from '@rrweb/utils';
+import type { recordOptions } from 'rrweb';
+
+import {
+  ArrayQueue,
+  ExponentialBackoff,
+  Websocket,
+  WebsocketBuilder,
+  WebsocketEvent,
+} from 'websocket-ts';
+
+export type clientConfig = {
+  serverUrl: string;
+  publicApiKey: string;
+  autostart: boolean;
+  includePii: boolean;
+  meta?: nameValues;
+};
+
+export type nameValues = Record<string, string | boolean | number>;
+
+export type browserClientRecordOptions = Omit<
+  recordOptions<eventWithTime>,
+  'emit'
+> &
+  clientConfig & {
+    emit?: recordOptions<eventWithTime>['emit'] | string;
+  };
+
+type websocketListenerHandler = (i: Websocket, ev: MessageEvent) => void;
+type ServerMessage =
+  | { type: 'error' }
+  | { type: 'upstream-result'; ok?: boolean }
+  | { type?: unknown; ok?: unknown };
+
+export type customEventWithTime = customEvent & {
+  timestamp: number;
+};
+
+let defaultClientConfig: clientConfig = {
+  serverUrl: 'ws://localhost:40000',
+  publicApiKey: '',
+  autostart: false,
+  includePii: false,
+};
+const sessionStorageName = 'rrweb-browser-client-recording-id';
+const wsLimit = 10e5; // this is approximate and depends on the browser, also on how unicode is encoded (we are comparing against the length of a javascript string)
+
+let ws: Websocket | undefined;
+let wsConnectionPaused = false;
+
+const buffer: ArrayQueue<string> = new ArrayQueue();
+let rrwebStopFn: listenerHandler | undefined;
+
+function isServerMessage(value: unknown): value is ServerMessage {
+  return typeof value === 'object' && value !== null;
+}
+
+export function stop(resetRecordingId: boolean) {
+  // reset all state so that start() can start afresh
+  if (rrwebStopFn !== undefined) {
+    rrwebStopFn();
+    rrwebStopFn = undefined;
+  }
+  if (ws) {
+    const closeEvent: customEventWithTime = {
+      timestamp: nowTimestamp(),
+      type: EventType.Custom,
+      data: {
+        tag: 'close-' + (resetRecordingId ? 'permanent' : 'temporary'),
+        payload: {},
+      },
+    };
+    // Clear old events before send, so websocket-ts can buffer the close event
+    // for the HTTP fallback when the socket is not currently open.
+    buffer.clear();
+    ws.send(JSON.stringify(closeEvent));
+    ws.close();
+    wsConnectionPaused = false;
+    ws = undefined; // so `emit` can restart it again if page is unfrozen
+  } else {
+    buffer.clear();
+  }
+  if (resetRecordingId) {
+    removeRecordingId();
+  }
+}
+
+function removeRecordingId(): void {
+  sessionStorage.removeItem(sessionStorageName);
+}
+
+function getSetVisitorId() {
+  const nameEQ = 'rrweb-browser-client-visitor-id=';
+  let value: string | null = null;
+  if (document.cookie) {
+    document.cookie.split(';').forEach((cp) => {
+      if (cp.trim().startsWith(nameEQ)) {
+        value = cp.trim();
+        // we could `break` (if not in a forEach) as we're not setting multiple cookies against different subdomains/paths
+      }
+    });
+  }
+  if (!value) {
+    // eslint-disable-next-line compat/compat -- @rrweb/browser-client targets modern browsers with crypto UUID support for recording/session identity.
+    value = self.crypto.randomUUID();
+    const date = new Date();
+    date.setTime(date.getTime() + 366 * 86400000); // 1 year
+    const expires = 'expires=' + date.toUTCString();
+
+    // SameSite=Lax to cross subdomains
+    const secure = window.location.protocol === 'https:' ? ';Secure' : '';
+    const domain = `;domain=${document.location.host.replace(/^www\./, '')}`;
+    document.cookie = `${nameEQ}${value};${expires}${domain};path=/;SameSite=Lax${secure}`;
+  }
+  return value;
+}
+
+function getSetRecordingId(): string | null {
+  let value: string | null = null;
+  try {
+    value = sessionStorage.getItem(sessionStorageName);
+    if (!value) {
+      // eslint-disable-next-line compat/compat -- @rrweb/browser-client targets modern browsers with crypto UUID support for recording/session identity.
+      value = self.crypto.randomUUID();
+      try {
+        sessionStorage.setItem(sessionStorageName, value);
+      } catch (e) {
+        value = null;
+      }
+    }
+  } catch (e) {
+    value = null;
+  }
+  return value;
+}
+
+// if API client requests the recording ID prior to start,
+// set it immediately so that it will be the eventual id used
+export const getRecordingId = getSetRecordingId;
+
+function connect(
+  serverUrl: string,
+  postUrl: string,
+  publicApiKey: string,
+  messageHandler: websocketListenerHandler,
+): Websocket {
+  const wsUrl = new URL(serverUrl);
+  if (publicApiKey) {
+    wsUrl.searchParams.set('token', publicApiKey);
+  }
+  wsUrl.protocol = wsUrl.protocol.replace('http', 'ws'); // testing/puppeteer: SyntaxError: Failed to construct 'WebSocket': The URL's scheme must be either 'ws' or 'wss'. 'https' is not allowed.
+
+  const ws = new WebsocketBuilder(wsUrl.href)
+    .withBuffer(buffer) // when disconnected
+    .withBackoff(
+      new ExponentialBackoff(500 + Math.round(1000 * Math.random()), 6),
+    ) // retry around every 1s, 2s, 4s, 8s, maxing out with a retry every ~1minute
+    .build();
+
+  const fallbackPosting = setInterval(() => {
+    if (buffer.length()) {
+      void postData(postUrl, publicApiKey, buffer).catch((error) => {
+        clearInterval(fallbackPosting);
+        console.error('Error periodically POSTing events:', error);
+      });
+    }
+  }, 5 * 1000);
+
+  // Add event listeners
+  ws.addEventListener(WebsocketEvent.open, () => {
+    clearInterval(fallbackPosting);
+  });
+  ws.addEventListener(WebsocketEvent.message, messageHandler);
+  return ws;
+}
+
+async function postData(
+  postUrl: string,
+  publicApiKey: string,
+  buffer: ArrayQueue<string> | string,
+) {
+  const keepaliveLimit = 65000;
+  let done = false;
+  const responses: Response[] = [];
+  const toSend: string[] = [];
+  do {
+    let body;
+    if (buffer instanceof ArrayQueue) {
+      // this clears the buffer so no need to call buffer.clear()
+      let sendSize = 0;
+      done = true;
+      for (
+        let eventStr = buffer.read();
+        eventStr !== undefined;
+        eventStr = buffer.read()
+      ) {
+        toSend.push(eventStr);
+        sendSize += eventStr.length;
+        if (sendSize > keepaliveLimit) {
+          done = false;
+          break;
+        }
+      }
+      body = toSend.join('\n');
+    } else {
+      body = buffer;
+      done = true;
+    }
+    // eslint-disable-next-line compat/compat -- fetch is the runtime transport for POST fallback in supported browsers.
+    const response = await fetch(postUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        Authorization: `Bearer ${publicApiKey}`,
+      },
+      body,
+      keepalive: body.length < keepaliveLimit, // don't abort POST after end of session (must be under the limit)
+    });
+    responses.push(response);
+    if (!response.ok) {
+      if (buffer instanceof ArrayQueue) {
+        // re-queue events in case we can reconnect next time or with ws
+        toSend.forEach((eventStr) => buffer.add(eventStr));
+      }
+      break;
+    } else if (done) {
+      break;
+    }
+  } while (!done);
+  const badResponse = responses.find((r) => r.status >= 300);
+  if (badResponse) {
+    let badResponseInfo = `${badResponse.status} ${badResponse.statusText}`;
+    if (!badResponse.bodyUsed) {
+      badResponseInfo +=
+        '\nresponse body:' + JSON.stringify(await badResponse.json());
+    }
+    throw new Error(`Bad response from POST: ${badResponseInfo}`);
+  }
+  return responses;
+}
+
+export function start(
+  options: browserClientRecordOptions = defaultClientConfig,
+) {
+  const { includePii, publicApiKey, ...recordOptions } = options;
+  let { serverUrl } = options;
+
+  if (recordOptions.slimDOMOptions === undefined) {
+    recordOptions.slimDOMOptions = 'all';
+  }
+  if (recordOptions.maskAllInputs === undefined) {
+    recordOptions.maskAllInputs = true; // default to more privacy
+  }
+  // TODO: switch this back to captureAssets.stylesheets once rrweb pulls in
+  // the captureAssets recording API from the assets branch.
+  if (recordOptions.inlineStylesheet === undefined) {
+    recordOptions.inlineStylesheet = true;
+  }
+
+  const configEmit = recordOptions.emit;
+
+  const handleMessage = (_: Websocket, ev: MessageEvent) => {
+    const parsedEvent: unknown = JSON.parse(String(ev.data));
+    if (
+      isServerMessage(parsedEvent) &&
+      (parsedEvent.type === 'error' ||
+        (parsedEvent.type === 'upstream-result' && !parsedEvent.ok))
+    ) {
+      console.warn('received error, pausing websockets:', parsedEvent);
+      wsConnectionPaused = true;
+    } else {
+      console.log(`received message: ${String(ev.data)}`);
+    }
+  };
+
+  const recordingId = getSetRecordingId();
+  if (!recordingId) {
+    // TODO: we could allow client to supply their own recordingId
+    // however that would have implications on how we can handle
+    // recordings server side (that a recording could mix events from
+    // multiple browsing contexts)
+    console.error(
+      '@rrweb/browser-client: Unable to start(); sessionStorage unavailable',
+    );
+    return;
+  }
+
+  const initialPayload: nameValues = {
+    domain: document.location.hostname || document.location.href.split('?')[0], // latter is for debugging (e.g. a file:// url)
+    includePii: Boolean(includePii), // tell server not to store IP addresses or user agents
+  };
+
+  // the expected replacement of recording id
+  serverUrl = serverUrl.replace('{recordingId}', recordingId);
+  serverUrl = serverUrl.replace('%7BrecordingId%7D', recordingId); // as mangled by `new URL`
+
+  const sURL = new URL(serverUrl);
+  if (!serverUrl.includes(recordingId)) {
+    // '{recordingId}' wasn't in the url;
+    // pass as a query string param instead
+    sURL.searchParams.set('recordingId', recordingId);
+    serverUrl = sURL.href;
+    // also include in initialPayload in case query string gets lost during upgrade or proxying
+    initialPayload.recordingId = recordingId;
+  }
+  if (sURL.pathname.endsWith('/ws')) {
+    sURL.pathname = sURL.pathname.slice(0, -3);
+  }
+  const postUrl = sURL.href;
+
+  if (includePii) {
+    initialPayload.visitor = getSetVisitorId();
+    try {
+      initialPayload.timezone =
+        Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (e) {
+      initialPayload.timezone = 'unknown';
+    }
+    try {
+      if (navigator.languages !== undefined) {
+        initialPayload.language = navigator.languages[0];
+      } else {
+        initialPayload.language = navigator.language;
+      }
+    } catch (e) {
+      initialPayload.language = 'unknown';
+    }
+    // initialPayload.userAgent = navigator.userAgent;  // we should be able to get this server side
+    // the following is different to EventType.Meta width/height
+    // which is used in replay; it's more about what size screen
+    // the visitor has for analytics
+    initialPayload.screenWidth = screen.width;
+    initialPayload.screenHeight = screen.height;
+    initialPayload.devicePixelRatio = window.devicePixelRatio;
+  }
+  if (options.meta) {
+    Object.assign(initialPayload, options.meta);
+  }
+
+  const metaEvent: customEventWithTime = {
+    timestamp: nowTimestamp(),
+    type: EventType.Custom,
+    data: {
+      tag: 'recording-meta',
+      payload: initialPayload,
+    },
+  };
+  // metadata event should be the first seen server side
+  buffer.add(JSON.stringify(metaEvent));
+
+  recordOptions.emit = (event: eventWithTime) => {
+    if (!ws) {
+      // don't make a connection until rrweb starts (looks at document.readyState and waits for DOMContentLoaded or load)
+      ws = connect(serverUrl, postUrl, publicApiKey, handleMessage);
+
+      ws.addEventListener(WebsocketEvent.close, () => {
+        // fallback to postData while backoff algorithm is in effect
+        wsConnectionPaused = true;
+      });
+    }
+    if (configEmit !== undefined) {
+      if (typeof configEmit === 'function') {
+        configEmit(event);
+      } else if (
+        typeof (window as unknown as Record<string, unknown>)[configEmit] ===
+        'function'
+      ) {
+        const emit = (window as unknown as Record<string, unknown>)[
+          configEmit
+        ] as (event: eventWithTime) => void;
+        emit(event);
+      } else {
+        console.error('Could not understand emit config option:', configEmit);
+      }
+    }
+    if (event.type === EventType.Meta && includePii) {
+      const metaData = event.data as typeof event.data & {
+        title?: string;
+        referrer?: string;
+      };
+      metaData.title = document.title.substring(0, 500); // already recorded in rrweb as part of the <title> element
+      metaData.referrer = document.referrer; // could potentially contain PII
+    }
+
+    const eventStr = JSON.stringify(event);
+    // TODO: add browser native compression
+    if (eventStr.length > wsLimit) {
+      // Assuming wsLimit is a defined constant, and eventStr.length is intended.
+      void postData(postUrl, publicApiKey, eventStr);
+    } else if (ws && !wsConnectionPaused) {
+      ws.send(eventStr);
+    } else {
+      buffer.add(eventStr);
+    }
+  };
+
+  let startWhenVisible = false;
+  if (!document.hidden) {
+    rrwebStopFn = record(recordOptions as recordOptions<eventWithTime>);
+  } else {
+    startWhenVisible = true;
+  }
+  if (typeof document.hidden !== 'undefined') {
+    document.addEventListener(
+      'visibilitychange',
+      () => {
+        if (!document.hidden && startWhenVisible) {
+          rrwebStopFn = record(recordOptions as recordOptions<eventWithTime>);
+          startWhenVisible = false;
+          return;
+        }
+        try {
+          // either of 'page-hidden' or 'page-visible'
+          record.addCustomEvent('page-' + document.visibilityState, {});
+          if (document.hidden) {
+            /*
+            - a user navigates to a new page
+            - switches tabs
+            - closes the tab
+            - minimizes or closes the browser
+            - switches from the browser to a different app
+          */
+            // don't record background animations etc. while page isn't visible
+            record.freezePage();
+
+            // document.hidden is better than beforeunload, see:
+            // https://developer.chrome.com/docs/web-platform/page-lifecycle-api
+            if ((!ws || wsConnectionPaused) && buffer.length()) {
+              void postData(postUrl, publicApiKey, buffer);
+            }
+          }
+        } catch (e) {
+          // ignore, recording may not be active yet
+        }
+      },
+      false,
+    );
+  }
+  document.addEventListener('freeze', () => {
+    // https://developer.chrome.com/docs/web-platform/page-lifecycle-api
+    // "In particular, it's important that you ... close any open Web Socket connections
+    if (ws) {
+      ws.close();
+      wsConnectionPaused = false;
+      ws = undefined; // so `emit` can restart it again if page is unfrozen
+    }
+    if (rrwebStopFn !== undefined) {
+      rrwebStopFn();
+      startWhenVisible = true;
+    }
+  });
+}
+
+export const addCustomEvent = <T>(tag: string, payload: T) => {
+  if (rrwebStopFn !== undefined) {
+    record.addCustomEvent(tag, payload);
+  } else {
+    const customEvent: customEventWithTime = {
+      timestamp: nowTimestamp(),
+      type: EventType.Custom,
+      data: {
+        tag,
+        payload,
+      },
+    };
+    // let websocket buffer handle it
+    buffer.add(JSON.stringify(customEvent));
+  }
+};
+
+export function addMeta(payload: nameValues) {
+  addCustomEvent('recording-meta', payload);
+}
+
+export function addPageviewMeta(payload: nameValues) {
+  // could alter timestamp to match Meta/FullSnapshot event
+  addCustomEvent('pageview-meta', payload);
+}
+
+if (document && document.currentScript) {
+  let config = defaultClientConfig;
+  const truthyAttr: readonly (string | null)[] = ['', 'yes', 'on', 'true', '1']; // empty string allows setting plain html5 attributes without values
+  const self = document.currentScript as HTMLScriptElement;
+  if (self.innerText && self.innerText.trim()) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- script tag config is an external payload.
+      config = JSON.parse(
+        self.innerText
+          .replace(/^\s*\/\/.*/gm, '') // remove comment lines
+          .replace(/,(\s*[\]}])/g, '$1'), // allow trailing commas
+      );
+    } catch (error) {
+      console.error(
+        '@rrweb/browser-client: Could not parse script tag config as JSON',
+        error,
+      );
+    }
+  }
+  if (truthyAttr.includes(self.getAttribute('includepii'))) {
+    config.includePii = true;
+  }
+  if (self.src) {
+    try {
+      if (config.serverUrl) {
+        // transform provided relative URLs into absolute based on where we are served from
+        config.serverUrl = new URL(config.serverUrl, self.src).href;
+      } else {
+        // generate a default server url
+        const srcUrl = new URL(self.src);
+        if (srcUrl.hostname) {
+          let apiHost = srcUrl.hostname;
+          if (
+            apiHost === 'rrweb.com' ||
+            apiHost === 'www.rrweb.com' ||
+            apiHost === 'rrweb.io' ||
+            apiHost.endsWith('.rrweb.io')
+          ) {
+            apiHost = 'api.rrweb.com';
+          }
+          config.serverUrl = `https://${apiHost}/recordings/{recordingId}/events/ws`;
+        }
+      }
+    } catch {
+      // maybe we are in a weird environment, we're likely gonna fail when we next call new URL on serverurl
+    }
+  }
+  // if start later (no autostart), or manually stop and (re)start() later
+  defaultClientConfig = config;
+  if (config.autostart || truthyAttr.includes(self.getAttribute('autostart'))) {
+    start(config);
+  }
+}
+
+export default {
+  start,
+  stop,
+  addMeta,
+  addPageviewMeta,
+  addCustomEvent,
+  getRecordingId,
+};

--- a/packages/browser-client/test/__integration.snapshots__/browser_client_integration_tests.can_record_events.json
+++ b/packages/browser-client/test/__integration.snapshots__/browser_client_integration_tests.can_record_events.json
@@ -1,0 +1,140 @@
+[
+  {
+    "type": 4,
+    "data": {
+      "href": "about:blank",
+      "width": 1920,
+      "height": 1080
+    }
+  },
+  {
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {
+              "lang": "en"
+            },
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "UTF-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "name": "viewport",
+                      "content": "width=device-width, initial-scale=1.0"
+                    },
+                    "childNodes": [],
+                    "id": 6
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "title",
+                    "attributes": {},
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "Link click",
+                        "id": 8
+                      }
+                    ],
+                    "id": 7
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n    \n\n  ",
+                "id": 9
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "span",
+                    "attributes": {
+                      "id": "not-a-link"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "not link",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 14
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "about:blank#clicked"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "link",
+                        "id": 16
+                      }
+                    ],
+                    "id": 15
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  \n\n",
+                    "id": 17
+                  }
+                ],
+                "id": 10
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
+    }
+  }
+]

--- a/packages/browser-client/test/autostart.html
+++ b/packages/browser-client/test/autostart.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@rrweb/browser-client</title>
+    <script src="../dist/browser-client.umd.cjs" async autostart>
+      {
+          serverUrl: 'https://api.rrweb.com/recordings/{recordingId}/events/ws'
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Click Around</h1>
+    <button>Test</button>
+  </body>
+</html>

--- a/packages/browser-client/test/html/link.html
+++ b/packages/browser-client/test/html/link.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Link click</title>
+  </head>
+
+  <body>
+    <span id="not-a-link">not link</span>
+    <a href="about:blank#clicked">link</a>
+  </body>
+</html>

--- a/packages/browser-client/test/integration.test.ts
+++ b/packages/browser-client/test/integration.test.ts
@@ -1,0 +1,395 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type * as puppeteer from 'puppeteer';
+import { vi } from 'vitest';
+import {
+  startServer,
+  getServerURL,
+  launchPuppeteer,
+  replaceLast,
+  ISuite,
+} from './utils';
+import type { browserClientRecordOptions } from '../src';
+import { eventWithTime, EventType } from '@rrweb/types';
+import { randomUUID } from 'crypto';
+
+// These default to the local test server used by the integration suite.
+const TEST_SERVER_URL =
+  import.meta.env.VITE_RRWEB_BROWSER_CLIENT_SERVER_URL ||
+  'http://localhost:8787/recordings/{recordingId}/events/ws';
+const TEST_API_BASE_URL = (
+  import.meta.env.VITE_RRWEB_BROWSER_CLIENT_API_BASE_URL ||
+  'http://localhost:8787'
+).replace(/\/$/, '');
+const TEST_API_KEY = import.meta.env.VITE_TEST_API_KEY || '';
+
+function apiUrl(path: string): string {
+  return `${TEST_API_BASE_URL}${path}`;
+}
+
+function postEventsUrl(serverUrl: string): string {
+  return serverUrl.replace(/\/ws(?=([?#]|$))/, '');
+}
+
+function defaultOptions(
+  options: Partial<browserClientRecordOptions> = {},
+): Partial<browserClientRecordOptions> {
+  options.emit = 'emitFnName';
+  if (!options.serverUrl) {
+    options.serverUrl = TEST_SERVER_URL;
+  }
+  options.publicApiKey = TEST_API_KEY;
+
+  if (!options.meta) {
+    options.meta = {
+      custom: 'yes',
+      sessionId: 'session-123',
+    };
+  }
+  return options;
+}
+
+type RoundtripOptions = Partial<browserClientRecordOptions> & {
+  disableWebsockets?: boolean;
+};
+
+const roundtripOptions: RoundtripOptions[] = [
+  {},
+  {
+    disableWebsockets: true, // dummy
+    serverUrl: postEventsUrl(TEST_SERVER_URL), // actually disable websockets
+  },
+];
+
+async function pollUntil<T>(
+  callback: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  { timeout, interval }: { timeout: number; interval: number },
+): Promise<T> {
+  const start = Date.now();
+  let lastError: unknown;
+
+  do {
+    try {
+      const value = await callback();
+      if (predicate(value)) {
+        return value;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  } while (Date.now() - start < timeout);
+
+  if (lastError) {
+    throw lastError;
+  }
+  throw new Error(`Timed out after ${timeout}ms`);
+}
+
+const describeWithApi = TEST_API_KEY ? describe : describe.skip;
+
+describeWithApi(
+  '@rrweb/browser-client integration tests',
+  function (this: ISuite) {
+    vi.setConfig({ testTimeout: 20_000 });
+
+    const getHtml = (
+      fileName: string,
+      options: Partial<browserClientRecordOptions> = {},
+    ): string => {
+      const filePath = path.resolve(__dirname, `./html/${fileName}`);
+      const html = fs.readFileSync(filePath, 'utf8');
+      return replaceLast(
+        html,
+        '</head>',
+        `
+<script>
+window.snapshots = [];
+function emitFnName(event) {
+  window.snapshots.push(event);
+}
+</script>
+<script src="${testServerURL}/browser-client.umd.cjs" autostart async>
+${JSON.stringify(defaultOptions(options))}
+</script>
+</head>
+    `,
+      );
+    };
+
+    let server: ISuite['server'];
+    let testServerURL: string;
+    let browser: ISuite['browser'];
+
+    beforeAll(async () => {
+      server = await startServer();
+      testServerURL = getServerURL(server);
+      browser = await launchPuppeteer();
+
+      expect(
+        fs.existsSync(
+          path.resolve(__dirname, '../dist/browser-client.umd.cjs'),
+        ),
+      ).toBe(true);
+    });
+
+    afterAll(async () => {
+      await browser.close();
+      server.close();
+    });
+
+    it.concurrent.each(roundtripOptions)(
+      'can roundtrip events: %j',
+      async (options) => {
+        let optionsIn = JSON.stringify(options);
+
+        const context = await browser.createIncognitoBrowserContext(); // no interference during concurrency
+        let page = await context.newPage();
+
+        const fetchSpy = vi.spyOn(global, 'fetch');
+
+        let logs = '';
+
+        let recordingId = '<recordingId not yet set>';
+
+        let waitForEvents;
+        if (options.disableWebsockets) {
+          waitForEvents = page.waitForRequest((request) => {
+            console.log('got: ' + request.url());
+            return request.url().includes('/events');
+          });
+        }
+
+        page.on('console', (msg) => {
+          if (
+            options.disableWebsockets &&
+            msg.text().includes('Error during WebSocket handshake')
+          ) {
+            // an expected log when we are simulating websocket failure
+          } else {
+            console.log(recordingId + ': ' + msg.text());
+          }
+          logs += msg.text();
+        });
+
+        await page.goto(testServerURL); // need a real domain for sessionStorage
+        await page.setContent(getHtml.call(this, 'link.html', options));
+
+        const snapshots = (await page.evaluate(
+          'window.snapshots',
+        )) as eventWithTime[];
+
+        expect(snapshots.length).toBeGreaterThan(1); // meta and fullsnapshot
+
+        recordingId = (await page.evaluate(
+          'rrwebBrowserClient.getRecordingId()',
+        )) as string;
+
+        expect(recordingId).toMatch(
+          /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+        );
+
+        console.log(`got recordingId ${recordingId} test: ${optionsIn}`);
+
+        await page.evaluate('rrwebBrowserClient.addMeta({reality: "updated"})');
+
+        if (options.disableWebsockets) {
+          console.log(`${recordingId} waitForEvents...`);
+          await waitForEvents;
+          console.log(`${recordingId} waitForEvents done`);
+        }
+
+        let expectLogs = expect(logs);
+        let expectFetch = expect(fetchSpy);
+        if (!options.disableWebsockets) {
+          expectLogs = expectLogs.not;
+          expectFetch = expectFetch.not;
+        }
+        expectLogs.toMatch(/WebSocket connection to .* failed/);
+        //expectLogs.toMatch(/Failed to load resource/);
+        if (!options.disableWebsockets) {
+          // dunno why we need this if, something not working as we've already done waitForEvents
+          expectFetch.toHaveBeenCalled();
+        }
+
+        const serverEvents = await pollUntil(
+          async () => {
+            const res = await fetch(
+              apiUrl(`/recordings/${recordingId}/events`),
+              {
+                headers: {
+                  Authorization: 'Bearer ' + TEST_API_KEY,
+                },
+              },
+            );
+            if (!res.ok) {
+              throw new Error(`HTTP error! status: ${res.status}`);
+            }
+            return res.json();
+          },
+          (events) => events.length > 0,
+          { timeout: 7000, interval: 200 },
+        );
+
+        expect(serverEvents.length).toBeGreaterThan(1);
+
+        serverEvents.forEach((e) => {
+          // TODO: these should probably not be returned in the first place
+          if ('recordingId' in e && e.recordingId === recordingId) {
+            delete e.recordingId;
+          }
+          if ('sequenceId' in e) {
+            delete e.sequenceId;
+          }
+        });
+
+        expect(snapshots).toMatchObject(serverEvents);
+
+        const metaJson = await pollUntil(
+          async () => {
+            const res = await fetch(apiUrl(`/recordings/${recordingId}`), {
+              headers: {
+                Authorization: 'Bearer ' + TEST_API_KEY,
+              },
+            });
+            if (!res.ok) {
+              throw new Error(`HTTP error! status: ${res.status}`);
+            }
+            return res.json();
+          },
+          (metadataResponse) =>
+            Boolean(
+              metadataResponse &&
+                metadataResponse.metadata &&
+                Object.keys(metadataResponse.metadata).length,
+            ),
+          { timeout: 8000, interval: 200 },
+        );
+
+        expect(metaJson).toMatchObject({
+          metadata: {
+            custom: 'yes',
+            sessionId: 'session-123',
+            domain: 'localhost',
+            includePii: 'false', // TODO: could this be a real boolean?
+            reality: 'updated',
+          },
+        });
+
+        // no need to write to disk (we can e.g. allow rrweb output to change between versions)
+        // WARNING: this would mutate scrub timestamps and change Meta urls!
+        //await assertSnapshot(snapshots, true);
+      },
+    );
+
+    it('can clear recordingId using stop()', async () => {
+      const options = {
+        meta: {
+          sessionId: randomUUID(),
+        },
+      };
+      let optionsIn = JSON.stringify(options);
+
+      let page = await browser.newPage();
+
+      const client = await page.target().createCDPSession();
+      await client.send('Network.enable');
+
+      const messages = [];
+      const messagesPromise = new Promise((resolve) => {
+        client.on('Network.webSocketFrameSent', ({ response }) => {
+          messages.push(response.payloadData);
+          if (messages.length >= 3) {
+            resolve(messages);
+          }
+        });
+      });
+
+      let logs = '';
+
+      let recordingId = '<recordingId not yet set>';
+
+      page.on('console', (msg) => {
+        console.log(recordingId + ': ' + msg.text());
+        logs += msg.text();
+      });
+
+      await page.goto(testServerURL); // need a real domain for sessionStorage
+      await page.setContent(getHtml.call(this, 'link.html', options));
+
+      const snapshots = (await page.evaluate(
+        'window.snapshots',
+      )) as eventWithTime[];
+
+      expect(snapshots.length).toBeGreaterThan(1); // meta and fullsnapshot
+
+      recordingId = (await page.evaluate(
+        'rrwebBrowserClient.getRecordingId()',
+      )) as string;
+
+      expect(recordingId).toMatch(
+        /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+      );
+
+      await messagesPromise;
+
+      let eventsFromFirst = snapshots.length + 1; // .stop() also generates a custom event
+
+      await page.evaluate('rrwebBrowserClient.stop(true)');
+      await page.evaluate(`rrwebBrowserClient.start()`);
+
+      const recordingId2 = (await page.evaluate(
+        'rrwebBrowserClient.getRecordingId()',
+      )) as string;
+
+      expect(recordingId2).toMatch(
+        /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+      );
+
+      expect(recordingId).not.toMatch(recordingId2);
+
+      console.log(apiUrl(`/replay?meta[sessionId]=${options.meta.sessionId}`));
+      const serverEvents = await pollUntil(
+        async () => {
+          const res = await fetch(
+            apiUrl(`/replay?meta[sessionId]=${options.meta.sessionId}`),
+            {
+              headers: {
+                Authorization: 'Bearer ' + TEST_API_KEY,
+              },
+            },
+          );
+          if (!res.ok) {
+            throw new Error(`HTTP error! status: ${res.status}`);
+          }
+          return res.json();
+        },
+        (events) => events.length > eventsFromFirst,
+        { timeout: 7000, interval: 200 },
+      );
+
+      expect(serverEvents.length).toBeGreaterThan(eventsFromFirst);
+
+      const customEvents = [];
+      const recordingIds = new Set();
+      serverEvents.forEach((e) => {
+        if ('recordingId' in e) {
+          recordingIds.add(e.recordingId);
+        }
+        if (e.type === EventType.Custom) {
+          customEvents.push(e);
+        }
+      });
+      expect(recordingIds.size).toEqual(2);
+      expect(customEvents).toMatchObject([
+        {
+          type: EventType.Custom,
+          data: {
+            tag: 'close-permanent',
+          },
+        },
+      ]);
+    });
+  },
+);

--- a/packages/browser-client/test/integration.test.ts
+++ b/packages/browser-client/test/integration.test.ts
@@ -13,6 +13,10 @@ import type { browserClientRecordOptions } from '../src';
 import { eventWithTime, EventType } from '@rrweb/types';
 import { randomUUID } from 'crypto';
 
+const browserClientPackage = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'),
+) as { version: string };
+
 // These default to the local test server used by the integration suite.
 const TEST_SERVER_URL =
   import.meta.env.VITE_RRWEB_BROWSER_CLIENT_SERVER_URL ||
@@ -274,6 +278,10 @@ ${JSON.stringify(defaultOptions(options))}
             domain: 'localhost',
             includePii: 'false', // TODO: could this be a real boolean?
             reality: 'updated',
+            recordVersion: browserClientPackage.version,
+            recordCommitHash: expect.any(String),
+            jsSource: `${testServerURL}/browser-client.umd.cjs`,
+            jsEntrypoint: 'script-tag',
           },
         });
 

--- a/packages/browser-client/test/load-diagnostics.test.ts
+++ b/packages/browser-client/test/load-diagnostics.test.ts
@@ -1,0 +1,313 @@
+// @vitest-environment happy-dom
+import { EventType } from '@rrweb/types';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type QueueLike = {
+  items: string[];
+  add(value: string): void;
+  clear(): void;
+  length(): number;
+  read(): string | undefined;
+};
+
+type MockState = {
+  buffers: QueueLike[];
+  lastRecordOptions?: Record<string, unknown>;
+  lastWebsocketUrl?: string;
+};
+
+const mockState = vi.hoisted(
+  (): MockState => ({
+    buffers: [],
+  }),
+);
+
+vi.mock('@rrweb/record', () => {
+  const record = vi.fn((options: { emit?: (event: unknown) => void }) => {
+    mockState.lastRecordOptions = options as Record<string, unknown>;
+    options.emit?.({
+      timestamp: 1,
+      type: 4,
+      data: {
+        href: document.location.href,
+        width: 1024,
+        height: 768,
+      },
+    });
+    return vi.fn();
+  });
+  record.addCustomEvent = vi.fn();
+  record.freezePage = vi.fn();
+  return { record };
+});
+
+vi.mock('websocket-ts', () => {
+  class ArrayQueue {
+    items: string[] = [];
+    add(value: string) {
+      this.items.push(value);
+    }
+    clear() {
+      this.items = [];
+    }
+    length() {
+      return this.items.length;
+    }
+    read() {
+      return this.items.shift();
+    }
+  }
+
+  class ExponentialBackoff {
+    constructor(
+      public readonly initial: number,
+      public readonly exponent: number,
+    ) {}
+  }
+
+  class Websocket {
+    send = vi.fn();
+    close = vi.fn();
+    addEventListener = vi.fn();
+  }
+
+  class WebsocketBuilder {
+    constructor(private readonly url: string) {}
+    withBuffer(buffer: QueueLike) {
+      mockState.buffers.push(buffer);
+      return this;
+    }
+    withBackoff() {
+      return this;
+    }
+    build() {
+      mockState.lastWebsocketUrl = this.url;
+      return new Websocket();
+    }
+  }
+
+  return {
+    ArrayQueue,
+    ExponentialBackoff,
+    Websocket,
+    WebsocketBuilder,
+    WebsocketEvent: {
+      open: 'open',
+      message: 'message',
+      close: 'close',
+    },
+  };
+});
+
+function packageVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(__dirname, '../package.json'), 'utf8'),
+  ) as { version: string };
+  return packageJson.version;
+}
+
+function setCurrentScript(script: HTMLScriptElement | null) {
+  Object.defineProperty(document, 'currentScript', {
+    configurable: true,
+    value: script,
+  });
+}
+
+async function importFreshClient() {
+  vi.resetModules();
+  mockState.buffers = [];
+  mockState.lastRecordOptions = undefined;
+  mockState.lastWebsocketUrl = undefined;
+  return await import('../src/index');
+}
+
+function latestRecordingMetaPayload(): Record<string, unknown> {
+  const [buffer] = mockState.buffers;
+  expect(buffer).toBeDefined();
+  const event = JSON.parse(buffer.items[0]) as {
+    type: EventType;
+    data: {
+      tag: string;
+      payload: Record<string, unknown>;
+    };
+  };
+  expect(event.type).toBe(EventType.Custom);
+  expect(event.data.tag).toBe('recording-meta');
+  return event.data.payload;
+}
+
+function storedRecordingId(): string {
+  const recordingId = sessionStorage.getItem(
+    'rrweb-browser-client-recording-id',
+  );
+  expect(recordingId).toBeTruthy();
+  return recordingId as string;
+}
+
+function expectBrowserClientDiagnostics(
+  payload: Record<string, unknown>,
+  expected: Record<string, unknown>,
+) {
+  expect(payload).toMatchObject({
+    recordVersion: packageVersion(),
+    recordCommitHash: expect.any(String),
+    ...expected,
+  });
+  expect(payload.recordCommitHash).not.toBe('');
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  document.body.innerHTML = '';
+  setCurrentScript(null);
+  window.history.replaceState({}, '', 'http://localhost/');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('@rrweb/browser-client load diagnostics', () => {
+  it('adds programmatic diagnostics without jsSource by default', async () => {
+    const client = await importFreshClient();
+
+    client.start({
+      serverUrl: 'http://localhost:8787/recordings/{recordingId}/events/ws',
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      autostart: false,
+      emit: () => undefined,
+    });
+
+    const payload = latestRecordingMetaPayload();
+    expectBrowserClientDiagnostics(payload, {
+      jsEntrypoint: 'programmatic',
+    });
+    expect(payload).not.toHaveProperty('jsSource');
+  });
+
+  it('uses the default api.rrweb.com endpoint for programmatic start without serverUrl', async () => {
+    const client = await importFreshClient();
+
+    client.start({
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      autostart: false,
+      emit: () => undefined,
+    });
+
+    expect(mockState.lastWebsocketUrl).toBe(
+      `wss://api.rrweb.com/recordings/${storedRecordingId()}/events/ws?token=public_key_rr_test`,
+    );
+  });
+
+  it('uses an explicit serverUrl for programmatic start', async () => {
+    const client = await importFreshClient();
+
+    client.start({
+      serverUrl: 'http://localhost:8787/recordings/{recordingId}/events/ws',
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      autostart: false,
+      emit: () => undefined,
+    });
+
+    expect(mockState.lastWebsocketUrl).toBe(
+      `ws://localhost:8787/recordings/${storedRecordingId()}/events/ws?token=public_key_rr_test`,
+    );
+  });
+
+  it('sanitizes explicit programmatic jsSource and strips diagnostics before record()', async () => {
+    const client = await importFreshClient();
+
+    client.start({
+      serverUrl: 'http://localhost:8787/recordings/{recordingId}/events/ws',
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      autostart: false,
+      jsSource: 'https://example.com/recorder.js?token=secret#section',
+      jsEntrypoint: 'internal-loader',
+      emit: () => undefined,
+    });
+
+    expect(latestRecordingMetaPayload()).toMatchObject({
+      jsSource: 'https://example.com/recorder.js',
+      jsEntrypoint: 'internal-loader',
+    });
+    expect(mockState.lastRecordOptions).not.toHaveProperty('jsSource');
+    expect(mockState.lastRecordOptions).not.toHaveProperty('jsEntrypoint');
+  });
+
+  it('uses script-tag diagnostics from currentScript', async () => {
+    const script = document.createElement('script');
+    script.src =
+      'https://cdn.rrweb.com/browser-client/current/browser-client.umd.min.cjs?v=123#loaded';
+    script.setAttribute('autostart', '');
+    script.text = JSON.stringify({
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      emit: 'emitFnName',
+    });
+    (window as unknown as Record<string, unknown>).emitFnName = () => undefined;
+    setCurrentScript(script);
+
+    await importFreshClient();
+
+    expectBrowserClientDiagnostics(latestRecordingMetaPayload(), {
+      jsSource:
+        'https://cdn.rrweb.com/browser-client/current/browser-client.umd.min.cjs',
+      jsEntrypoint: 'script-tag',
+    });
+    expect(mockState.lastWebsocketUrl).toContain('wss://api.rrweb.com/');
+  });
+
+  it('uses data-rrweb-entrypoint for bookmarklet script loads', async () => {
+    const script = document.createElement('script');
+    script.src =
+      'https://cdn.rrweb.com/browser-client/next/browser-client.umd.min.cjs';
+    script.dataset.rrwebEntrypoint = 'bookmarklet';
+    script.setAttribute('autostart', '');
+    script.text = JSON.stringify({
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      emit: 'emitFnName',
+    });
+    (window as unknown as Record<string, unknown>).emitFnName = () => undefined;
+    setCurrentScript(script);
+
+    await importFreshClient();
+
+    expect(latestRecordingMetaPayload()).toMatchObject({
+      jsSource:
+        'https://cdn.rrweb.com/browser-client/next/browser-client.umd.min.cjs',
+      jsEntrypoint: 'bookmarklet',
+    });
+  });
+
+  it('prevents user metadata from overriding diagnostics', async () => {
+    const client = await importFreshClient();
+
+    client.start({
+      serverUrl: 'http://localhost:8787/recordings/{recordingId}/events/ws',
+      publicApiKey: 'public_key_rr_test',
+      includePii: false,
+      autostart: false,
+      meta: {
+        recordVersion: 'wrong',
+        recordCommitHash: 'wrong',
+        jsEntrypoint: 'wrong',
+        jsSource: 'https://wrong.example/recorder.js',
+      },
+      jsSource: 'https://example.com/right.js?token=secret#hash',
+      jsEntrypoint: 'programmatic',
+      emit: () => undefined,
+    });
+
+    expectBrowserClientDiagnostics(latestRecordingMetaPayload(), {
+      jsSource: 'https://example.com/right.js',
+      jsEntrypoint: 'programmatic',
+    });
+  });
+});

--- a/packages/browser-client/test/record.html
+++ b/packages/browser-client/test/record.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@rrweb/browser-client</title>
+    <script>
+      function emitFn(e) {
+        console.log('ok', e);
+      }
+    </script>
+    <script src="../dist/browser-client.umd.cjs">
+      // provide some config
+      {
+        "emit": "emitFn",
+        "serverUrl": "https://api.rrweb.com/recordings/{recordingId}/events/ws",
+        "publicApiKey": document.location.search.split('publicApiKey=')[1],
+        "autostart": true,
+        "blockSelector": '.my-block',
+        "meta": {
+          "visitor": 'x1234',
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Click Around</h1>
+    <button>Test</button>
+  </body>
+</html>

--- a/packages/browser-client/test/utils.ts
+++ b/packages/browser-client/test/utils.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+import * as puppeteer from 'puppeteer';
+import * as url from 'url';
+
+export async function launchPuppeteer(
+  options?: Parameters<(typeof puppeteer)['launch']>[0],
+) {
+  const args = [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-features=LocalNetworkAccessChecks',
+    ...(options?.args ?? []),
+  ];
+
+  return await puppeteer.launch({
+    headless: process.env.PUPPETEER_HEADLESS ? 'new' : false,
+    defaultViewport: {
+      width: 1920,
+      height: 1080,
+    },
+    ...options,
+    args,
+  });
+}
+
+interface IMimeType {
+  [key: string]: string;
+}
+
+export interface ISuite {
+  server: http.Server;
+  browser: puppeteer.Browser;
+}
+
+export const startServer = (defaultPort: number = 3031) =>
+  new Promise<http.Server>((resolve) => {
+    const mimeType: IMimeType = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css',
+    };
+    const s = http.createServer((req, res) => {
+      const parsedUrl = url.parse(req.url!);
+      const sanitizePath = path
+        .normalize(parsedUrl.pathname!)
+        .replace(/^(\.\.[/\\])+/, '');
+
+      let pathname = path.join(__dirname, sanitizePath);
+      if (/^\/browser-client.*\.c?js.*/.test(sanitizePath)) {
+        pathname = path.join(__dirname, `../dist`, sanitizePath);
+      }
+
+      try {
+        const data = fs.readFileSync(pathname);
+        const ext = path.parse(pathname).ext;
+        res.setHeader('Content-type', mimeType[ext] || 'text/plain');
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-type');
+        setTimeout(() => {
+          res.end(data);
+        }, 100);
+      } catch (error) {
+        res.end();
+      }
+    });
+    s.listen(defaultPort)
+      .on('listening', () => {
+        resolve(s);
+      })
+      .on('error', () => {
+        s.listen().on('listening', () => {
+          resolve(s);
+        });
+      });
+  });
+
+export function getServerURL(server: http.Server): string {
+  const address = server.address();
+  if (address && typeof address !== 'string') {
+    return `http://localhost:${address.port}`;
+  } else {
+    return `${address}`;
+  }
+}
+
+export function replaceLast(str: string, find: string, replace: string) {
+  const index = str.lastIndexOf(find);
+  if (index === -1) {
+    return str;
+  }
+  return str.substring(0, index) + replace + str.substring(index + find.length);
+}

--- a/packages/browser-client/tsconfig.json
+++ b/packages/browser-client/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+  },
+  "references": [
+    {
+      "path": "../record"
+    },
+    {
+      "path": "../types"
+    },
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../rrweb"
+    }
+  ]
+}

--- a/packages/browser-client/vite.config.ts
+++ b/packages/browser-client/vite.config.ts
@@ -1,10 +1,18 @@
 import path from 'path';
+import { defineConfig, mergeConfig } from 'vite';
 import config from '../../vite.config.default';
+import { browserClientBuildDefines } from './buildMetadata';
 
-export default config(
+const browserClientConfig = config(
   path.resolve(__dirname, 'src/index.ts'),
   'rrwebBrowserClient',
   {
     fileName: 'browser-client',
   },
+);
+
+export default defineConfig((env) =>
+  mergeConfig(browserClientConfig(env), {
+    define: browserClientBuildDefines(),
+  }),
 );

--- a/packages/browser-client/vite.config.ts
+++ b/packages/browser-client/vite.config.ts
@@ -1,0 +1,10 @@
+import path from 'path';
+import config from '../../vite.config.default';
+
+export default config(
+  path.resolve(__dirname, 'src/index.ts'),
+  'rrwebBrowserClient',
+  {
+    fileName: 'browser-client',
+  },
+);

--- a/packages/browser-client/vitest.config.ts
+++ b/packages/browser-client/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { defineProject, mergeConfig } from 'vitest/config';
+import configShared from '../../vitest.config';
+
+export default mergeConfig(
+  configShared,
+  defineProject({
+    test: {
+      globals: true,
+    },
+  }),
+);

--- a/packages/browser-client/vitest.config.ts
+++ b/packages/browser-client/vitest.config.ts
@@ -1,10 +1,12 @@
 /// <reference types="vitest" />
 import { defineProject, mergeConfig } from 'vitest/config';
 import configShared from '../../vitest.config';
+import { browserClientBuildDefines } from './buildMetadata';
 
 export default mergeConfig(
   configShared,
   defineProject({
+    define: browserClientBuildDefines(),
     test: {
       globals: true,
     },

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -14,6 +14,7 @@ import type { Mirror, SlimDOMOptions } from 'rrweb-snapshot';
 import { isShadowRoot, IGNORED_NODE, classMatchesRegex } from 'rrweb-snapshot';
 import { RRNode, RRIFrameElement, BaseRRNode } from 'rrdom';
 import dom from '@rrweb/utils';
+export { nowTimestamp } from '@rrweb/utils';
 
 export function on(
   type: string,
@@ -126,15 +127,6 @@ export function hookSetter<T>(
   );
   return () => hookSetter(target, key, original || {}, true);
 }
-
-// guard against old third party libraries which redefine Date.now
-let nowTimestamp = Date.now;
-
-if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now().toString()))) {
-  // they have already redefined it! use a fallback
-  nowTimestamp = () => new Date().getTime();
-}
-export { nowTimestamp };
 
 export function getWindowScroll(win: Window) {
   const doc = win.document;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -232,6 +232,15 @@ export function mutationObserverCtor(): (typeof MutationObserver)['prototype']['
   return getUntaintedPrototype('MutationObserver').constructor;
 }
 
+// guard against old third party libraries which redefine Date.now
+let nowTimestamp = Date.now;
+
+if (!(/*@__PURE__*/ /[1-9][0-9]{12}/.test(Date.now().toString()))) {
+  // they have already redefined it! use a fallback
+  nowTimestamp = () => new Date().getTime();
+}
+export { nowTimestamp };
+
 // copy from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts
 export function patch(
   source: { [key: string]: any },
@@ -289,5 +298,6 @@ export default {
   querySelector,
   querySelectorAll,
   mutationObserver: mutationObserverCtor,
+  nowTimestamp,
   patch,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10677,6 +10677,11 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
+websocket-ts@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/websocket-ts/-/websocket-ts-2.3.0.tgz#e0f69de04566128b672d75bc84ed8e67a21e26e4"
+  integrity sha512-DocKMdXx7i8TCBMU+XUKZeUaKwQ7O2NPlxUcgb0poG4RwDrIqBo19mRdW00a1Sm7MSijhIEsgv9UJ0kB/qNy+Q==
+
 whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"


### PR DESCRIPTION
Related: https://github.com/rrweb-cloud/backend/pull/157

## Summary
- Add `@rrweb/browser-client` as a new rrweb workspace package based on the extracted browser recording client.
- Rename the package surface, browser global, and build outputs to `@rrweb/browser-client` / `rrwebBrowserClient` / `dist/browser-client.*`.
- Point browser-client examples, runtime defaults, and tests at the rrweb Cloud events endpoint: `https://api.rrweb.com/recordings/{recordingId}/events/ws`.
- Add browser-client load diagnostics (`recordVersion`, `recordCommitHash`, `jsSource`, `jsEntrypoint`) to initial recording metadata so Cloud can identify canonical CDN/browser-client loads without patched recorder files.
- Document the ESM-first package setup, public API key format, metadata helpers, recording id behavior, WebSocket/HTTP fallback transport, endpoint proxying, and links to the relevant rrweb Cloud docs.
- Move `nowTimestamp` into `@rrweb/utils`, keep `rrweb/src/utils.ts` re-exporting it for compatibility, and have browser-client import from `@rrweb/utils` instead of `rrweb/utils`.
- Add release metadata, local dev/test env configuration, and lock the new `websocket-ts` dependency.

## Notes
- This branch is rebased on current `master` and relies on the upstream rrvideo/CI fixes from `724a97c5`; it no longer carries the previous CI workaround commit.
- Old `rrweb.io` hosted script URLs are only handled as runtime compatibility and map to `api.rrweb.com`; new docs/examples point at `rrweb.com` / `api.rrweb.com`.
- Runtime defaults stay static. Env-driven URLs are test/example-only via `VITE_RRWEB_BROWSER_CLIENT_SERVER_URL` and `VITE_RRWEB_BROWSER_CLIENT_API_BASE_URL`.
- The README deliberately focuses on npm/ESM usage and links to the online JavaScript SDK guide for hosted script installation details.
- The extracted client is adapted to the current rrweb API by using `inlineStylesheet` for now. A TODO and README note document switching back to `captureAssets.stylesheets` once the captureAssets recording API lands from the assets branch.
- API-backed integration tests require a local rrweb Cloud API and `VITE_TEST_API_KEY`; without that key, the local package test builds the package and skips those integration cases.

## Changesets
- Adds `@rrweb/browser-client` and the supporting `@rrweb/utils` `nowTimestamp` export in one changeset.

## Validation
- `yarn workspace @rrweb/browser-client check-types`
- `yarn workspace @rrweb/browser-client lint`
- `RRWEB_COMMIT_HASH=test-commit-hash yarn workspace @rrweb/browser-client vitest run test/load-diagnostics.test.ts`
- `RRWEB_COMMIT_HASH=test-commit-hash yarn workspace @rrweb/browser-client test`
- `yarn workspace @rrweb/utils prepublish`
- `yarn turbo run prepublish --filter=@rrweb/browser-client`
- `yarn prettier --check packages/browser-client/README.md`