### PR TITLE
[chore] Update rrvideo Playwright

### DIFF
--- a/.changeset/smooth-playwrights-bake.md
+++ b/.changeset/smooth-playwrights-bake.md
@@ -1,0 +1,5 @@
+---
+"rrvideo": patch
+---
+
+Update Playwright to 1.60.0.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,12 +40,22 @@ jobs:
       - name: Install Playwright browsers
         run: cd packages/rrvideo && yarn playwright install chromium
 
+      - name: Read Puppeteer browser revision
+        id: puppeteer-browser
+        run: |
+          echo "revision=$(node -p "require('./.puppeteerrc.cjs').browserRevision")" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: ${{ steps.puppeteer-browser.outputs.revision }}
+
       - name: Check types
         run: yarn check-types
 
       - name: Run tests
-        # run: PUPPETEER_EXECUTABLE_PATH=${{ steps.setup-chrome.outputs.chrome-path }} PUPPETEER_HEADLESS=true xvfb-run --server-args="-screen 0 1920x1080x24" yarn test
-        run: PUPPETEER_HEADLESS=true xvfb-run --server-args="-screen 0 1920x1080x24" yarn test
+        run: PUPPETEER_EXECUTABLE_PATH=${{ steps.setup-chrome.outputs.chrome-path }} PUPPETEER_HEADLESS=true xvfb-run --server-args="-screen 0 1920x1080x24" yarn test
 
       - name: Upload diff images to GitHub
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
         env:
-          PUPPETEER_DOWNLOAD_BASE_URL: 'https://storage.googleapis.com/chrome-for-testing-public'
+          PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Build Project
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn build:all
@@ -43,7 +43,8 @@ jobs:
       - name: Read Puppeteer browser revision
         id: puppeteer-browser
         run: |
-          echo "revision=$(node -p "require('./.puppeteerrc.cjs').browserRevision")" >> "$GITHUB_OUTPUT"
+          revision=$(node -p "require('./.puppeteerrc.cjs').browserRevision")
+          echo "revision=${revision}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Chrome
         id: setup-chrome

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -33,7 +33,7 @@
     "@open-tech-world/cli-progress-bar": "^2.0.2",
     "fs-extra": "^11.1.1",
     "minimist": "^1.2.5",
-    "playwright": "^1.56.1",
+    "playwright": "^1.60.0",
     "rrweb-player": "^2.0.0-alpha.20"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,11 @@
     "vite.config.default.ts",
     "tsconfig.json"
   ],
-  "globalPassThroughEnv": ["PUPPETEER_HEADLESS", "DISABLE_WORKER_INLINING"],
+  "globalPassThroughEnv": [
+    "PUPPETEER_EXECUTABLE_PATH",
+    "PUPPETEER_HEADLESS",
+    "DISABLE_WORKER_INLINING"
+  ],
   "tasks": {
     "prepublish": {
       "dependsOn": ["^prepublish", "//#references:update"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8359,17 +8359,17 @@ pkg-types@^1.0.3, pkg-types@^1.1.1:
     mlly "^1.7.0"
     pathe "^1.1.2"
 
-playwright-core@1.56.1:
-  version "1.56.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.56.1.tgz#24a66481e5cd33a045632230aa2c4f0cb6b1db3d"
-  integrity sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@^1.56.1:
-  version "1.56.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.56.1.tgz#62e3b99ddebed0d475e5936a152c88e68be55fbf"
-  integrity sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==
+playwright@^1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.56.1"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Summary
- update rrvideo's Playwright dependency from 1.56.1 to 1.60.0
- refresh the Yarn lockfile for Playwright and Playwright Core
- install Playwright's matching Chromium payload for rrvideo: Chrome for Testing 148.0.7778.96 revision 1223
- configure CI Puppeteer tests to use the repo-pinned Chrome version from .puppeteerrc.cjs via browser-actions/setup-chrome

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-cd.yml'); puts 'yaml ok'"
- bash -c 'revision=$(node -p "require(\"./.puppeteerrc.cjs\").browserRevision"); echo "revision=${revision}"'
- yarn turbo run prepublish --filter=rrvideo...
- yarn workspace rrvideo check-types
- yarn workspace rrvideo test