### PR TITLE
[codex] Fix release changelog batching

### DIFF
--- a/.github/scripts/patch-changesets-github-info.cjs
+++ b/.github/scripts/patch-changesets-github-info.cjs
@@ -1,0 +1,54 @@
+const fs = require('fs');
+
+const packagePath = require.resolve('@changesets/get-github-info', {
+  paths: [process.cwd()],
+});
+
+function patchSource(source) {
+  if (/maxBatchSize\s*:/.test(source)) {
+    return source;
+  }
+
+  const loaderStart =
+    'const GHDataLoader = new DataLoader__default["default"](async requests => {';
+  const startIndex = source.indexOf(loaderStart);
+
+  if (startIndex === -1) {
+    throw new Error('Could not find Changesets GitHub info DataLoader');
+  }
+
+  const loaderEndPattern = /\n}\);\n((?:async\s+)?function getInfo)/;
+  const endMatch = loaderEndPattern.exec(source.slice(startIndex));
+
+  if (!endMatch) {
+    throw new Error('Could not find Changesets GitHub info DataLoader end');
+  }
+
+  const endIndex = startIndex + endMatch.index;
+  const getInfoStart = endMatch[1];
+  const restIndex = endIndex + endMatch[0].length;
+
+  return `${source.slice(
+    0,
+    endIndex,
+  )}\n}, { maxBatchSize: 20 });\n${getInfoStart}${source.slice(restIndex)}`;
+}
+
+function main() {
+  const source = fs.readFileSync(packagePath, 'utf8');
+  const patched = patchSource(source);
+
+  if (patched === source) {
+    console.log('@changesets/get-github-info already limits GitHub batches');
+    return;
+  }
+
+  fs.writeFileSync(packagePath, patched);
+  console.log('Patched @changesets/get-github-info GitHub batch size');
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { patchSource };

--- a/.github/scripts/patch-changesets-github-info.test.cjs
+++ b/.github/scripts/patch-changesets-github-info.test.cjs
@@ -1,0 +1,32 @@
+const assert = require('assert');
+
+const { patchSource } = require('./patch-changesets-github-info.cjs');
+
+const source = `
+const GHDataLoader = new DataLoader__default["default"](async requests => {
+  return requests;
+});
+async function getInfo(request) {
+  return request;
+}
+`;
+
+const patched = patchSource(source);
+
+assert.match(patched, /}, \{ maxBatchSize: 20 \}\);/);
+assert.strictEqual(patchSource(patched), patched);
+assert.strictEqual(
+  patchSource(source.replace('});', '}, { maxBatchSize : 50 });')),
+  source.replace('});', '}, { maxBatchSize : 50 });'),
+);
+
+const nonAsyncSource = source.replace(
+  'async function getInfo',
+  'function getInfo',
+);
+assert.match(patchSource(nonAsyncSource), /\nfunction getInfo/);
+
+assert.throws(
+  () => patchSource('const GHDataLoader = new DataLoader(async () => {});'),
+  /Could not find/,
+);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:                                                         
-      contents: write                                                    
-      pull-requests: write                                               
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -27,6 +27,9 @@ jobs:
         run: yarn install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+
+      - name: Limit Changesets GitHub changelog batch size
+        run: node .github/scripts/patch-changesets-github-info.cjs
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Summary

- Patch `@changesets/get-github-info` after install so its DataLoader splits GitHub changelog lookups into batches of 20.
- Run the patch before `changesets/action` in the release workflow.
- Add a small Node test for the patch helper.

## Root cause

The 2.0.0 release has a large number of pending changesets. `@changesets/changelog-github` asks `@changesets/get-github-info` for commit and PR metadata for changelog entries, and that package batches all lookups into one large GraphQL query. GitHub rejects that query during validation with `Timeout on validation of query`.

Splitting the same lookups into smaller batches preserves the same changelog data while avoiding the oversized GraphQL document.

## Validation

- `node .github/scripts/patch-changesets-github-info.test.cjs`
- `git diff --check`
- In a throwaway worktree from failing commit `6db8f710`, ran install, applied the patch, then `GITHUB_TOKEN=$(gh auth token) NODE_OPTIONS='--max-old-space-size=4096' yarn changeset version`; it completed successfully.
