### PR TITLE
[codex] Add release OIDC permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

- Add `id-token: write` to the release workflow permissions so npm trusted publishing can use GitHub Actions OIDC.
- Keep `NPM_TOKEN` in the release environment for now because the `rrweb` npm package is still pending trusted publisher setup.

## Validation

- `git diff --check`
- `yarn prettier --check .github/workflows/release.yml`
