### PR TITLE
[chore] Remove release npm token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build Chrome Extension
         if: steps.changesets.outputs.published == 'true'

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -14,6 +14,10 @@
     "rrweb",
     "rrdom-nodejs"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rrweb-io/rrweb.git"
+  },
   "license": "MIT",
   "type": "module",
   "main": "./dist/rrdom-nodejs.umd.cjs",

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -11,6 +11,10 @@
     "package.json"
   ],
   "types": "build/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rrweb-io/rrweb.git"
+  },
   "scripts": {
     "install": "playwright install",
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Remove `NPM_TOKEN` from the release workflow so npm publishes use trusted publishing/OIDC.
- Add repository metadata to `rrdom-nodejs` and `rrvideo` package manifests so npm provenance validation can match the GitHub Actions source repository.

## Context

The latest release run published most packages, but failed for `rrdom-nodejs` and `rrvideo` because their packed `package.json` files had no `repository.url`. npm rejected the provenance bundle because it expected `https://github.com/rrweb-io/rrweb` from the GitHub Actions OIDC identity.

## Validation

- `git diff --check`
- `yarn prettier --check .github/workflows/release.yml packages/rrdom-nodejs/package.json packages/rrvideo/package.json`
- `npm pack ./packages/rrdom-nodejs --dry-run --json`
- `npm pack ./packages/rrvideo --dry-run --json`
