### PR TITLE
docs: add tracelane and peek to "Who's using rrweb?"

### DIFF
--- a/.changeset/whos-using-tracelane-peek.md
+++ b/.changeset/whos-using-tracelane-peek.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: add tracelane and peek to the "Who's using rrweb?" section (README only; no package changes).

--- a/README.md
+++ b/README.md
@@ -247,4 +247,16 @@ In addition to adding integration tests and unit tests, rrweb also provides a RE
       </a>
     </td>
   </tr>
+  <tr>
+    <td align="center">
+      <a href="https://tracelane.cubenest.in" target="_blank">
+        <img style="padding: 8px" alt="Embeds self-contained rrweb replays in E2E test-failure reports" width="195px" src="https://raw.githubusercontent.com/Cubenest/rrweb-stack/main/assets/brand/sub-tracelane.svg">
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://peek.cubenest.in" target="_blank">
+        <img style="padding: 8px" alt="Feeds authenticated browser context to AI coding agents via MCP" width="195px" src="https://raw.githubusercontent.com/Cubenest/rrweb-stack/main/assets/brand/sub-peek.svg">
+      </a>
+    </td>
+  </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -272,8 +272,6 @@ In addition to adding integration tests and unit tests, rrweb also provides a RE
         <img style="padding: 8px" alt="Interactive product demos for small marketing teams" width="195px" src="https://assets-global.website-files.com/650afb446f1dd5bd410f00cc/650b2cec6188ff54dd9b01e1_Logo.svg">
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center">
       <a href="https://tracelane.cubenest.in" target="_blank">
         <img style="padding: 8px" alt="Embeds self-contained rrweb replays in E2E test-failure reports" width="195px" src="https://raw.githubusercontent.com/Cubenest/rrweb-stack/main/assets/brand/sub-tracelane.svg">


### PR DESCRIPTION
Adds two Apache-2.0 OSS projects to the "Who's using rrweb?" section:

- **tracelane** (https://tracelane.cubenest.in) — uses rrweb to embed self-contained replays in E2E test-failure reports (WebdriverIO / Playwright).
- **peek** (https://peek.cubenest.in) — uses rrweb to capture authenticated browser sessions and feed that context to AI coding agents via a local MCP server.

Both are pre-1.0 side projects. Logo files are referenced via raw URLs (SVG, 195px). Happy to swap to smaller variants, host the logos elsewhere, or drop the descriptions if you prefer. No copy changes elsewhere.
