### PR TITLE
[codex] Ship @rrweb/all style css

### DIFF
--- a/.changeset/shiny-all-style-css.md
+++ b/.changeset/shiny-all-style-css.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/all": patch
+---
+
+Ship `dist/style.css` from `@rrweb/all` by importing rrweb's replay styles in the bundle entry and exporting the CSS subpath.

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -41,7 +41,8 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/all.cjs"
       }
-    }
+    },
+    "./dist/style.css": "./dist/style.css"
   },
   "files": [
     "umd",

--- a/packages/all/src/index.ts
+++ b/packages/all/src/index.ts
@@ -1,4 +1,5 @@
 export * from 'rrweb';
 export * from '@rrweb/packer';
+import 'rrweb/dist/style.css';
 // export * from '@rrweb/rrweb-plugin-console-record';
 // export * from '@rrweb/rrweb-plugin-console-replay';

--- a/packages/all/test/package-css.test.ts
+++ b/packages/all/test/package-css.test.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+describe('@rrweb/all package css', () => {
+  it('exports and builds replay style.css', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+    );
+    const entry = fs.readFileSync(
+      path.resolve(__dirname, '../src/index.ts'),
+      'utf-8',
+    );
+
+    expect(packageJson.exports['./dist/style.css']).toBe('./dist/style.css');
+    expect(entry).toContain("import 'rrweb/dist/style.css';");
+  });
+});

--- a/packages/all/test/package-css.test.ts
+++ b/packages/all/test/package-css.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('@rrweb/all package css', () => {
   it('exports and builds replay style.css', () => {
+    const stylePath = path.resolve(__dirname, '../dist/style.css');
     const packageJson = JSON.parse(
       fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
     );
@@ -12,7 +13,8 @@ describe('@rrweb/all package css', () => {
       'utf-8',
     );
 
+    expect(fs.existsSync(stylePath)).toBe(true);
     expect(packageJson.exports['./dist/style.css']).toBe('./dist/style.css');
-    expect(entry).toContain("import 'rrweb/dist/style.css';");
+    expect(entry).toMatch(/import\s+['"]rrweb\/dist\/style\.css['"]/);
   });
 });


### PR DESCRIPTION
## Summary

- Import `rrweb/dist/style.css` from the `@rrweb/all` bundle entry so Vite emits `dist/style.css` for the package.
- Export `./dist/style.css` from `@rrweb/all` package exports.
- Add a regression test and changeset for the package CSS contract.

## Root Cause

`@rrweb/all` re-exported the JavaScript APIs from `rrweb` and `@rrweb/packer`, but unlike `rrweb` and `@rrweb/replay`, it did not import the replay stylesheet or expose the CSS subpath. As a result, published `@rrweb/all` packages did not ship `dist/style.css` for consumers.

## Validation

- `yarn vitest run packages/all/test/package-css.test.ts`
- `yarn turbo run prepublish --filter=@rrweb/all`
- `yarn changeset status`
