### PR TITLE
[docs] Update contribution link and package keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,7 @@ Since we want the record and replay sides to share a strongly typed data structu
 
 [Typescript handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
 
-1. Fork this repository.
-2. Run `yarn install` in the root to install required dependencies for all sub-packages (note: `npm install` is _not_ recommended).
-3. Run `yarn build:all` to build all packages and get a stable base, then `yarn dev` in the root to get auto-building for all the sub-packages whenever you modify anything.
-4. Navigate to one of the sub-packages (in the `packages` folder) where you'd like to make a change.
-5. Patch the code and run `yarn test` to run the tests, make sure they pass before you commit anything. Add test cases in order to avoid future regression.
-6. If tests are failing, but the change in output is desirable, run `yarn test:update` and carefully commit the changes in test output.
-7. Push the code and create a pull request.
-
-Protip: You can run `yarn test` in the root folder to run all the tests.
+For the latest setup, testing, and pull request workflow, see [Contributing to rrweb](./CONTRIBUTING.md).
 
 In addition to adding integration tests and unit tests, rrweb also provides a REPL testing tool.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "url": "git+ssh://git@github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "yanzhen@smartx.com",

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/all"
   ],

--- a/packages/browser-client/package.json
+++ b/packages/browser-client/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/browser-client",
     "websocket"

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/packer"
   ],

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -35,6 +35,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "justin@recordonce.com",

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -35,6 +35,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "justin@recordonce.com",

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -37,6 +37,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "yanzhen@smartx.com",

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -35,6 +35,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "yanzhen@smartx.com",

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -35,6 +35,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "yanzhen@smartx.com",

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -35,6 +35,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "yanzhen@smartx.com",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/record"
   ],

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/replay"
   ],

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -11,6 +11,9 @@
     "lint": "yarn eslint src/**/*.ts"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "rrdom-nodejs"
   ],

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -61,6 +61,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "author": "yanzhen@smartx.com",

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -24,6 +24,9 @@
     "url": "git+https://github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "snapshot",
     "DOM"

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -30,6 +30,9 @@
     "url": "git+ssh://git@github.com/rrweb-io/rrweb.git"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb"
   ],
   "main": "./dist/rrweb.umd.cjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/types"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,9 @@
     "access": "public"
   },
   "keywords": [
+    "devtools",
+    "product-analytics",
+    "real-user-monitoring",
     "rrweb",
     "@rrweb/utils"
   ],


### PR DESCRIPTION
## What changed

- Replaced the duplicated README contribution steps with a link to `CONTRIBUTING.md` so the standalone guide is the source of truth.
- Added `devtools`, `product-analytics`, and `real-user-monitoring` keywords to the root package metadata and the `rrweb` package metadata.

## Why

The standalone contributing guide has the more current workflow details, including changesets, lint/typecheck guidance, local commands, and WebKit test instructions. The extra keywords improve discovery for people searching for rrweb by adjacent use cases.

## Validation

- `yarn prettier --check README.md package.json packages/rrweb/package.json`

## Notes

An unrelated generated file, `packages/rrweb-player/.svelte-kit/ambient.d.ts`, was already modified locally and was not staged or included in this PR.