### PR TITLE
[chore] Update package authors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -37,7 +37,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "justin@recordonce.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -37,7 +37,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "justin@recordonce.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -39,7 +39,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -37,7 +37,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -37,7 +37,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -37,7 +37,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -22,7 +22,7 @@
     "check-types": "tsc -noEmit",
     "prepublish": "yarn build"
   },
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "devDependencies": {
     "@types/fs-extra": "11.0.1",

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -63,7 +63,7 @@
   "keywords": [
     "rrweb"
   ],
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -50,7 +50,7 @@
     "package.json"
   ],
   "sideEffects": false,
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -55,7 +55,7 @@
     "package.json"
   ],
   "sideEffects": false,
-  "author": "yanzhen@smartx.com",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "2.0.1",
   "description": "The web extension of rrweb which helps to run rrweb on any website out of box",
-  "author": "rrweb-io",
+  "author": "rrweb Core Team <maintainers@rrweb.com>",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Updates existing `author` fields across the monorepo package manifests to use the team identity:

`rrweb Core Team <maintainers@rrweb.com>`

## Impact

This removes individual or inconsistent author metadata from packages and keeps the existing npm-compatible string format.

## Validation

- Parsed all 25 `package.json` files successfully with Node.js.
- Verified every remaining `author` field uses the new value.