### PR TITLE
[chore] Configure jsDelivr UMD defaults

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -33,6 +33,8 @@
   "main": "./dist/all.cjs",
   "module": "./dist/all.js",
   "unpkg": "./dist/all.umd.cjs",
+  "jsdelivr": "./umd/all.js",
+  "style": "./dist/style.css",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/browser-client/package.json
+++ b/packages/browser-client/package.json
@@ -41,6 +41,7 @@
   "main": "./dist/browser-client.cjs",
   "module": "./dist/browser-client.js",
   "unpkg": "./dist/browser-client.umd.cjs",
+  "jsdelivr": "./umd/browser-client.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-canvas-webrtc-record.umd.cjs",
   "module": "./dist/rrweb-plugin-canvas-webrtc-record.js",
   "unpkg": "./dist/rrweb-plugin-canvas-webrtc-record.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-canvas-webrtc-record.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-canvas-webrtc-replay.umd.cjs",
   "module": "./dist/rrweb-plugin-canvas-webrtc-replay.js",
   "unpkg": "./dist/rrweb-plugin-canvas-webrtc-replay.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-canvas-webrtc-replay.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-console-record.umd.cjs",
   "module": "./dist/rrweb-plugin-console-record.js",
   "unpkg": "./dist/rrweb-plugin-console-record.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-console-record.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-console-replay.umd.cjs",
   "module": "./dist/rrweb-plugin-console-replay.js",
   "unpkg": "./dist/rrweb-plugin-console-replay.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-console-replay.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugins/rrweb-plugin-network-record/package.json
+++ b/packages/plugins/rrweb-plugin-network-record/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-network-record.umd.cjs",
   "module": "./dist/rrweb-plugin-network-record.js",
   "unpkg": "./dist/rrweb-plugin-network-record.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-network-record.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
@@ -20,8 +21,8 @@
     }
   },
   "files": [
-    "dist",
     "umd",
+    "dist",
     "package.json"
   ],
   "scripts": {

--- a/packages/plugins/rrweb-plugin-network-replay/package.json
+++ b/packages/plugins/rrweb-plugin-network-replay/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-network-replay.umd.cjs",
   "module": "./dist/rrweb-plugin-network-replay.js",
   "unpkg": "./dist/rrweb-plugin-network-replay.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-network-replay.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
@@ -20,8 +21,8 @@
     }
   },
   "files": [
-    "dist",
     "umd",
+    "dist",
     "package.json"
   ],
   "scripts": {

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-sequential-id-record.umd.cjs",
   "module": "./dist/rrweb-plugin-sequential-id-record.js",
   "unpkg": "./dist/rrweb-plugin-sequential-id-record.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-sequential-id-record.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/rrweb-plugin-sequential-id-replay.umd.cjs",
   "module": "./dist/rrweb-plugin-sequential-id-replay.js",
   "unpkg": "./dist/rrweb-plugin-sequential-id-replay.umd.cjs",
+  "jsdelivr": "./umd/rrweb-plugin-sequential-id-replay.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -34,6 +34,7 @@
   "main": "./dist/record.cjs",
   "module": "./dist/record.js",
   "unpkg": "./dist/record.umd.cjs",
+  "jsdelivr": "./umd/record.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -33,6 +33,8 @@
   "main": "./dist/replay.cjs",
   "module": "./dist/replay.js",
   "unpkg": "./dist/replay.umd.cjs",
+  "jsdelivr": "./umd/replay.js",
+  "style": "./dist/style.css",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -26,6 +26,7 @@
   "main": "./dist/rrdom-nodejs.umd.cjs",
   "module": "./dist/rrdom-nodejs.js",
   "unpkg": "./dist/rrdom-nodejs.umd.cjs",
+  "jsdelivr": "./umd/rrdom-nodejs.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/rrdom.cjs",
   "module": "./dist/rrdom.js",
   "unpkg": "./dist/rrdom.umd.cjs",
+  "jsdelivr": "./umd/rrdom.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -36,6 +36,8 @@
   "main": "./dist/rrweb-player.umd.cjs",
   "module": "./dist/rrweb-player.js",
   "unpkg": "./dist/rrweb-player.umd.cjs",
+  "jsdelivr": "./umd/rrweb-player.js",
+  "style": "./dist/style.css",
   "typings": "dist/rrweb-player.d.ts",
   "exports": {
     ".": {

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -34,6 +34,7 @@
   "main": "./dist/rrweb-snapshot.umd.cjs",
   "module": "./dist/rrweb-snapshot.js",
   "unpkg": "./dist/rrweb-snapshot.umd.cjs",
+  "jsdelivr": "./umd/rrweb-snapshot.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -38,6 +38,8 @@
   "main": "./dist/rrweb.umd.cjs",
   "module": "./dist/rrweb.js",
   "unpkg": "./dist/rrweb.umd.cjs",
+  "jsdelivr": "./umd/rrweb.js",
+  "style": "./dist/style.css",
   "typings": "dist/rrweb.d.ts",
   "exports": {
     ".": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,6 +31,7 @@
   "main": "./dist/types.umd.cjs",
   "module": "./dist/types.js",
   "unpkg": "./dist/types.umd.cjs",
+  "jsdelivr": "./umd/types.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,6 +31,7 @@
   "main": "./dist/utils.umd.cjs",
   "module": "./dist/utils.js",
   "unpkg": "./dist/utils.umd.cjs",
+  "jsdelivr": "./umd/utils.js",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/vite.config.default.ts
+++ b/vite.config.default.ts
@@ -64,7 +64,7 @@ function minifyAndUMDPlugin({
               isCss: false,
               outDir,
             });
-            // Workaround because jsdelivr does use correct mime types for .umd.cjs
+            // Workaround because jsDelivr does not use correct MIME types for .umd.cjs.
             // More info: https://github.com/jsdelivr/jsdelivr/issues/18584 https://github.com/rrweb-io/rrweb/pull/1704
             copyFileSync(
               outUmd,


### PR DESCRIPTION
## Summary

Configures jsDelivr package "defaults" to use the generated UMD `.js` mirrors instead of allowing jsDelivr to guess the ESM `dist/*.js` files.

## Why

jsDelivr serves `.umd.cjs` files with a non-browser MIME type, while its "default"-file docs prefer the `jsdelivr` field and look for a matching `.min.js` file. Pointing `jsdelivr` at `./umd/*.js` gives the install widget and short CDN URLs a classic script-compatible UMD bundle that exposes the package global, while preserving the existing `dist/*.umd.cjs` outputs for direct references.

Hopefully removes the message below and points [jsDelivr](https://www.jsdelivr.com/package/npm/rrweb) to the correct file:
<img width="905" height="598" alt="image" src="https://github.com/user-attachments/assets/3102c898-0d76-4cf4-9121-f9b66352b795" />

## Changes

- Adds `jsdelivr` fields for browser-facing UMD packages, pointing to `./umd/*.js`.
- Adds `style: ./dist/style.css` for packages that publish a CSS bundle.
- Keeps the `/umd` mirror generation and restores the jsDelivr MIME-type workaround comment.

## Validation

- `git diff --cached --check`
- JSON parse check across all package manifests
- Static metadata check that UMD packages publish `umd` and point `jsdelivr` at `./umd/*.js`

Prettier/TypeScript checks were not run locally because this worktree does not have `node_modules` installed.