### PR TITLE
docs: prefer minified CDN ESM assets

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -49,8 +49,8 @@ Use browser ESM assets from a CDN:
   href="https://cdn.rrweb.com/replay/current/dist/style.css"
 />
 <script type="module">
-  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.js';
-  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.js';
+  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.min.js';
+  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.min.js';
 
   record({
     emit(event) {
@@ -61,9 +61,10 @@ Use browser ESM assets from a CDN:
 ```
 
 Use `current` for the latest stable release, or pin an exact version such as
-`https://cdn.rrweb.com/record/2.0.0/dist/record.js` and
-`https://cdn.rrweb.com/replay/2.0.0/dist/replay.js` for immutable
-production URLs.
+`https://cdn.rrweb.com/record/2.0.0/dist/record.min.js` and
+`https://cdn.rrweb.com/replay/2.0.0/dist/replay.min.js` for immutable
+production URLs. Use `.min.js` for production; the unminified `.js` sibling
+remains useful for debugging.
 
 `rrweb-player` is also available as a browser ESM asset:
 
@@ -73,7 +74,7 @@ production URLs.
   href="https://cdn.rrweb.com/rrweb-player/current/style.css"
 />
 <script type="module">
-  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.js';
+  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.min.js';
 </script>
 ```
 
@@ -329,7 +330,7 @@ the CDN:
   href="https://cdn.rrweb.com/replay/current/dist/style.css"
 />
 <script type="module">
-  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.js';
+  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.min.js';
 
   const events = YOUR_EVENTS;
 
@@ -337,6 +338,9 @@ the CDN:
   replayer.play();
 </script>
 ```
+
+Use `.min.js` for production; switch to the unminified `.js` sibling when
+debugging.
 
 #### Control the replayer by API
 
@@ -410,9 +414,12 @@ Browser without bundler (ESM):
   href="https://cdn.rrweb.com/rrweb-player/current/style.css"
 />
 <script type="module">
-  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.js';
+  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.min.js';
 </script>
 ```
+
+Use `.min.js` for production; switch to the unminified `.js` sibling when
+debugging.
 
 Legacy direct `<script>` include (UMD fallback):
 

--- a/guide.zh_CN.md
+++ b/guide.zh_CN.md
@@ -47,8 +47,8 @@ import '@rrweb/all/dist/style.css';
   href="https://cdn.rrweb.com/replay/current/dist/style.css"
 />
 <script type="module">
-  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.js';
-  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.js';
+  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.min.js';
+  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.min.js';
 
   record({
     emit(event) {
@@ -59,8 +59,9 @@ import '@rrweb/all/dist/style.css';
 ```
 
 `current` 指向最新稳定版本；生产环境也可以固定到不可变的精确版本，例如
-`https://cdn.rrweb.com/record/2.0.0/dist/record.js` 和
-`https://cdn.rrweb.com/replay/2.0.0/dist/replay.js`。
+`https://cdn.rrweb.com/record/2.0.0/dist/record.min.js` 和
+`https://cdn.rrweb.com/replay/2.0.0/dist/replay.min.js`。生产环境请使用 `.min.js`；
+未压缩的 `.js` 同级文件仍适合调试。
 
 `rrweb-player` 也提供浏览器 ESM 资源：
 
@@ -70,7 +71,7 @@ import '@rrweb/all/dist/style.css';
   href="https://cdn.rrweb.com/rrweb-player/current/style.css"
 />
 <script type="module">
-  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.js';
+  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.min.js';
 </script>
 ```
 
@@ -323,7 +324,7 @@ import '@rrweb/replay/dist/style.css';
   href="https://cdn.rrweb.com/replay/current/dist/style.css"
 />
 <script type="module">
-  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.js';
+  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.min.js';
 
   const events = YOUR_EVENTS;
 
@@ -331,6 +332,8 @@ import '@rrweb/replay/dist/style.css';
   replayer.play();
 </script>
 ```
+
+生产环境请使用 `.min.js`；调试时可改用未压缩的 `.js` 同级文件。
 
 #### 使用 API 控制回放
 
@@ -402,9 +405,11 @@ import 'rrweb-player/dist/style.css';
   href="https://cdn.rrweb.com/rrweb-player/current/style.css"
 />
 <script type="module">
-  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.js';
+  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.min.js';
 </script>
 ```
+
+生产环境请使用 `.min.js`；调试时可改用未压缩的 `.js` 同级文件。
 
 Legacy 直接 `<script>` 引入（UMD 兼容）：
 

--- a/packages/record/README.md
+++ b/packages/record/README.md
@@ -22,13 +22,14 @@ browser:
 
 ```html
 <script type="module">
-  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.js';
+  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.min.js';
 </script>
 ```
 
 Use `current` for the latest stable release, or pin an exact version such as
-`https://cdn.rrweb.com/record/2.0.0/dist/record.js` for immutable
-production URLs.
+`https://cdn.rrweb.com/record/2.0.0/dist/record.min.js` for immutable
+production URLs. Use `.min.js` for production; the unminified `.js` sibling
+remains useful for debugging.
 
 ### 3) Legacy Direct `<script>` Include (UMD fallback)
 

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -27,13 +27,14 @@ browser:
   href="https://cdn.rrweb.com/replay/current/dist/style.css"
 />
 <script type="module">
-  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.js';
+  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.min.js';
 </script>
 ```
 
 Use `current` for the latest stable release, or pin an exact version such as
-`https://cdn.rrweb.com/replay/2.0.0/dist/replay.js` for immutable
-production URLs.
+`https://cdn.rrweb.com/replay/2.0.0/dist/replay.min.js` for immutable
+production URLs. Use `.min.js` for production; the unminified `.js` sibling
+remains useful for debugging.
 
 ### 3) Legacy Direct `<script>` Include (UMD fallback)
 

--- a/packages/rrweb-player/README.md
+++ b/packages/rrweb-player/README.md
@@ -27,14 +27,16 @@ import 'rrweb-player/dist/style.css';
   href="https://cdn.rrweb.com/rrweb-player/current/style.css"
 />
 <script type="module">
-  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.js';
+  import rrwebPlayer from 'https://cdn.rrweb.com/rrweb-player/current/rrweb-player.min.js';
 </script>
 ```
 
 Use `current` for the latest stable release, or pin an exact version such as
-`https://cdn.rrweb.com/rrweb-player/2.0.0/rrweb-player.js` for immutable
-production URLs. See the [CDN assets docs](https://rrweb.com/docs/cloud/cdn-assets)
-for the full URL shape and catalog.
+`https://cdn.rrweb.com/rrweb-player/2.0.0/rrweb-player.min.js` for immutable
+production URLs. Use `.min.js` for production; the unminified `.js` sibling
+remains useful for debugging. See the
+[CDN assets docs](https://rrweb.com/docs/cloud/cdn-assets) for the full URL
+shape and catalog.
 
 ### 3) Legacy Direct `<script>` Include (UMD fallback)
 

--- a/packages/rrweb/README.md
+++ b/packages/rrweb/README.md
@@ -67,15 +67,16 @@ import 'rrweb/dist/style.css';
   href="https://cdn.rrweb.com/replay/current/dist/style.css"
 />
 <script type="module">
-  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.js';
-  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.js';
+  import { record } from 'https://cdn.rrweb.com/record/current/dist/record.min.js';
+  import { Replayer } from 'https://cdn.rrweb.com/replay/current/dist/replay.min.js';
 </script>
 ```
 
 Use `current` for the latest stable release, or pin exact versions such as
-`https://cdn.rrweb.com/record/2.0.0/dist/record.js` and
-`https://cdn.rrweb.com/replay/2.0.0/dist/replay.js` for immutable
-production URLs.
+`https://cdn.rrweb.com/record/2.0.0/dist/record.min.js` and
+`https://cdn.rrweb.com/replay/2.0.0/dist/replay.min.js` for immutable
+production URLs. Use `.min.js` for production; the unminified `.js` sibling
+remains useful for debugging.
 
 ### 3) Legacy Direct `<script>` Include (UMD fallback)
 


### PR DESCRIPTION
## Summary

Update no-build/browser CDN ESM examples to use the production-oriented `.min.js` assets for record, replay, and rrweb-player.

- switch first-party CDN ESM import examples from `.js` to `.min.js`
- keep CSS URLs and UMD fallback examples unchanged
- document that unminified `.js` siblings remain useful for debugging
- use concrete exact-version examples because historical CDN versions are expected to be backfilled with minified ESM assets

## Notes

This docs change assumes first-party CDN minified ESM assets are available for current and pinned CDN versions after the CDN backfill is completed.

## Verification

- `git diff --check`
- searched edited docs for stale older-version caveats and remaining direct CDN ESM `record.js`, `replay.js`, or `rrweb-player.js` examples where `.min.js` is appropriate
- confirmed only the intended six docs files changed

Could not run `yarn prettier --check ...` in the fresh worktree because dependencies were not installed and `prettier` was unavailable.