### PR TITLE
Fix browser-client breaking when imported on projects that use SSR

### DIFF
--- a/.changeset/silver-paths-stay.md
+++ b/.changeset/silver-paths-stay.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/browser-client": patch
+---
+
+Add compatibility for importing browser-client in projects which use SSR

--- a/packages/browser-client/src/index.ts
+++ b/packages/browser-client/src/index.ts
@@ -63,6 +63,10 @@ let wsConnectionPaused = false;
 const buffer: ArrayQueue<string> = new ArrayQueue();
 let rrwebStopFn: listenerHandler | undefined;
 
+function hasDocument(): boolean {
+  return typeof document !== 'undefined';
+}
+
 function isServerMessage(value: unknown): value is ServerMessage {
   return typeof value === 'object' && value !== null;
 }
@@ -116,7 +120,11 @@ export function stop(resetRecordingId: boolean) {
 }
 
 function removeRecordingId(): void {
-  sessionStorage.removeItem(sessionStorageName);
+  try {
+    sessionStorage.removeItem(sessionStorageName);
+  } catch {
+    // Ignore environments without sessionStorage, such as SSR.
+  }
 }
 
 function getSetVisitorId() {
@@ -272,6 +280,10 @@ async function postData(
 export function start(
   options: browserClientRecordOptions = defaultClientConfig,
 ) {
+  if (!hasDocument()) {
+    return;
+  }
+
   const {
     includePii,
     publicApiKey,
@@ -521,7 +533,7 @@ export function addPageviewMeta(payload: nameValues) {
   addCustomEvent('pageview-meta', payload);
 }
 
-if (document && document.currentScript) {
+if (hasDocument() && document.currentScript) {
   let config = defaultClientConfig;
   const truthyAttr: readonly (string | null)[] = ['', 'yes', 'on', 'true', '1']; // empty string allows setting plain html5 attributes without values
   const self = document.currentScript as HTMLScriptElement;

--- a/packages/browser-client/test/ssr-import.test.ts
+++ b/packages/browser-client/test/ssr-import.test.ts
@@ -4,31 +4,22 @@ const mockState = vi.hoisted(() => ({
   record: vi.fn(),
 }));
 
-vi.mock(
-  '@rrweb/record',
-  () => {
-    mockState.record.addCustomEvent = vi.fn();
-    mockState.record.freezePage = vi.fn();
-    return { record: mockState.record };
+vi.mock('@rrweb/record', () => {
+  mockState.record.addCustomEvent = vi.fn();
+  mockState.record.freezePage = vi.fn();
+  return { record: mockState.record };
+});
+
+vi.mock('@rrweb/types', () => ({
+  EventType: {
+    Custom: 5,
+    Meta: 4,
   },
-);
+}));
 
-vi.mock(
-  '@rrweb/types',
-  () => ({
-    EventType: {
-      Custom: 5,
-      Meta: 4,
-    },
-  }),
-);
-
-vi.mock(
-  '@rrweb/utils',
-  () => ({
-    nowTimestamp: () => 1,
-  }),
-);
+vi.mock('@rrweb/utils', () => ({
+  nowTimestamp: () => 1,
+}));
 
 vi.mock('websocket-ts', () => {
   class ArrayQueue {

--- a/packages/browser-client/test/ssr-import.test.ts
+++ b/packages/browser-client/test/ssr-import.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockState = vi.hoisted(() => ({
+  record: vi.fn(),
+}));
+
+vi.mock(
+  '@rrweb/record',
+  () => {
+    mockState.record.addCustomEvent = vi.fn();
+    mockState.record.freezePage = vi.fn();
+    return { record: mockState.record };
+  },
+);
+
+vi.mock(
+  '@rrweb/types',
+  () => ({
+    EventType: {
+      Custom: 5,
+      Meta: 4,
+    },
+  }),
+);
+
+vi.mock(
+  '@rrweb/utils',
+  () => ({
+    nowTimestamp: () => 1,
+  }),
+);
+
+vi.mock('websocket-ts', () => {
+  class ArrayQueue {
+    private items: string[] = [];
+
+    add(value: string) {
+      this.items.push(value);
+    }
+
+    clear() {
+      this.items = [];
+    }
+
+    length() {
+      return this.items.length;
+    }
+
+    read() {
+      return this.items.shift();
+    }
+  }
+
+  class ExponentialBackoff {}
+
+  class Websocket {
+    send = vi.fn();
+    close = vi.fn();
+    addEventListener = vi.fn();
+  }
+
+  class WebsocketBuilder {
+    withBuffer() {
+      return this;
+    }
+
+    withBackoff() {
+      return this;
+    }
+
+    build() {
+      return new Websocket();
+    }
+  }
+
+  return {
+    ArrayQueue,
+    ExponentialBackoff,
+    Websocket,
+    WebsocketBuilder,
+    WebsocketEvent: {
+      open: 'open',
+      message: 'message',
+      close: 'close',
+    },
+  };
+});
+
+describe('@rrweb/browser-client SSR import', () => {
+  it('does not require document at import time or when start is called', async () => {
+    vi.resetModules();
+
+    const client = await import('../src/index');
+
+    expect(() => {
+      client.start({
+        publicApiKey: 'public_key_rr_test',
+        includePii: false,
+        autostart: false,
+      });
+    }).not.toThrow();
+    expect(() => client.stop(true)).not.toThrow();
+    expect(mockState.record).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
When importing the browser-client package on projects that use components both server-side and client-side (@TanStack Start for example) the reliance on `document` and `localStorage` would break. This fixes that.