### PR TITLE
Make autostart and includePii attributes optional as is defined in docs

### DIFF
--- a/.changeset/full-days-cross.md
+++ b/.changeset/full-days-cross.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/browser-client": patch
+---
+
+Make autostart and includePii attributes optional on initialization

--- a/packages/browser-client/src/index.ts
+++ b/packages/browser-client/src/index.ts
@@ -19,8 +19,8 @@ declare const __RRWEB_BROWSER_CLIENT_COMMIT_HASH__: string;
 export type clientConfig = {
   serverUrl?: string;
   publicApiKey: string;
-  autostart: boolean;
-  includePii: boolean;
+  autostart?: boolean;
+  includePii?: boolean;
   jsSource?: string;
   jsEntrypoint?: string;
   meta?: nameValues;


### PR DESCRIPTION
In the docs this is defined as optional and they have default values specified. To be consistent with that the documentation says I think these should indeed be made optional