### PR TITLE
fix plugin api emit syntax

### DIFF
--- a/docs/recipes/plugin-api.md
+++ b/docs/recipes/plugin-api.md
@@ -59,7 +59,7 @@ const exampleRecordPlugin: RecordPlugin<{ foo: string }> = {
 };
 
 record({
-  emit: emit(event) {},
+  emit(event) {},
   plugins: [exampleRecordPlugin],
 });
 ```

--- a/docs/recipes/plugin-api.zh_CN.md
+++ b/docs/recipes/plugin-api.zh_CN.md
@@ -59,7 +59,7 @@ const exampleRecordPlugin: RecordPlugin<{ foo: string }> = {
 };
 
 record({
-  emit: emit(event) {},
+  emit(event) {},
   plugins: [exampleRecordPlugin],
 });
 ```


### PR DESCRIPTION
## What changed

- Fixed the record plugin example in the English and Chinese plugin API docs so `emit` uses valid object method shorthand.
- Replaced `emit: emit(event) {}` with `emit(event) {}`.

## Why

- The previous snippet is invalid TypeScript/JavaScript syntax and fails when copied into real code.

## Impact

- Docs-only change.
- No runtime behavior changes.

## Validation

- `rg -n "emit:\\s*emit\\(event\\)" docs packages -g "*.md" -g "*.ts" -g "*.tsx"` found no matches.
- `yarn prettier --check docs/recipes/plugin-api.md docs/recipes/plugin-api.zh_CN.md` passed.
- TypeScript code fences in both files parse cleanly with the TypeScript parser.
- `git diff --check -- docs/recipes/plugin-api.md docs/recipes/plugin-api.zh_CN.md` passed.
- `yarn markdownlint docs/recipes/plugin-api.md docs/recipes/plugin-api.zh_CN.md` still fails on pre-existing heading structure and line-length issues in these docs.
