### PR TITLE
Avoid accidental major releases from in-range peer bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -32,5 +32,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
## Why

PR #1867 generated a `3.0.0` release for the pending changes even though the release content is patch fixes plus the new network plugin work, which should be a minor release.

What happened in #1867:

- The network plugin changeset marks `@rrweb/types` as `minor` because it adds the network plugin TypeScript types.
- Some rrweb packages consume internal packages through `peerDependencies`.
- Changesets' default behavior treats a non-patch peer dependency bump as requiring a major bump for peer dependents, even when the new version still satisfies the existing semver range.
- rrweb keeps the published packages in one fixed release group, so that peer-dependent major bump was propagated across the whole group and produced `3.0.0` versions.

See: https://github.com/rrweb-io/rrweb/pull/1867

## What changed

This adds Changesets' `onlyUpdatePeerDependentsWhenOutOfRange` option:

```json
"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
  "onlyUpdatePeerDependentsWhenOutOfRange": true
}
```

With this enabled, peer dependents are only bumped as major when the released peer version is actually outside the declared peer range. For the current release, `2.1.0` still satisfies ranges like `^2.0.1`, so Changesets can keep the release on the `2.x` line instead of forcing `3.0.0`.

## Notes

This only changes Changesets' automatic peer-dependent bumping behavior. Packages that genuinely require newly introduced APIs or types should still tighten their own peer dependency ranges explicitly; for example, the new network plugins need the `@rrweb/types` network types introduced in `2.1.0`.
