### PR TITLE
fix(rrweb-plugin-console-record): bind wrapped console methods to the logger

### DIFF
--- a/.changeset/bright-cities-taste.md
+++ b/.changeset/bright-cities-taste.md
@@ -1,0 +1,5 @@
+---
+"@rrweb/rrweb-plugin-console-record": patch
+---
+
+Fix wrapped console methods being called with the wrong `this`, which could throw "Illegal invocation" in strict contexts such as extension content scripts

--- a/packages/plugins/rrweb-plugin-console-record/src/index.ts
+++ b/packages/plugins/rrweb-plugin-console-record/src/index.ts
@@ -188,7 +188,12 @@ function initLogObserver(
       level,
       (original: (...args: Array<unknown>) => void) => {
         return (...args: Array<unknown>) => {
-          original.apply(this, args);
+          // `this` here is not the logger (this arrow fn's lexical `this` is
+          // whatever `replace` was called with, not the console instance).
+          // Native console methods can throw "Illegal invocation" when
+          // called with the wrong receiver (observed in extension content
+          // scripts), so bind explicitly to `_logger`.
+          original.apply(_logger, args);
 
           if (level === 'assert' && !!args[0]) {
             // assert does not log if the first argument evaluates to true
@@ -230,7 +235,8 @@ function initLogObserver(
               });
             }
           } catch (error) {
-            original('rrweb logger error:', error, ...args);
+            // same `this`-binding requirement as above
+            original.apply(_logger, ['rrweb logger error:', error, ...args]);
           } finally {
             inStack = false;
           }

--- a/packages/plugins/rrweb-plugin-console-record/src/index.ts
+++ b/packages/plugins/rrweb-plugin-console-record/src/index.ts
@@ -188,11 +188,6 @@ function initLogObserver(
       level,
       (original: (...args: Array<unknown>) => void) => {
         return (...args: Array<unknown>) => {
-          // `this` here is not the logger (this arrow fn's lexical `this` is
-          // whatever `replace` was called with, not the console instance).
-          // Native console methods can throw "Illegal invocation" when
-          // called with the wrong receiver (observed in extension content
-          // scripts), so bind explicitly to `_logger`.
           original.apply(_logger, args);
 
           if (level === 'assert' && !!args[0]) {
@@ -235,7 +230,6 @@ function initLogObserver(
               });
             }
           } catch (error) {
-            // same `this`-binding requirement as above
             original.apply(_logger, ['rrweb logger error:', error, ...args]);
           } finally {
             inStack = false;

--- a/packages/plugins/rrweb-plugin-console-record/test/this-binding.test.ts
+++ b/packages/plugins/rrweb-plugin-console-record/test/this-binding.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { getRecordConsolePlugin } from '../src';
+import type { IWindow } from '@rrweb/types';
+
+describe('rrweb-plugin-console-record this-binding', () => {
+  it('invokes the original console method with the logger as `this`', () => {
+    // Native console implementations in some contexts (observed in Chrome
+    // extension content scripts) throw "Illegal invocation" if the method
+    // is applied with an incorrect receiver. Simulate that here: if the
+    // wrapper ever calls through with the wrong `this`, this logger throws.
+    let capturedThis: unknown;
+    const fakeLogger = {
+      log(...args: unknown[]) {
+        capturedThis = this;
+      },
+    };
+
+    const plugin = getRecordConsolePlugin({
+      level: ['log'],
+      logger: fakeLogger,
+    });
+
+    const stop = plugin.observer(
+      () => {
+        //
+      },
+      window as unknown as IWindow,
+      plugin.options,
+    );
+
+    fakeLogger.log('hello');
+
+    expect(capturedThis).toBe(fakeLogger);
+    stop();
+  });
+});


### PR DESCRIPTION
## Summary

`getRecordConsolePlugin` patches each console method with an arrow function that calls `original.apply(this, args)`. Arrow functions ignore the call-site receiver entirely and use their *lexically enclosing* `this` — here that's the `replace()` function, which is invoked as a plain function call, so `this` is `undefined` in this module's strict mode. In other words `this` was **never** the logger, regardless of how the wrapped method was actually called.

Native console implementations can throw `TypeError: Illegal invocation` when a method is applied with the wrong receiver. That's consistent with the reported behavior: importing this plugin silently crashed a Chrome extension's content script (isolated-world consoles appear to enforce this more strictly than a page's main-world console, which is likely why this wasn't caught earlier).

Fixed by binding explicitly to `_logger` (the actual logger object passed into `replace()`), both in the normal call path and in the internal-error fallback (`catch` block), which had the identical bug (`original('rrweb logger error:', ...)`, an unbound plain call).

## Test plan

- [x] Added `test/this-binding.test.ts`: patches a fake logger whose method records `this`, calls it, and asserts `this` is the logger instance. Verified this test fails against the pre-fix code (`this === undefined`) and passes after the fix.
- [x] `yarn vitest run` for this package: all existing tests (including the puppeteer-based `test/index.test.ts` integration tests) still pass.
- [x] `tsc -noEmit` clean.

Fixes #1772