### PR TITLE
fix(rrweb-snapshot): omit srcdoc attribute when rebuilding iframe elements

### DIFF
--- a/.changeset/common-pants-crash.md
+++ b/.changeset/common-pants-crash.md
@@ -1,0 +1,5 @@
+---
+"rrweb-snapshot": patch
+---
+
+Omit srcdoc attribute when rebuilding iframe elements

--- a/.changeset/dark-rooms-tease.md
+++ b/.changeset/dark-rooms-tease.md
@@ -1,0 +1,5 @@
+---
+"rrweb-snapshot": patch
+---
+
+Omit the `srcdoc` attribute when rebuilding iframe elements, so the browser doesn't race its own async document load against rrweb's own reconstruction of the iframe's contents (which could desync the mirror and throw `insertBefore` errors)

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -426,6 +426,19 @@ function buildNode(
               'rrweb-original-srcset',
               n.attributes.srcset as string,
             );
+          } else if (tagName === 'iframe' && name === 'srcdoc') {
+            /**
+             * Setting `srcdoc` makes the browser asynchronously parse and load
+             * its own document into the iframe, racing against (and getting
+             * clobbered by or clobbering) the document we reconstruct for this
+             * iframe from its separately-recorded child nodes/mutations. That
+             * race can leave the mirror out of sync with the live DOM, causing
+             * later mutations to target nodes that no longer exist (e.g.
+             * insertBefore throwing "parameter 1 is not of type 'Node'").
+             * Omit it; our own reconstruction is the source of truth.
+             * @see https://github.com/rrweb-io/rrweb/issues/1736
+             */
+            // ignore
           } else {
             node.setAttribute(name, value.toString());
           }

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -411,6 +411,38 @@ describe('rebuild', function () {
     });
   });
 
+  describe('iframe srcdoc', function () {
+    it('omits the srcdoc attribute so the browser does not load its own document into the iframe', function () {
+      /**
+       * Setting `srcdoc` on a live iframe makes the browser asynchronously
+       * parse and load that markup into the iframe's contentDocument, racing
+       * against rrweb's own reconstruction of the iframe's document (built
+       * separately from recorded child nodes/mutations). That race can
+       * desync the mirror from the live DOM, later causing mutations to
+       * target nodes that no longer exist.
+       * @see https://github.com/rrweb-io/rrweb/issues/1736
+       */
+      const node = buildNodeWithSN(
+        {
+          id: 1,
+          tagName: 'iframe',
+          type: NodeType.Element,
+          attributes: {
+            srcdoc: '<html><body>hi</body></html>',
+          },
+          childNodes: [],
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      ) as HTMLIFrameElement;
+      expect(node.hasAttribute('srcdoc')).toBe(false);
+    });
+  });
+
   describe('rr_width/rr_height', function () {
     it('rebuild blocked element with correct dimensions', function () {
       const node = buildNodeWithSN(


### PR DESCRIPTION
## Summary

When rebuilding a serialized `<iframe>` that has a `srcdoc` attribute, `buildNode` was setting `srcdoc` on the live element via `node.setAttribute(name, value.toString())` like any other attribute. Setting `srcdoc` makes the browser **asynchronously parse and load its own document** into the iframe's `contentDocument` — but rrweb *also* separately reconstructs that iframe's document from its own recorded child nodes/mutations (`attachDocumentToIframe` / the mirror). These two reconstructions race, and the browser's native srcdoc load can clobber (or be clobbered by) rrweb's own tree, desyncing the mirror from the live DOM. A later mutation then targets a node that no longer exists, throwing e.g.:

```
Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.
```

...which crashes the replayer (per the report, wrapping it in try/catch just breaks the player instead).

`rrdom`'s diff-based renderer already special-cases this exact issue (see `packages/rrdom/src/diff.ts:354` and its CHANGELOG: *"Omit the 'srcdoc' attribute of iframes to avoid overwriting content"*), but the plain browser-DOM rebuild path in `rrweb-snapshot` (used by the default web replayer) never got the same treatment. This PR applies the same fix there: skip setting `srcdoc`, since rrweb's own reconstruction is the source of truth for the iframe's contents.

## Test plan

- [x] Added a test in `rebuild.test.ts` that builds an `<iframe srcdoc="...">` node via `buildNodeWithSN` and asserts the resulting live element has no `srcdoc` attribute. Verified it fails without the fix and passes with it.
- [x] Full `rrweb-snapshot` test suite (`rebuild.test.ts`, `css.test.ts`, `snapshot.test.ts`) passes: 72/72.
- [x] `tsc -noEmit` clean.

Fixes #1736