### PR TITLE
Replay mutation DOMException refactor

### DIFF
--- a/.changeset/replay-domexception-refactor.md
+++ b/.changeset/replay-domexception-refactor.md
@@ -1,6 +1,6 @@
 ---
-'rrweb': patch
-'@rrweb/replay': patch
+"rrweb": patch
+"@rrweb/replay": patch
 ---
 
 Make replay slightly more robust against bad mutations - replace a prior try/catch from #620 which didn't work against rrdom, and also cover appendChild failures

--- a/.changeset/replay-domexception-refactor.md
+++ b/.changeset/replay-domexception-refactor.md
@@ -1,0 +1,6 @@
+---
+'rrweb': patch
+'@rrweb/replay': patch
+---
+
+Make replay slightly more robust against bad mutations - replace a prior try/catch from #620 which didn't work against rrdom, and also cover appendChild failures

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1518,7 +1518,7 @@ export class Replayer {
         return queue.push(mutation);
       } else if (!canContainChildren(parent)) {
         this.warn(
-          'parent is a leaf node and cannot be used to append a child',
+          'parent is a leaf node and cannot be used to append new child in mutation',
           parent,
           mutation.node,
         );

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1453,32 +1453,29 @@ export class Replayer {
       }
       // target may be removed with its parents before
       mirror.removeNodeFromMap(target as Node & RRNode);
-      if (parent)
-        try {
-          parent.removeChild(target as Node & RRNode);
-          /**
-           * https://github.com/rrweb-io/rrweb/pull/887
-           * Remove any virtual style rules for stylesheets if a child text node is removed.
-           */
-          if (
-            this.usingVirtualDom &&
-            target.nodeName === '#text' &&
-            parent.nodeName === 'STYLE' &&
-            (parent as RRStyleElement).rules?.length > 0
-          )
-            (parent as RRStyleElement).rules = [];
-        } catch (error) {
-          if (error instanceof DOMException) {
-            this.warn(
-              'parent could not remove child in mutation',
-              parent,
-              target,
-              d,
-            );
-          } else {
-            throw error;
-          }
-        }
+      if (!parent) {
+        return;
+      } else if (parent.nodeType !== 1 && parent.nodeType !== 9 && parent.nodeType !== 11) {
+        this.warn(
+          "parent is a leaf node and cannot remove child in mutation",
+          parent,
+          target,
+          d,
+        );
+        return;
+      }
+      parent.removeChild(target as Node & RRNode);
+      /**
+       * https://github.com/rrweb-io/rrweb/pull/887
+       * Remove any virtual style rules for stylesheets if a child text node is removed.
+       */
+      if (
+        this.usingVirtualDom &&
+          target.nodeName === '#text' &&
+          parent.nodeName === 'STYLE' &&
+          (parent as RRStyleElement).rules?.length > 0
+      )
+        (parent as RRStyleElement).rules = [];
     });
 
     const legacy_missingNodeMap: missingNodeMap = {

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1456,21 +1456,14 @@ export class Replayer {
       mirror.removeNodeFromMap(target as Node & RRNode);
       if (!parent) return;
       if (parent !== target.parentNode) {
-        if (!canContainChildren(parent)) {
-          this.warn(
-            'invalid parent, cannot be used to remove node',
-            parent,
-            target,
-            d,
-          );
-        } else {
-          this.warn(
-            'parent mismatch, cannot be used to remove node',
-            parent,
-            target,
-            d,
-          );
-        }
+        this.warn(
+          canContainChildren(parent)
+            ? 'parent mismatch, cannot be used to remove node in mutation'
+            : 'invalid parent, cannot be used to remove node in mutation',
+          parent,
+          target,
+          d,
+        );
         return;
       }
       parent.removeChild(target as Node & RRNode);

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -79,6 +79,7 @@ import {
   type AppendedIframe,
   getBaseDimension,
   hasShadowRoot,
+  canContainChildren,
   isSerializedIframe,
   getNestedRule,
   getPositionsAndIndex,
@@ -1456,7 +1457,11 @@ export class Replayer {
       if (!parent)
         return;
       if (parent !== target.parentNode) {
-        this.warn("parent child mismatch in mutation", parent, target, d);
+        if (!canContainChildren(parent)) {
+          this.warn('invalid parent, cannot be used to remove node', parent, target, d);
+        } else {
+          this.warn('parent mismatch, cannot be used to remove node', parent, target, d);
+        }
         return;
       }
       parent.removeChild(target as Node & RRNode);
@@ -1509,7 +1514,7 @@ export class Replayer {
           return this.newDocumentQueue.push(mutation);
         }
         return queue.push(mutation);
-      } else if (parent.nodeType !== 1 && parent.nodeType !== 9 && parent.nodeType !== 11) {
+      } else if (!canContainChildren(parent)) {
         this.warn(
           "parent is a leaf node and cannot be used to append a child",
           parent,

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1453,15 +1453,10 @@ export class Replayer {
       }
       // target may be removed with its parents before
       mirror.removeNodeFromMap(target as Node & RRNode);
-      if (!parent) {
+      if (!parent)
         return;
-      } else if (parent.nodeType !== 1 && parent.nodeType !== 9 && parent.nodeType !== 11) {
-        this.warn(
-          "parent is a leaf node and cannot remove child in mutation",
-          parent,
-          target,
-          d,
-        );
+      if (parent !== target.parentNode) {
+        this.warn("parent child mismatch in mutation", parent, target, d);
         return;
       }
       parent.removeChild(target as Node & RRNode);
@@ -1514,6 +1509,12 @@ export class Replayer {
           return this.newDocumentQueue.push(mutation);
         }
         return queue.push(mutation);
+      } else if (parent.nodeType !== 1 && parent.nodeType !== 9 && parent.nodeType !== 11) {
+        this.warn(
+          "parent is a leaf node and cannot be used to append a child",
+          parent,
+          mutation.node,
+        );
       }
 
       if (mutation.node.isShadow) {

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1457,9 +1457,19 @@ export class Replayer {
       if (!parent) return;
       if (parent !== target.parentNode) {
         if (!canContainChildren(parent)) {
-          this.warn('invalid parent, cannot be used to remove node', parent, target, d);
+          this.warn(
+            'invalid parent, cannot be used to remove node',
+            parent,
+            target,
+            d,
+          );
         } else {
-          this.warn('parent mismatch, cannot be used to remove node', parent, target, d);
+          this.warn(
+            'parent mismatch, cannot be used to remove node',
+            parent,
+            target,
+            d,
+          );
         }
         return;
       }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1454,8 +1454,7 @@ export class Replayer {
       }
       // target may be removed with its parents before
       mirror.removeNodeFromMap(target as Node & RRNode);
-      if (!parent)
-        return;
+      if (!parent) return;
       if (parent !== target.parentNode) {
         if (!canContainChildren(parent)) {
           this.warn('invalid parent, cannot be used to remove node', parent, target, d);
@@ -1471,9 +1470,9 @@ export class Replayer {
        */
       if (
         this.usingVirtualDom &&
-          target.nodeName === '#text' &&
-          parent.nodeName === 'STYLE' &&
-          (parent as RRStyleElement).rules?.length > 0
+        target.nodeName === '#text' &&
+        parent.nodeName === 'STYLE' &&
+        (parent as RRStyleElement).rules?.length > 0
       )
         (parent as RRStyleElement).rules = [];
     });
@@ -1516,7 +1515,7 @@ export class Replayer {
         return queue.push(mutation);
       } else if (!canContainChildren(parent)) {
         this.warn(
-          "parent is a leaf node and cannot be used to append a child",
+          'parent is a leaf node and cannot be used to append a child',
           parent,
           mutation.node,
         );

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -413,6 +413,20 @@ export function hasShadowRoot<T extends Node | RRNode>(
 }
 
 /**
+ * Whether a node can contain children, i.e. is an Element, Document or
+ * DocumentFragment which properly support appendChild or removeChild.
+ * Duck typing against those methods won't work as they are in fact present
+ * on leaf nodes, but throw a HierarchyRequestError/DOMException when used
+ */
+export function canContainChildren(node: Node | RRNode): boolean {
+  return (
+    node.nodeType === Node.ELEMENT_NODE ||
+    node.nodeType === Node.DOCUMENT_NODE ||
+    node.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+  );
+}
+
+/**
  * Traverses a CSSRuleList to find a nested rule at the given position.
  *
  * Returns null instead of throwing if the rule doesn't exist. This is important


### PR DESCRIPTION
The previous DOMException try/catch added by me in #620 was added to ensure that an entire mutation didn't cause an exception when a particular _removes_ mutation was not found.  This PR:

 - extends this protection to rrdom (exception thrown there doesn't inherit from DOMException)
 - adds similar protection to appendChild (addition) mutations which are likely to happen in same scenario

The scenario is 'degenerate' replay state, e.g. applying mutations against a different fullsnapshot or when a prior mutation is missing, so I haven't added testing as it's not something that we need to care about if other mechanisms are in place to ensure replay integrity.