### PR TITLE
feat(rrweb): add `adaptCssInTextMutations` player config option

### DIFF
--- a/.changeset/adapt-css-in-text-mutations.md
+++ b/.changeset/adapt-css-in-text-mutations.md
@@ -1,0 +1,6 @@
+---
+"rrweb": minor
+"@rrweb/replay": minor
+---
+
+Add a `adaptCssInTextMutations` player config option (default `true`) so that a consumer which already passes text mutation values through `adaptCssForReplay` can stop the replayer from doing it again. Rewriting is a postcss parse of the whole value, so replaying a stylesheet that is built up over many text mutations otherwise costs one parse of the accumulated CSS per mutation.

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -203,6 +203,7 @@ export class Replayer {
       pauseAnimation: true,
       mouseTail: defaultMouseTailConfig,
       useVirtualDom: true, // Virtual-dom optimization is enabled by default.
+      adaptCssInTextMutations: true,
       logger: console,
     };
     this.config = Object.assign({}, defaultConfig, config);
@@ -1759,7 +1760,12 @@ export class Replayer {
       }
 
       const parentEl = target.parentElement as Element | RRElement;
-      if (mutation.value && parentEl && parentEl.tagName === 'STYLE') {
+      if (
+        mutation.value &&
+        parentEl &&
+        parentEl.tagName === 'STYLE' &&
+        this.config.adaptCssInTextMutations
+      ) {
         // assumes hackCss: true (which isn't currently configurable from rrweb)
         target.textContent = adaptCssForReplay(mutation.value, this.cache);
       } else {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -199,6 +199,21 @@ export type playerConfig = {
       };
   unpackFn?: UnpackFn;
   useVirtualDom: boolean;
+  /**
+   * Whether the replayer rewrites CSS for replay (`:hover` -> `.\:hover`,
+   * `max-device-width` -> `max-width`) when applying a text mutation to a
+   * child of a `<style>` element. Defaults to `true`.
+   *
+   * Set this to `false` when the consumer supplies text mutations whose values
+   * have already been passed through `adaptCssForReplay`. The rewrite is a
+   * postcss parse of the whole value, so a consumer that replays a stylesheet
+   * built up over many text mutations otherwise pays it once per mutation on
+   * the accumulated CSS, which is quadratic in the number of mutations.
+   *
+   * This only covers text mutations. Nodes added via `adds` are always
+   * rewritten, because their values come straight from the recording.
+   */
+  adaptCssInTextMutations: boolean;
   logger: {
     log: (...args: Parameters<typeof console.log>) => void;
     warn: (...args: Parameters<typeof console.warn>) => void;

--- a/packages/rrweb/test/events/style-text-mutation-hover.ts
+++ b/packages/rrweb/test/events/style-text-mutation-hover.ts
@@ -1,0 +1,96 @@
+import { EventType, IncrementalSource } from '@rrweb/types';
+import type { eventWithTime } from '@rrweb/types';
+
+const now = Date.now();
+
+/**
+ * A `<style>` element whose text node is later replaced by a text mutation,
+ * with a `:hover` rule in the new value. Used to check whether the replayer
+ * rewrites CSS in text mutations (see `adaptCssInTextMutations`).
+ */
+const events: eventWithTime[] = [
+  {
+    type: EventType.DomContentLoaded,
+    data: {},
+    timestamp: now,
+  },
+  {
+    type: EventType.Load,
+    data: {},
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost',
+      width: 1000,
+      height: 800,
+    },
+    timestamp: now + 100,
+  },
+  {
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          { id: 2, name: 'html', type: 1, publicId: '', systemId: '' },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: { lang: 'en' },
+            childNodes: [
+              {
+                id: 4,
+                type: 2,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 101,
+                    type: 2,
+                    tagName: 'style',
+                    attributes: {},
+                    childNodes: [
+                      {
+                        id: 102,
+                        type: 3,
+                        isStyle: true,
+                        textContent: '.initial {color: yellow;}',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: 107,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: { top: 0, left: 0 },
+    },
+    type: EventType.FullSnapshot,
+    timestamp: now + 100,
+  },
+  // replaces the stylesheet text with a rule that has a `:hover` selector
+  {
+    data: {
+      texts: [{ id: 102, value: '.mutated:hover {color: red;}' }],
+      attributes: [],
+      removes: [],
+      adds: [],
+      source: IncrementalSource.Mutation,
+    },
+    type: EventType.IncrementalSnapshot,
+    timestamp: now + 500,
+  },
+];
+
+export default events;

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -22,6 +22,7 @@ import shadowDomEvents from './events/shadow-dom';
 import badTextareaEvents from './events/bad-textarea';
 import badStyleEvents from './events/bad-style';
 import StyleSheetTextMutation from './events/style-sheet-text-mutation';
+import styleTextMutationHover from './events/style-text-mutation-hover';
 import canvasInIframe from './events/canvas-in-iframe';
 import adoptedStyleSheet from './events/adopted-style-sheet';
 import adoptedStyleSheetModification from './events/adopted-style-sheet-modification';
@@ -476,6 +477,28 @@ describe('replayer', function () {
       rules.some((x) => x.selectorText === '.css-added-at-1000-overwritten-at-1500');
     `);
     expect(result).toEqual(false);
+  });
+
+  it('should adapt css in a text mutation on a style element by default', async () => {
+    await page.evaluate(`events = ${JSON.stringify(styleTextMutationHover)}`);
+    const result = await page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events);
+      replayer.pause(600);
+      replayer.getMirror().getNode(101).textContent;
+    `);
+    expect(result).toEqual('.mutated:hover,\n.mutated.\\:hover {color: red;}');
+  });
+
+  it('should not adapt css in a text mutation when adaptCssInTextMutations is false', async () => {
+    await page.evaluate(`events = ${JSON.stringify(styleTextMutationHover)}`);
+    const result = await page.evaluate(`
+      const { Replayer } = rrweb;
+      const replayer = new Replayer(events, { adaptCssInTextMutations: false });
+      replayer.pause(600);
+      replayer.getMirror().getNode(101).textContent;
+    `);
+    expect(result).toEqual('.mutated:hover {color: red;}');
   });
 
   it('should apply fast-forwarded StyleSheetRules that came after appending text node to stylesheet element', async () => {


### PR DESCRIPTION
### Problem

When the replayer applies a text mutation to a child of a `<style>` element, it
rewrites the value for replay (`:hover` → `.\:hover`, `max-device-width` →
`max-width`):

https://github.com/rrweb-io/rrweb/blob/main/packages/rrweb/src/replay/index.ts#L1761-L1766

```ts
const parentEl = target.parentElement as Element | RRElement;
if (mutation.value && parentEl && parentEl.tagName === 'STYLE') {
  // assumes hackCss: true (which isn't currently configurable from rrweb)
  target.textContent = adaptCssForReplay(mutation.value, this.cache);
} else {
  target.textContent = mutation.value;
}
```

That is correct, and it fixed a real gap — before #1431 / #1437 the rewrite was
only applied to nodes added via `adds`, so a stylesheet updated through text
mutations lost its `:hover` rules on replay.

The cost, though, is a postcss parse of the **whole value**, once per mutation.
That is fine when each mutation replaces a small stylesheet. It is not fine when
a consumer replays a stylesheet that is *built up* over many text mutations,
because each mutation then carries the accumulated CSS and the total work is
quadratic in the number of mutations.

We hit this in a session-replay tool for an app whose CSS-in-JS runtime appends
one rule at a time. To keep seeking fast we pre-process the recording so that the
rules for one `<style>` are folded into a single text node, and the additions
after the first become text mutations carrying the CSS accumulated so far. That
turns ~1250 stylesheet child insertions (each of which makes the browser reparse
the whole sheet) into one, which is a large win — but the replayer then parses
the accumulated CSS ~1250 times.

Measured in Chromium on a synthetic recording with 1251 rules in one `<style>`
(124 KB of CSS in total, 14k DOM nodes, 175 s), median of 3:

| | first sync apply | seek backwards |
| --- | --- | --- |
| folded, rewrite in the replayer | **9005 ms** | 38–69 ms |
| not folded | 1312 ms | 297–1158 ms |
| floor: same node count, no CSS involved | 90 ms | 10–70 ms |

The 9 s is entirely postcss. The per-`Replayer` cache in `adaptCssForReplay`
makes later seeks cheap, but the first pass over a stretch of unvisited events
blocks the main thread for ~9 s.

Rewriting per rule and concatenating produces the same result and is O(n) — the
two plugins in `adaptCssForReplay` work per rule, so processing each rule and
joining is equivalent to processing the join. There is currently no way for a
consumer to say "I already did this", and the cache is private to `Replayer`, so
it cannot be pre-populated either.

### Change

Adds `adaptCssInTextMutations` to `playerConfig`, defaulting to `true` — existing
behaviour is unchanged, and nothing needs to be updated by existing consumers.
Setting it to `false` means "the text mutation values I supply are already
replay-ready".

Only text mutations are covered. Nodes added via `adds` are always rewritten,
because their values come straight from the recording.

With the option set to `false` and the rewrite done per rule on our side, the
same measurement lands at **63 ms** for the first sync apply and 10–55 ms for
backward seeks — i.e. at the floor above — and the CSS that ends up in the DOM is
byte-for-byte identical to what the replayer produces on its own (129,217 bytes,
250 `:hover`, 125 `.\:hover`).

### Tests

Two tests in `packages/rrweb/test/replayer.test.ts` over a new fixture
(`test/events/style-text-mutation-hover.ts`) — a `<style>` whose text node is
replaced by a mutation carrying a `:hover` rule:

- default config → the value is rewritten
- `adaptCssInTextMutations: false` → it is passed through unchanged

Both pass. Note that 6 snapshot tests in `replayer.test.ts` fail in my
environment both with and without this change (they look Chromium-version
dependent), so those failures are unrelated.

A changeset is included (`minor` for `rrweb` and `@rrweb/replay`).
