### PR TITLE
fix: ignore autoplay attribute mutations regardless of tagName case

### DIFF
--- a/.changeset/fix-ignore-attribute-tagname-case.md
+++ b/.changeset/fix-ignore-attribute-tagname-case.md
@@ -1,0 +1,6 @@
+---
+"rrweb-snapshot": patch
+"rrweb": patch
+---
+
+Ignore `autoplay` attribute mutations on `<video>`/`<audio>` regardless of tag-name case.

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -204,12 +204,14 @@ export function transformAttribute(
 }
 
 export function ignoreAttribute(
-  tagName: string,
+  tagName: Lowercase<string>,
   name: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _value: unknown,
 ): boolean {
-  return ['video', 'audio'].includes(tagName) && name === 'autoplay';
+  return (
+    ['video', 'audio'].includes(tagName) && toLowerCase(name) === 'autoplay'
+  );
 }
 
 export function _isBlockedElement(

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import snapshot, {
   _isBlockedElement,
+  ignoreAttribute,
   serializeNodeWithId,
 } from '../src/snapshot';
 import { elementNode, serializedNodeWithId } from '../src/types';
@@ -156,6 +157,23 @@ describe('isBlockedElement()', () => {
     expect(
       subject('<div data-rr-block />', { blockSelector: '[data-rr-block]' }),
     ).toEqual(true);
+  });
+});
+
+describe('ignoreAttribute()', () => {
+  it('ignores autoplay on lowercase media tag names', () => {
+    expect(ignoreAttribute('video', 'autoplay', '')).toEqual(true);
+    expect(ignoreAttribute('audio', 'autoplay', '')).toEqual(true);
+  });
+
+  it('ignores autoplay regardless of attribute-name case', () => {
+    expect(ignoreAttribute('video', 'AUTOPLAY', '')).toEqual(true);
+    expect(ignoreAttribute('audio', 'AutoPlay', '')).toEqual(true);
+  });
+
+  it('does not ignore other attributes or other elements', () => {
+    expect(ignoreAttribute('video', 'src', '')).toEqual(false);
+    expect(ignoreAttribute('div', 'autoplay', '')).toEqual(false);
   });
 });
 

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -578,6 +578,7 @@ export default class MutationBuffer {
       }
       case 'attributes': {
         const target = m.target as HTMLElement;
+        const tagNameLower = toLowerCase(target.tagName);
         let attributeName = m.attributeName as string;
         let value = (m.target as HTMLElement).getAttribute(attributeName);
 
@@ -602,7 +603,7 @@ export default class MutationBuffer {
 
         let item = this.attributeMap.get(m.target);
         if (
-          target.tagName === 'IFRAME' &&
+          tagNameLower === 'iframe' &&
           attributeName === 'src' &&
           !this.keepIframeSrcFn(value as string)
         ) {
@@ -629,17 +630,17 @@ export default class MutationBuffer {
         // This is used to ensure we do not unmask value when using e.g. a "Show password" type button
         if (
           attributeName === 'type' &&
-          target.tagName === 'INPUT' &&
+          tagNameLower === 'input' &&
           (m.oldValue || '').toLowerCase() === 'password'
         ) {
           target.setAttribute('data-rr-is-password', 'true');
         }
 
-        if (!ignoreAttribute(target.tagName, attributeName, value)) {
+        if (!ignoreAttribute(tagNameLower, attributeName, value)) {
           // overwrite attribute if the mutations was triggered in same time
           item.attributes[attributeName] = transformAttribute(
             this.doc,
-            toLowerCase(target.tagName),
+            tagNameLower,
             toLowerCase(attributeName),
             value,
           );


### PR DESCRIPTION
Fixes #1916.

`ignoreAttribute` compares the tag name against lowercase `['video', 'audio']`, but the attribute-mutation handler in `packages/rrweb/src/record/mutation.ts` passes the native uppercase `target.tagName`, so `autoplay` changes on media elements were never ignored during live recording. This lowercases the tag name inside `ignoreAttribute`, making the snapshot and mutation paths behave the same.

Includes unit tests (the uppercase case fails without the fix) and a changeset.
