### PR TITLE
Publish package previews for pull requests

### DIFF
--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn turbo run lint
       - name: Publish package previews
         if: github.event_name == 'pull_request'
-        run: yarn pkg-pr-new publish './packages/*' './packages/plugins/*' --previewVersion --peerDeps --no-template --commentWithSha --no-compact
+        run: yarn pkg-pr-new publish './packages/*' './packages/plugins/*' --previewVersion --no-template --commentWithSha --no-compact
       - name: Save Code Linting Report JSON
         run: yarn lint:report
         # Continue to the next step even if this fails

--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -18,9 +18,12 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Checkout current branch
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -36,6 +39,9 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Eslint Check
         run: yarn turbo run lint
+      - name: Publish package previews
+        if: github.event_name == 'pull_request'
+        run: yarn pkg-pr-new publish './packages/*' './packages/plugins/*' --previewVersion --peerDeps --no-template --commentWithSha --no-compact
       - name: Save Code Linting Report JSON
         run: yarn lint:report
         # Continue to the next step even if this fails
@@ -70,6 +76,8 @@ jobs:
     steps:
       - name: Checkout workflow ref
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Prepare bundle size helper
         run: |
           cp .github/scripts/measure-bundle-sizes.js /tmp/measure-bundle-sizes.js
@@ -77,6 +85,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
       - name: Download PR bundle sizes
         uses: actions/download-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "happy-dom": "^14.12.0",
     "markdownlint": "^0.25.1",
     "markdownlint-cli": "^0.31.1",
+    "pkg-pr-new": "0.0.88",
     "prettier": "2.8.4",
     "rollup-plugin-visualizer": "^5.12.0",
     "turbo": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7947,6 +7947,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-pr-new@0.0.88:
+  version "0.0.88"
+  resolved "https://registry.yarnpkg.com/pkg-pr-new/-/pkg-pr-new-0.0.88.tgz#6bd135b80155612105847a5e286d7b604a809221"
+  integrity sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==
+
 pkg-types@^1.0.3, pkg-types@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.1.1.tgz#07b626880749beb607b0c817af63aac1845a73f2"


### PR DESCRIPTION
## Summary

- publish npm-compatible preview packages for every PR using pkg.pr.new
- cover top-level packages and plugins with commit-specific long-form URLs and preview versions
- keep the workflow token read-only and prevent checkout credentials from persisting

Related to #1925, which tracks first-party CDN previews separately.

## Security

- no npm token or repository secrets are used
- the workflow retains only `contents: read`
- publishing runs from the locked `pkg-pr-new@0.0.88` dependency after build and lint
- the pkg.pr.new GitHub App installation is restricted to selected repositories

## Test plan

- [x] `yarn turbo run lint`
- [x] Prettier check for the changed workflow and package manifest
- [x] frozen offline dependency install
- [x] workflow permission, ordering, checkout-credential, and CLI-flag assertions
- [x] independent security and correctness review
- [x] full `yarn test`: 22/26 Turbo tasks pass locally; browser snapshot/integration suites differ under the locally installed Chrome version. CI should verify them with the repository browser environment.

`actionlint` reports only the two pre-existing `actions/setup-node@v3` age warnings.