### PR TITLE
style: fix rrweb-player changelog formatting

### DIFF
--- a/packages/rrweb-player/CHANGELOG.md
+++ b/packages/rrweb-player/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#1769](https://github.com/rrweb-io/rrweb/pull/1769) [`956fc48`](https://github.com/rrweb-io/rrweb/commit/956fc48e4c7624d343dd456b4498563b1f6f90bb) Thanks [@heathdutton](https://github.com/heathdutton)! - Emit custom events even when skipping over them, eg. when seeking to a specific time 
+- [#1769](https://github.com/rrweb-io/rrweb/pull/1769) [`956fc48`](https://github.com/rrweb-io/rrweb/commit/956fc48e4c7624d343dd456b4498563b1f6f90bb) Thanks [@heathdutton](https://github.com/heathdutton)! - Emit custom events even when skipping over them, eg. when seeking to a specific time
 - Updated dependencies [[`956fc48`](https://github.com/rrweb-io/rrweb/commit/956fc48e4c7624d343dd456b4498563b1f6f90bb)]:
   - @rrweb/replay@2.1.2
   - @rrweb/packer@2.1.2


### PR DESCRIPTION
## Summary

- remove trailing whitespace from the rrweb-player changelog
- restore Prettier compliance for tracked TypeScript and Markdown files

## Test plan

- [x] `git ls-files -z "*.ts" "*.md" | xargs -0 node_modules/.bin/prettier --check`
- [x] `yarn workspace rrweb-player test`
- [ ] `yarn test` currently fails in five unrelated workspaces due local browser timeouts, missing generated build artifacts, and a WebGL snapshot mismatch