### PR TITLE
Collapse multiple text mutations when frozen / throttled

### DIFF
--- a/.changeset/tricky-emus-matter.md
+++ b/.changeset/tricky-emus-matter.md
@@ -1,0 +1,6 @@
+---
+"rrweb": patch
+"@rrweb/record": patch
+---
+
+Collapse multiple text mutation against the same node when frozen / throttled to a single text mutation emission for that node (the final value at emission time)

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -141,9 +141,8 @@ export default class MutationBuffer {
   private frozen = false;
   private locked = false;
 
-  private texts: textCursor[] = [];
-  private attributes: attributeCursor[] = [];
-  private attributeMap = new WeakMap<Node, attributeCursor>();
+  private texts = new Map<Node, textCursor>();
+  private attributes = new Map<Node, attributeCursor>();
   private removes: removedNodeMutation[] = [];
   private mapRemoves: Node[] = [];
 
@@ -449,7 +448,7 @@ export default class MutationBuffer {
     }
 
     const payload = {
-      texts: this.texts
+      texts: Array.from(this.texts.values())
         .map((text) => {
           const n = text.node;
           const parent = dom.parentNode(n);
@@ -466,7 +465,7 @@ export default class MutationBuffer {
         .filter((text) => !addedIds.has(text.id))
         // text mutation's id was not in the mirror map means the target node has been removed
         .filter((text) => this.mirror.has(text.id)),
-      attributes: this.attributes
+      attributes: Array.from(this.attributes.values())
         .map((attribute) => {
           const { attributes } = attribute;
           if (typeof attributes.style === 'string') {
@@ -508,9 +507,8 @@ export default class MutationBuffer {
     }
 
     // reset
-    this.texts = [];
-    this.attributes = [];
-    this.attributeMap = new WeakMap<Node, attributeCursor>();
+    this.texts = new Map<Node, textCursor>();
+    this.attributes = new Map<Node, attributeCursor>();
     this.removes = [];
     this.addedSet = new Set<Node>();
     this.movedSet = new Set<Node>();
@@ -522,7 +520,7 @@ export default class MutationBuffer {
   };
 
   private genTextAreaValueMutation = (textarea: HTMLTextAreaElement) => {
-    let item = this.attributeMap.get(textarea);
+    let item = this.attributes.get(textarea);
     if (!item) {
       item = {
         node: textarea,
@@ -530,8 +528,7 @@ export default class MutationBuffer {
         styleDiff: {},
         _unchangedStyles: {},
       };
-      this.attributes.push(item);
-      this.attributeMap.set(textarea, item);
+      this.attributes.set(textarea, item);
     }
     const value = Array.from(
       dom.childNodes(textarea),
@@ -559,20 +556,26 @@ export default class MutationBuffer {
           !isBlocked(m.target, this.blockClass, this.blockSelector, false) &&
           value !== m.oldValue
         ) {
-          this.texts.push({
-            value:
-              needMaskingText(
-                m.target,
-                this.maskTextClass,
-                this.maskTextSelector,
-                true, // checkAncestors
-              ) && value
-                ? this.maskTextFn
-                  ? this.maskTextFn(value, closestElementOfNode(m.target))
-                  : value.replace(/[\S]/g, '*')
-                : value,
-            node: m.target,
-          });
+          const maskedValue =
+            needMaskingText(
+              m.target,
+              this.maskTextClass,
+              this.maskTextSelector,
+              true, // checkAncestors
+            ) && value
+              ? this.maskTextFn
+                ? this.maskTextFn(value, closestElementOfNode(m.target))
+                : value.replace(/[\S]/g, '*')
+              : value;
+          const item = this.texts.get(m.target);
+          if (item) {
+            item.value = maskedValue;
+          } else {
+            this.texts.set(m.target, {
+              value: maskedValue,
+              node: m.target,
+            });
+          }
         }
         break;
       }
@@ -601,7 +604,7 @@ export default class MutationBuffer {
           return;
         }
 
-        let item = this.attributeMap.get(m.target);
+        let item = this.attributes.get(m.target);
         if (
           tagNameLower === 'iframe' &&
           attributeName === 'src' &&
@@ -622,8 +625,7 @@ export default class MutationBuffer {
             styleDiff: {},
             _unchangedStyles: {},
           };
-          this.attributes.push(item);
-          this.attributeMap.set(m.target, item);
+          this.attributes.set(m.target, item);
         }
 
         // Keep this property on inputs that used to be password inputs

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -1337,10 +1337,6 @@ exports[`record integration tests > can record and replay style mutations 1`] = 
           \\"value\\": \\"body { color: yellow; }\\"
         },
         {
-          \\"id\\": 15,
-          \\"value\\": \\"body { color: yellow; }\\"
-        },
-        {
           \\"id\\": 38,
           \\"value\\": \\"body { background-color: purple; }\\"
         }


### PR DESCRIPTION
 - Ensure we don't emit multiple text mutations against the same node while throttled or when mutations are frozen
 - Replay should be unaffected, as the replayer would have applied all text mutations, which would end up in the same state (the final mutation)
 - Also recognize that the additional `WeakMap` added in #1343 in relation to `attributes`/`attributeMap` can be improved by replacing both variables with a single `Map`. The array was holding strong references to the Node anyway in the attributeCursor; these were freed at the end after `// reset` and this is still the case after this change