### PR TITLE
fix(web-extension): prevent cross-origin recording leaks

### DIFF
--- a/packages/web-extension/src/content/index.ts
+++ b/packages/web-extension/src/content/index.ts
@@ -11,7 +11,6 @@ import {
   EventName,
 } from '~/types';
 import Channel from '~/utils/channel';
-import { isInCrossOriginIFrame } from '~/utils';
 
 const channel = new Channel();
 
@@ -29,16 +28,21 @@ void (() => {
           {
             message: MessageName.StartRecord,
             config: {
-              recordCrossOriginIframes: true,
+              // Cross-origin iframe events must not be forwarded through the
+              // embedding page's window. That would make the recorded data
+              // visible to scripts in the parent page.
+              recordCrossOriginIframes: false,
             },
           },
           location.origin,
         );
     },
   );
-  if (isInCrossOriginIFrame()) {
-    void initCrossOriginIframe();
-  } else if (window === window.top) {
+  // Same-origin iframes are recorded by rrweb from the top-level document.
+  // Do not start an independent recorder in cross-origin frames: rrweb's
+  // cross-origin transport uses window.parent.postMessage(), which is
+  // observable by the untrusted embedding page.
+  if (window === window.top) {
     void initMainPage();
   }
 })();
@@ -106,28 +110,6 @@ async function initMainPage() {
   ) {
     startRecord();
   }
-}
-
-async function initCrossOriginIframe() {
-  Browser.storage.local.onChanged.addListener((change) => {
-    if (change[LocalDataKey.recorderStatus]) {
-      const statusChange = change[LocalDataKey.recorderStatus];
-      const newStatus =
-        statusChange.newValue as LocalData[LocalDataKey.recorderStatus];
-      if (newStatus.status === RecorderStatus.RECORDING) startRecord();
-      else
-        window.postMessage(
-          { message: MessageName.StopRecord },
-          location.origin,
-        );
-    }
-  });
-  const localData = (await Browser.storage.local.get()) as LocalData;
-  if (
-    localData?.[LocalDataKey.recorderStatus]?.status ===
-    RecorderStatus.RECORDING
-  )
-    startRecord();
 }
 
 function startRecord() {


### PR DESCRIPTION
### Motivation

- The web-extension injected recorders into every frame and enabled `recordCrossOriginIframes`, causing cross-origin iframe snapshots and events to be posted to `window.parent` where any script in the embedding page could observe them.
- The change aims to stop cross-origin frames from independently starting recorders and to avoid rrweb's page-visible cross-origin forwarding so sensitive cross-origin DOM and input data are not exposed to untrusted parent pages.

### Description

- In `packages/web-extension/src/content/index.ts` the `StartRecord` message now sets `recordCrossOriginIframes: false` so the injected page-context recorder will not enable rrweb's cross-origin parent forwarding.
- Recorder initialization was restricted to the top-level document by removing the cross-origin iframe initialization path and only calling `initMainPage()` when `window === window.top`, preventing cross-origin frames from reacting directly to the extension-wide recorder state.
- The top-level start/stop flows and the extension channel event collection were preserved so normal top-level and same-origin iframe recording behavior remains unchanged.
- Removed the cross-origin initialization code path and the now-unused helper import, keeping the fix localized to `packages/web-extension/src/content/index.ts`.

### Testing

- `yarn prettier --check packages/web-extension/src/content/index.ts` passed. 
- `ESLINT_USE_FLAT_CONFIG=false yarn eslint packages/web-extension/src/content/index.ts` passed.
- A static Node assertion verified the file contains `recordCrossOriginIframes: false` and that initialization is limited to the top-level document (assertion succeeded).
- `yarn workspace @rrweb/web-extension check-types` and `yarn workspace @rrweb/web-extension build:chrome` were attempted but blocked by a pre-existing unresolved `rrweb-player` workspace package, which is unrelated to this security fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9ef2474f08832da49040541a9d94b3)