### PR TITLE
chore: sync generated tsconfig project references for network plugins

### DIFF
--- a/.changeset/network-plugin-tsconfig-references.md
+++ b/.changeset/network-plugin-tsconfig-references.md
@@ -1,0 +1,4 @@
+---
+---
+
+Sync generated tsconfig project references for the network record/replay plugins so `yarn build` no longer leaves the working tree dirty (build-config only, no published changes).

--- a/packages/plugins/rrweb-plugin-network-record/tsconfig.json
+++ b/packages/plugins/rrweb-plugin-network-record/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "exclude": ["vite.config.ts", "vitest.config.ts", "test"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "test"
+  ],
   "compilerOptions": {
     "rootDir": "src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
@@ -12,6 +18,9 @@
     },
     {
       "path": "../../utils"
+    },
+    {
+      "path": "../../rrweb"
     }
   ]
 }

--- a/packages/plugins/rrweb-plugin-network-replay/tsconfig.json
+++ b/packages/plugins/rrweb-plugin-network-replay/tsconfig.json
@@ -1,17 +1,25 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "include": ["src"],
-  "exclude": ["vite.config.ts", "test"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "test"
+  ],
   "compilerOptions": {
     "rootDir": "src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "references": [
     {
+      "path": "../rrweb-plugin-network-record"
+    },
+    {
       "path": "../../types"
     },
     {
-      "path": "../rrweb-plugin-network-record"
+      "path": "../../rrweb"
     }
   ]
 }


### PR DESCRIPTION
## Motivation

Running `yarn build:all` regenerates `tsconfig.json` for the two network plugins, leaving the working tree dirty on every build. The turbo `prepublish` task depends on `//#references:update`, and `check-types` runs `workspaces-to-typescript-project-references --check`, so the committed state is out of sync with the tool's own contract.

Two things were stale in `rrweb-plugin-network-record` and `rrweb-plugin-network-replay`:

- The `../../rrweb` project reference was missing, even though both plugins declare `rrweb` in `devDependencies`/`peerDependencies` and the workspace `rrweb` (`2.1.4`) satisfies the `^2.0.1` range — so the generator adds it.
- The `include`/`exclude` arrays were single-line, but the generator (`comment-json.stringify(json, null, 2)`) emits them multi-line, so any reference change reformats the whole file.

## Change

This is the generator's exact output, committed so the files are idempotent under `workspaces-to-typescript-project-references`: `yarn build` no longer leaves the working tree dirty, and `check-types --check` is satisfied. Prettier's CI check only covers `.ts`/`.md`, not JSON, so nothing collapses the arrays back.

Build-config only — no published code changes (empty changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)